### PR TITLE
Expand support for all Drizzle SQL drivers

### DIFF
--- a/packages/adapters/drizzle/src/operations/mysql-operations.ts
+++ b/packages/adapters/drizzle/src/operations/mysql-operations.ts
@@ -5,8 +5,7 @@
 
 import { count, eq, inArray } from 'drizzle-orm';
 import type { MySqlTable } from 'drizzle-orm/mysql-core';
-import type { MySql2Database } from 'drizzle-orm/mysql2';
-import type { AnyTableType, DatabaseOperations, TableWithId } from '../types';
+import type { AnyTableType, DatabaseOperations, MySqlDatabaseType, TableWithId } from '../types';
 import { QueryError } from '../types';
 
 /**
@@ -15,6 +14,9 @@ import { QueryError } from '../types';
  * MySQL does NOT support the RETURNING clause, so we need to fetch records separately
  * after insert/update/delete operations. This implementation handles both auto-increment
  * integer primary keys and UUID/string primary keys.
+ *
+ * Supports all MySQL-compatible Drizzle drivers:
+ * - mysql2 (MySql2Database)
  *
  * @template TRecord - The record type for the table
  * @implements {DatabaseOperations<TRecord>}
@@ -25,20 +27,20 @@ import { QueryError } from '../types';
  * const user = await operations.insert(usersTable, { name: 'John', email: 'john@example.com' });
  * ```
  *
- * @since 1.0.0
+ * @since 1.0.0 (expanded to support all MySQL drivers in 1.1.0)
  */
 export class MySQLOperations<TRecord> implements DatabaseOperations<TRecord> {
   /**
    * Creates a new MySQL operations instance.
    *
-   * @param {MySql2Database} db - The MySQL database connection instance
+   * @param {MySqlDatabaseType} db - Any MySQL-compatible database connection instance
    *
    * @example
    * ```typescript
    * const operations = new MySQLOperations<User>(mysqlDb);
    * ```
    */
-  constructor(private readonly db: MySql2Database) {}
+  constructor(private readonly db: MySqlDatabaseType) {}
 
   /**
    * Inserts a new record into the table.

--- a/packages/adapters/drizzle/src/operations/operations-factory.ts
+++ b/packages/adapters/drizzle/src/operations/operations-factory.ts
@@ -6,17 +6,21 @@
  * This factory follows the Factory Pattern to create the appropriate
  * database operations implementation based on the driver type,
  * ensuring type safety through proper database type narrowing.
+ *
+ * Supports all driver variants for each SQL dialect:
+ * - PostgreSQL: postgres-js, node-postgres, neon-http
+ * - MySQL: mysql2
+ * - SQLite: better-sqlite3, libsql
  */
-
-import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
-import type { MySql2Database } from 'drizzle-orm/mysql2';
-import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 
 import type {
   DatabaseDriver,
   DatabaseOperations,
   DrizzleDatabase,
+  MySqlDatabaseType,
   OperationsFactory,
+  PostgresDatabaseType,
+  SQLiteDatabaseType,
 } from '../types';
 import { MySQLOperations } from './mysql-operations';
 import { PostgresOperations } from './postgres-operations';
@@ -26,19 +30,27 @@ import { SQLiteOperations } from './sqlite-operations';
  * Factory function to create database operations based on driver type.
  * This follows the Factory Pattern and provides type-safe operation creation.
  *
+ * Supports all driver variants for each SQL dialect:
+ * - 'postgres': PostgresJsDatabase, NodePgDatabase, NeonHttpDatabase
+ * - 'mysql': MySql2Database
+ * - 'sqlite': BetterSQLite3Database, LibSQLDatabase
+ *
  * @template TDriver - The database driver type
- * @param driver - The database driver identifier
+ * @param driver - The database driver identifier ('postgres', 'mysql', or 'sqlite')
  * @returns A factory function that creates operations for the specific driver
  *
  * @example
  * ```typescript
+ * // Works with any PostgreSQL-compatible driver
  * const createOperations = getOperationsFactory('postgres');
- * const operations = createOperations<User>(postgresDb);
+ * const operations = createOperations<User>(nodePgDb); // NodePgDatabase
+ * const operations = createOperations<User>(postgresJsDb); // PostgresJsDatabase
+ * const operations = createOperations<User>(neonDb); // NeonHttpDatabase
  * ```
  *
  * @throws {Error} If an unsupported driver is provided
  *
- * @since 1.0.0
+ * @since 1.0.0 (expanded to support all driver variants in 1.1.0)
  */
 export function getOperationsFactory<TDriver extends DatabaseDriver>(
   driver: TDriver
@@ -49,14 +61,16 @@ export function getOperationsFactory<TDriver extends DatabaseDriver>(
         // TypeScript's control flow analysis doesn't narrow generic types in switch statements.
         // However, this is safe because the DrizzleDatabase<TDriver> type is guaranteed to match
         // the specific driver's database type when TDriver is narrowed by the switch case.
-        // When TDriver = 'postgres', DrizzleDatabase<'postgres'> = PostgresJsDatabase
-        return new PostgresOperations<TRecord>(db as PostgresJsDatabase);
+        // When TDriver = 'postgres', DrizzleDatabase<'postgres'> = PostgresDatabaseType
+        // which includes PostgresJsDatabase, NodePgDatabase, and NeonHttpDatabase
+        return new PostgresOperations<TRecord>(db as PostgresDatabaseType);
       case 'mysql':
-        // Same reasoning: DrizzleDatabase<'mysql'> = MySql2Database
-        return new MySQLOperations<TRecord>(db as MySql2Database);
+        // Same reasoning: DrizzleDatabase<'mysql'> = MySqlDatabaseType
+        return new MySQLOperations<TRecord>(db as MySqlDatabaseType);
       case 'sqlite':
-        // Same reasoning: DrizzleDatabase<'sqlite'> = BetterSQLite3Database
-        return new SQLiteOperations<TRecord>(db as BetterSQLite3Database);
+        // Same reasoning: DrizzleDatabase<'sqlite'> = SQLiteDatabaseType
+        // which includes BetterSQLite3Database and LibSQLDatabase
+        return new SQLiteOperations<TRecord>(db as SQLiteDatabaseType);
       default:
         throw new Error(`Unsupported database driver: ${driver as string}`);
     }

--- a/packages/adapters/drizzle/src/operations/postgres-operations.ts
+++ b/packages/adapters/drizzle/src/operations/postgres-operations.ts
@@ -5,8 +5,7 @@
 
 import { count, eq, inArray } from 'drizzle-orm';
 import type { PgTable } from 'drizzle-orm/pg-core';
-import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
-import type { AnyTableType, DatabaseOperations, TableWithId } from '../types';
+import type { AnyTableType, DatabaseOperations, PostgresDatabaseType, TableWithId } from '../types';
 import { QueryError } from '../types';
 
 /**
@@ -15,29 +14,43 @@ import { QueryError } from '../types';
  * PostgreSQL supports the RETURNING clause for all operations, making it more
  * efficient than MySQL as we don't need separate fetch queries after mutations.
  *
+ * Supports all PostgreSQL-compatible Drizzle drivers:
+ * - postgres-js (PostgresJsDatabase)
+ * - node-postgres (NodePgDatabase)
+ * - neon-http (NeonHttpDatabase)
+ *
  * @template TRecord - The record type for the table
  * @implements {DatabaseOperations<TRecord>}
  *
  * @example
  * ```typescript
+ * // Works with any PostgreSQL driver
  * const operations = new PostgresOperations<User>(postgresDb);
  * const user = await operations.insert(usersTable, { name: 'John', email: 'john@example.com' });
  * ```
  *
- * @since 1.0.0
+ * @since 1.0.0 (expanded to support all PostgreSQL drivers in 1.1.0)
  */
 export class PostgresOperations<TRecord> implements DatabaseOperations<TRecord> {
   /**
    * Creates a new PostgreSQL operations instance.
    *
-   * @param {PostgresJsDatabase} db - The PostgreSQL database connection instance
+   * @param {PostgresDatabaseType} db - Any PostgreSQL-compatible database connection instance
+   *   (PostgresJsDatabase, NodePgDatabase, NeonHttpDatabase, etc.)
    *
    * @example
    * ```typescript
-   * const operations = new PostgresOperations<User>(postgresDb);
+   * // Using postgres-js
+   * const operations = new PostgresOperations<User>(postgresJsDb);
+   *
+   * // Using node-postgres
+   * const operations = new PostgresOperations<User>(nodePgDb);
+   *
+   * // Using Neon
+   * const operations = new PostgresOperations<User>(neonDb);
    * ```
    */
-  constructor(private readonly db: PostgresJsDatabase) {}
+  constructor(private readonly db: PostgresDatabaseType) {}
 
   /**
    * Inserts a new record into the table.

--- a/packages/adapters/drizzle/src/operations/sqlite-operations.ts
+++ b/packages/adapters/drizzle/src/operations/sqlite-operations.ts
@@ -4,9 +4,8 @@
  */
 
 import { count, eq, inArray } from 'drizzle-orm';
-import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import type { SQLiteTable } from 'drizzle-orm/sqlite-core';
-import type { AnyTableType, DatabaseOperations, TableWithId } from '../types';
+import type { AnyTableType, DatabaseOperations, SQLiteDatabaseType, TableWithId } from '../types';
 import { QueryError } from '../types';
 
 /**
@@ -15,29 +14,39 @@ import { QueryError } from '../types';
  * SQLite supports the RETURNING clause for all operations, making it efficient
  * similar to PostgreSQL. This implementation works with both in-memory and file-based databases.
  *
+ * Supports all SQLite-compatible Drizzle drivers:
+ * - better-sqlite3 (BetterSQLite3Database)
+ * - libsql/Turso (LibSQLDatabase)
+ *
  * @template TRecord - The record type for the table
  * @implements {DatabaseOperations<TRecord>}
  *
  * @example
  * ```typescript
+ * // Works with any SQLite driver
  * const operations = new SQLiteOperations<User>(sqliteDb);
  * const user = await operations.insert(usersTable, { name: 'John', email: 'john@example.com' });
  * ```
  *
- * @since 1.0.0
+ * @since 1.0.0 (expanded to support all SQLite drivers in 1.1.0)
  */
 export class SQLiteOperations<TRecord> implements DatabaseOperations<TRecord> {
   /**
    * Creates a new SQLite operations instance.
    *
-   * @param {BetterSQLite3Database} db - The SQLite database connection instance
+   * @param {SQLiteDatabaseType} db - Any SQLite-compatible database connection instance
+   *   (BetterSQLite3Database, LibSQLDatabase, etc.)
    *
    * @example
    * ```typescript
-   * const operations = new SQLiteOperations<User>(sqliteDb);
+   * // Using better-sqlite3
+   * const operations = new SQLiteOperations<User>(betterSqliteDb);
+   *
+   * // Using libsql/Turso
+   * const operations = new SQLiteOperations<User>(libsqlDb);
    * ```
    */
-  constructor(private readonly db: BetterSQLite3Database) {}
+  constructor(private readonly db: SQLiteDatabaseType) {}
 
   /**
    * Inserts a new record into the table.

--- a/packages/adapters/drizzle/src/query-builders/mysql-query-builder.ts
+++ b/packages/adapters/drizzle/src/query-builders/mysql-query-builder.ts
@@ -5,18 +5,21 @@
  * @description
  * MySQL query builder implementation with driver-specific optimizations.
  *
- * @since 1.0.0
+ * Supports all MySQL-compatible Drizzle drivers:
+ * - mysql2 (MySql2Database)
+ *
+ * @since 1.0.0 (expanded to support all MySQL drivers in 1.1.0)
  */
 
 import { count, isNotNull, max, min, type SQL, sql } from 'drizzle-orm';
 import type { MySqlColumn, MySqlTable } from 'drizzle-orm/mysql-core';
-import type { MySql2Database } from 'drizzle-orm/mysql2';
 import type { RelationshipManager } from '../relationship-manager';
 import type {
   AggregateFunction,
   AnyColumnType,
   AnyTableType,
   MySQLQueryBuilderWithJoins,
+  MySqlDatabaseType,
   QueryContext,
 } from '../types';
 import { QueryError } from '../types';
@@ -26,15 +29,18 @@ import { BaseQueryBuilder } from './base-query-builder';
 /**
  * MySQL query builder implementation.
  *
+ * Supports all MySQL-compatible Drizzle drivers:
+ * - mysql2 (MySql2Database)
+ *
  * @class MySQLQueryBuilder
  * @extends {BaseQueryBuilder}
- * @since 1.0.0
+ * @since 1.0.0 (expanded to support all MySQL drivers in 1.1.0)
  */
 export class MySQLQueryBuilder extends BaseQueryBuilder {
-  private db: MySql2Database;
+  private db: MySqlDatabaseType;
 
   constructor(
-    db: MySql2Database,
+    db: MySqlDatabaseType,
     schema: Record<string, AnyTableType>,
     relationshipManager: RelationshipManager
   ) {

--- a/packages/adapters/drizzle/src/query-builders/postgres-query-builder.ts
+++ b/packages/adapters/drizzle/src/query-builders/postgres-query-builder.ts
@@ -5,7 +5,12 @@
  * @description
  * PostgreSQL query builder implementation with driver-specific optimizations.
  *
- * @since 1.0.0
+ * Supports all PostgreSQL-compatible Drizzle drivers:
+ * - postgres-js (PostgresJsDatabase)
+ * - node-postgres (NodePgDatabase)
+ * - neon-http (NeonHttpDatabase)
+ *
+ * @since 1.0.0 (expanded to support all PostgreSQL drivers in 1.1.0)
  */
 
 import {
@@ -20,12 +25,12 @@ import {
   sql,
 } from 'drizzle-orm';
 import type { PgColumn, PgTable } from 'drizzle-orm/pg-core';
-import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import type { RelationshipManager } from '../relationship-manager';
 import type {
   AggregateFunction,
   AnyColumnType,
   AnyTableType,
+  PostgresDatabaseType,
   PostgresQueryBuilderWithJoins,
   QueryContext,
 } from '../types';
@@ -154,15 +159,20 @@ class RelationalQueryWrapper implements PostgresQueryBuilderWithJoins {
 /**
  * PostgreSQL query builder implementation.
  *
+ * Supports all PostgreSQL-compatible Drizzle drivers:
+ * - postgres-js (PostgresJsDatabase)
+ * - node-postgres (NodePgDatabase)
+ * - neon-http (NeonHttpDatabase)
+ *
  * @class PostgresQueryBuilder
  * @extends {BaseQueryBuilder}
- * @since 1.0.0
+ * @since 1.0.0 (expanded to support all PostgreSQL drivers in 1.1.0)
  */
 export class PostgresQueryBuilder extends BaseQueryBuilder {
-  private db: PostgresJsDatabase;
+  private db: PostgresDatabaseType;
 
   constructor(
-    db: PostgresJsDatabase,
+    db: PostgresDatabaseType,
     schema: Record<string, AnyTableType>,
     relationshipManager: RelationshipManager
   ) {

--- a/packages/adapters/drizzle/src/query-builders/query-builder-factory.ts
+++ b/packages/adapters/drizzle/src/query-builders/query-builder-factory.ts
@@ -6,14 +6,23 @@
  * This factory follows the Factory Pattern to create the appropriate
  * query builder implementation based on the driver type,
  * ensuring type safety through proper database type narrowing.
+ *
+ * Supports all driver variants for each SQL dialect:
+ * - PostgreSQL: postgres-js, node-postgres, neon-http
+ * - MySQL: mysql2
+ * - SQLite: better-sqlite3, libsql
  */
 
-import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
-import type { MySql2Database } from 'drizzle-orm/mysql2';
-import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
-
 import type { RelationshipManager } from '../relationship-manager';
-import type { AnyTableType, DatabaseDriver, DrizzleDatabase, QueryBuilderFactory } from '../types';
+import type {
+  AnyTableType,
+  DatabaseDriver,
+  DrizzleDatabase,
+  MySqlDatabaseType,
+  PostgresDatabaseType,
+  QueryBuilderFactory,
+  SQLiteDatabaseType,
+} from '../types';
 import type { BaseQueryBuilder } from './base-query-builder';
 import { MySQLQueryBuilder } from './mysql-query-builder';
 import { PostgresQueryBuilder } from './postgres-query-builder';
@@ -24,15 +33,21 @@ import { SQLiteQueryBuilder } from './sqlite-query-builder';
  * This follows the Factory Pattern and provides type-safe query builder creation.
  * Primary keys are auto-detected from the schema.
  *
+ * Supports all driver variants for each SQL dialect:
+ * - 'postgres': PostgresJsDatabase, NodePgDatabase, NeonHttpDatabase
+ * - 'mysql': MySql2Database
+ * - 'sqlite': BetterSQLite3Database, LibSQLDatabase
+ *
  * @template TDriver - The database driver type
- * @param driver - The database driver identifier
+ * @param driver - The database driver identifier ('postgres', 'mysql', or 'sqlite')
  * @returns A factory function that creates a query builder for the specific driver
  *
  * @example
  * ```typescript
+ * // Works with any PostgreSQL-compatible driver
  * const createQueryBuilder = getQueryBuilderFactory('postgres');
  * const queryBuilder = createQueryBuilder(
- *   postgresDb,
+ *   nodePgDb, // NodePgDatabase, PostgresJsDatabase, or NeonHttpDatabase
  *   schema,
  *   relationshipManager
  * );
@@ -40,7 +55,7 @@ import { SQLiteQueryBuilder } from './sqlite-query-builder';
  *
  * @throws {Error} If an unsupported driver is provided
  *
- * @since 1.0.0
+ * @since 1.0.0 (expanded to support all driver variants in 1.1.0)
  */
 export function getQueryBuilderFactory<TDriver extends DatabaseDriver>(
   driver: TDriver
@@ -55,14 +70,16 @@ export function getQueryBuilderFactory<TDriver extends DatabaseDriver>(
         // TypeScript's control flow analysis doesn't narrow generic types in switch statements.
         // However, this is safe because the DrizzleDatabase<TDriver> type is guaranteed to match
         // the specific driver's database type when TDriver is narrowed by the switch case.
-        // When TDriver = 'postgres', DrizzleDatabase<'postgres'> = PostgresJsDatabase
-        return new PostgresQueryBuilder(db as PostgresJsDatabase, schema, relationshipManager);
+        // When TDriver = 'postgres', DrizzleDatabase<'postgres'> = PostgresDatabaseType
+        // which includes PostgresJsDatabase, NodePgDatabase, and NeonHttpDatabase
+        return new PostgresQueryBuilder(db as PostgresDatabaseType, schema, relationshipManager);
       case 'mysql':
-        // Same reasoning: DrizzleDatabase<'mysql'> = MySql2Database
-        return new MySQLQueryBuilder(db as MySql2Database, schema, relationshipManager);
+        // Same reasoning: DrizzleDatabase<'mysql'> = MySqlDatabaseType
+        return new MySQLQueryBuilder(db as MySqlDatabaseType, schema, relationshipManager);
       case 'sqlite':
-        // Same reasoning: DrizzleDatabase<'sqlite'> = BetterSQLite3Database
-        return new SQLiteQueryBuilder(db as BetterSQLite3Database, schema, relationshipManager);
+        // Same reasoning: DrizzleDatabase<'sqlite'> = SQLiteDatabaseType
+        // which includes BetterSQLite3Database and LibSQLDatabase
+        return new SQLiteQueryBuilder(db as SQLiteDatabaseType, schema, relationshipManager);
       default:
         throw new Error(`Unsupported database driver: ${driver as string}`);
     }

--- a/packages/adapters/drizzle/src/query-builders/sqlite-query-builder.ts
+++ b/packages/adapters/drizzle/src/query-builders/sqlite-query-builder.ts
@@ -5,11 +5,14 @@
  * @description
  * SQLite query builder implementation with driver-specific optimizations.
  *
- * @since 1.0.0
+ * Supports all SQLite-compatible Drizzle drivers:
+ * - better-sqlite3 (BetterSQLite3Database)
+ * - libsql/Turso (LibSQLDatabase)
+ *
+ * @since 1.0.0 (expanded to support all SQLite drivers in 1.1.0)
  */
 
 import { count, isNotNull, max, min, type SQL, sql } from 'drizzle-orm';
-import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import type { SQLiteColumn, SQLiteTable } from 'drizzle-orm/sqlite-core';
 import type { RelationshipManager } from '../relationship-manager';
 import type {
@@ -17,6 +20,7 @@ import type {
   AnyColumnType,
   AnyTableType,
   QueryContext,
+  SQLiteDatabaseType,
   SQLiteQueryBuilderWithJoins,
 } from '../types';
 import { QueryError } from '../types';
@@ -26,15 +30,19 @@ import { BaseQueryBuilder } from './base-query-builder';
 /**
  * SQLite query builder implementation.
  *
+ * Supports all SQLite-compatible Drizzle drivers:
+ * - better-sqlite3 (BetterSQLite3Database)
+ * - libsql/Turso (LibSQLDatabase)
+ *
  * @class SQLiteQueryBuilder
  * @extends {BaseQueryBuilder}
- * @since 1.0.0
+ * @since 1.0.0 (expanded to support all SQLite drivers in 1.1.0)
  */
 export class SQLiteQueryBuilder extends BaseQueryBuilder {
-  private db: BetterSQLite3Database;
+  private db: SQLiteDatabaseType;
 
   constructor(
-    db: BetterSQLite3Database,
+    db: SQLiteDatabaseType,
     schema: Record<string, AnyTableType>,
     relationshipManager: RelationshipManager
   ) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Expanded Drizzle adapter and query builder support to accept all major drivers across PostgreSQL (postgres-js, node-postgres, neon-http), MySQL (mysql2), and SQLite, improving flexibility while keeping type safety.

- **Refactors**
  - Introduced driver-agnostic unions: PostgresDatabaseType, MySqlDatabaseType, SQLiteDatabaseType.
  - Updated operations and query-builder factories to return the right implementation for each driver.
  - Switched constructors in Postgres/MySQL/SQLite operations and query builders to use the new union types.
  - Improved docs and guards in types to clarify supported drivers and narrowing behavior.

- **Migration**
  - No changes needed for postgres-js, node-postgres, neon-http, mysql2, or better-sqlite3 users.
  - For libsql/Turso, cast your db to SQLiteDatabaseType when using the adapter until upstream typings align.

<sup>Written for commit 0f924f9cd821dc1ad8fd333267d8cd51104244c9. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

