### PR TITLE
fix: Wave A Cubic follow-ups (post-#83)

### DIFF
--- a/apps/marketing/src/app/api/tables/tickets/route.ts
+++ b/apps/marketing/src/app/api/tables/tickets/route.ts
@@ -1,5 +1,9 @@
 import { createAdapterRouteHandler } from '@better-tables/core';
 import { getSupportTables } from '@/lib/demo/support/db';
+import {
+  constrainTicketsAdapterRequest,
+  isAllowedTicketsAdapterRequest,
+} from '@/lib/demo/support/tickets-adapter-guard';
 
 /**
  * Client-callable table adapter for the tickets demo.
@@ -9,17 +13,31 @@ import { getSupportTables } from '@/lib/demo/support/db';
  * `createAdapterRouteHandler` dispatches to the real Drizzle adapter.
  *
  * IMPORTANT: a bare `createAdapterRouteHandler(adapter)` exposes every table
- * in the server adapter's schema. This route pins `primaryTable: 'tickets'`
- * via `constrainRequest` so clients cannot read `customers`/`assignees`/etc.
+ * in the server adapter's schema. This route:
+ * 1. Pins `primaryTable: 'tickets'` for `fetchData` via `constrainRequest`
+ * 2. Allowlists every referenced `columnId` (facet target, filters, sort,
+ *    columns) to the tickets demo surface — facet methods resolve their
+ *    table from `columnId`, so without (2) a client could still read
+ *    `customers`/`assignees`/`bulkTickets` via e.g. `company`.
  * Copy this pattern — do not mount a multi-table adapter without constraining.
  */
 export const POST = createAdapterRouteHandler(
   () => getSupportTables().then((tables) => tables.database),
   {
-    constrainRequest: (body) =>
-      body.method === 'fetchData'
-        ? { ...body, params: { ...body.params, primaryTable: 'tickets' } }
-        : body,
+    authorize: (_request, body) => {
+      if (!isAllowedTicketsAdapterRequest(body)) {
+        return new Response(
+          JSON.stringify({
+            ok: false,
+            error: 'Column not allowed on this endpoint.',
+            kind: 'bad_request',
+          }),
+          { status: 403, headers: { 'content-type': 'application/json' } }
+        );
+      }
+      return true;
+    },
+    constrainRequest: (body) => constrainTicketsAdapterRequest(body),
     onError: (error) => console.error('[api/tables/tickets]', error),
   }
 );

--- a/apps/marketing/src/app/api/users/route.test.ts
+++ b/apps/marketing/src/app/api/users/route.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
+import type { NextRequest } from 'next/server';
+import type { FetchUsersResult } from '@/lib/demo/fetch-users';
+
+const fetchUsersMock = mock(
+  (): Promise<FetchUsersResult> =>
+    Promise.resolve({
+      result: {
+        data: [],
+        total: 0,
+        pagination: { page: 1, limit: 10, totalPages: 0, hasNext: false, hasPrev: false },
+      },
+      filters: [],
+      sorting: [],
+      error: null,
+    })
+);
+
+mock.module('@/lib/demo/fetch-users', () => ({
+  fetchUsers: fetchUsersMock,
+}));
+
+// Import after mock.module so the route binds to the stub.
+const { GET } = await import('./route');
+
+describe('GET /api/users', () => {
+  let consoleErrorSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    fetchUsersMock.mockClear();
+    consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('returns 500 with a generic client message when fetchUsers fails', async () => {
+    fetchUsersMock.mockImplementationOnce(() =>
+      Promise.resolve({
+        result: {
+          data: [],
+          total: 0,
+          pagination: { page: 1, limit: 10, totalPages: 0, hasNext: false, hasPrev: false },
+        },
+        filters: [],
+        sorting: [],
+        error: 'secret sql fragment /Users/tome/.local/db',
+      })
+    );
+
+    const response = await GET(new Request('http://localhost/api/users') as NextRequest);
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ error: 'Failed to load demo data.' });
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      '[api/users]',
+      'secret sql fragment /Users/tome/.local/db'
+    );
+  });
+
+  it('returns data payload when fetchUsers succeeds', async () => {
+    fetchUsersMock.mockImplementationOnce(() =>
+      Promise.resolve({
+        result: {
+          data: [{ id: 1, name: 'Ada' }] as FetchUsersResult['result']['data'],
+          total: 1,
+          pagination: { page: 1, limit: 10, totalPages: 1, hasNext: false, hasPrev: false },
+          meta: { source: 'demo' },
+        },
+        filters: [],
+        sorting: [],
+        error: null,
+      })
+    );
+
+    const response = await GET(new Request('http://localhost/api/users') as NextRequest);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      data: [{ id: 1, name: 'Ada' }],
+      total: 1,
+      pagination: { page: 1, limit: 10, totalPages: 1, hasNext: false, hasPrev: false },
+      meta: { source: 'demo' },
+    });
+  });
+});

--- a/apps/marketing/src/lib/demo/support/tickets-adapter-guard.test.ts
+++ b/apps/marketing/src/lib/demo/support/tickets-adapter-guard.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from 'bun:test';
+import type { AdapterMeta, AdapterRequestBody, TableAdapter } from '@better-tables/core';
+import { createAdapterRouteHandler } from '@better-tables/core';
+import {
+  collectTicketsAdapterColumnIds,
+  constrainTicketsAdapterRequest,
+  isAllowedTicketsAdapterRequest,
+  TICKETS_DEMO_COLUMN_IDS,
+} from './tickets-adapter-guard';
+
+const META: AdapterMeta = {
+  name: 'test',
+  version: '1.0.0',
+  features: {
+    create: false,
+    read: true,
+    update: false,
+    delete: false,
+    bulkOperations: false,
+    realTimeUpdates: false,
+    export: false,
+    transactions: false,
+  },
+  supportedColumnTypes: ['text', 'number', 'option'],
+  supportedOperators: {
+    text: [],
+    number: [],
+    option: [],
+  } as unknown as AdapterMeta['supportedOperators'],
+};
+
+function makeSpyAdapter() {
+  const calls: { method: string; args: unknown[] }[] = [];
+  const adapter: TableAdapter = {
+    meta: META,
+    async fetchData(...args) {
+      calls.push({ method: 'fetchData', args });
+      return {
+        data: [],
+        total: 0,
+        pagination: { page: 1, limit: 10, totalPages: 0, hasNext: false, hasPrev: false },
+      };
+    },
+    async getFilterOptions(...args) {
+      calls.push({ method: 'getFilterOptions', args });
+      return [];
+    },
+    async getFacetedValues(...args) {
+      calls.push({ method: 'getFacetedValues', args });
+      return new Map([['open', 1]]);
+    },
+    async getMinMaxValues(...args) {
+      calls.push({ method: 'getMinMaxValues', args });
+      return [0, 3];
+    },
+  };
+  return { adapter, calls };
+}
+
+/** Mirror the marketing tickets route's authorize + constrain wiring. */
+function makeTicketsHandler(adapter: TableAdapter) {
+  return createAdapterRouteHandler(adapter, {
+    authorize: (_request, body) => {
+      if (!isAllowedTicketsAdapterRequest(body)) {
+        return new Response(
+          JSON.stringify({
+            ok: false,
+            error: 'Column not allowed on this endpoint.',
+            kind: 'bad_request',
+          }),
+          { status: 403, headers: { 'content-type': 'application/json' } }
+        );
+      }
+      return true;
+    },
+    constrainRequest: (body) => constrainTicketsAdapterRequest(body),
+  });
+}
+
+describe('tickets adapter column allowlist', () => {
+  it('includes tickets demo columns and relation paths, not bare related-table fields', () => {
+    expect(TICKETS_DEMO_COLUMN_IDS.has('status')).toBe(true);
+    expect(TICKETS_DEMO_COLUMN_IDS.has('customer.plan')).toBe(true);
+    expect(TICKETS_DEMO_COLUMN_IDS.has('reopenCount')).toBe(true);
+    // Bare customers/assignees/bulk columns must stay off the allowlist.
+    expect(TICKETS_DEMO_COLUMN_IDS.has('company')).toBe(false);
+    expect(TICKETS_DEMO_COLUMN_IDS.has('customerName')).toBe(false);
+    expect(TICKETS_DEMO_COLUMN_IDS.has('description')).toBe(false);
+  });
+
+  it('collects facet columnId plus nested filter column ids', () => {
+    const body: AdapterRequestBody = {
+      method: 'getFacetedValues',
+      columnId: 'status',
+      params: {
+        filters: {
+          kind: 'group',
+          logic: 'and',
+          children: [
+            {
+              columnId: 'priority',
+              type: 'option',
+              operator: 'is',
+              values: ['high'],
+            },
+          ],
+        },
+      },
+    };
+    expect(collectTicketsAdapterColumnIds(body)).toEqual(['status', 'priority']);
+  });
+
+  it('rejects facet requests that target a non-tickets schema column', () => {
+    const body: AdapterRequestBody = {
+      method: 'getFacetedValues',
+      columnId: 'company',
+    };
+    expect(isAllowedTicketsAdapterRequest(body)).toBe(false);
+  });
+
+  it('rejects fetchData when a filter references a non-tickets column', () => {
+    const body: AdapterRequestBody = {
+      method: 'fetchData',
+      params: {
+        filters: [{ columnId: 'company', type: 'text', operator: 'equals', values: ['Acme'] }],
+      },
+    };
+    expect(isAllowedTicketsAdapterRequest(body)).toBe(false);
+  });
+
+  it('allows legitimate tickets facet + relation filter requests', () => {
+    const body: AdapterRequestBody = {
+      method: 'getFacetedValues',
+      columnId: 'status',
+      params: {
+        filters: [
+          { columnId: 'customer.plan', type: 'option', operator: 'is', values: ['enterprise'] },
+        ],
+      },
+    };
+    expect(isAllowedTicketsAdapterRequest(body)).toBe(true);
+  });
+
+  it('pins fetchData primaryTable to tickets', () => {
+    const constrained = constrainTicketsAdapterRequest({
+      method: 'fetchData',
+      params: { primaryTable: 'customers', pagination: { page: 1, limit: 10 } },
+    });
+    expect(constrained.method).toBe('fetchData');
+    if (constrained.method === 'fetchData') {
+      expect(constrained.params.primaryTable).toBe('tickets');
+    }
+  });
+});
+
+describe('tickets adapter route guard (HTTP)', () => {
+  it('returns 403 and never hits the adapter for a leaked facet columnId', async () => {
+    const { adapter, calls } = makeSpyAdapter();
+    const handler = makeTicketsHandler(adapter);
+
+    const response = await handler(
+      new Request('http://x/api/tables/tickets', {
+        method: 'POST',
+        body: JSON.stringify({ method: 'getFacetedValues', columnId: 'company' }),
+      })
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      ok: false,
+      error: 'Column not allowed on this endpoint.',
+      kind: 'bad_request',
+    });
+    expect(calls).toHaveLength(0);
+  });
+
+  it('dispatches allowed getFacetedValues and pins fetchData primaryTable', async () => {
+    const { adapter, calls } = makeSpyAdapter();
+    const handler = makeTicketsHandler(adapter);
+
+    const facet = await handler(
+      new Request('http://x/api/tables/tickets', {
+        method: 'POST',
+        body: JSON.stringify({ method: 'getFacetedValues', columnId: 'status' }),
+      })
+    );
+    expect(facet.status).toBe(200);
+    expect(calls.some((c) => c.method === 'getFacetedValues')).toBe(true);
+
+    await handler(
+      new Request('http://x/api/tables/tickets', {
+        method: 'POST',
+        body: JSON.stringify({
+          method: 'fetchData',
+          params: { primaryTable: 'customers', pagination: { page: 1, limit: 5 } },
+        }),
+      })
+    );
+    const fetchCall = calls.find((c) => c.method === 'fetchData');
+    expect(fetchCall?.args[0]).toMatchObject({ primaryTable: 'tickets' });
+  });
+});

--- a/apps/marketing/src/lib/demo/support/tickets-adapter-guard.ts
+++ b/apps/marketing/src/lib/demo/support/tickets-adapter-guard.ts
@@ -1,0 +1,67 @@
+/**
+ * Request-surface allowlist for `/api/tables/tickets`.
+ *
+ * The server adapter backs a multi-table schema (`customers`, `assignees`,
+ * `tickets`, `bulkTickets`). `createAdapterRouteHandler` alone only pins
+ * `primaryTable` for `fetchData` — facet methods (`getFacetedValues`,
+ * `getMinMaxValues`, `getFilterOptions`) resolve the table from `columnId`,
+ * so a bare id like `company` can still read distributions from
+ * `customers`. This guard keeps every referenced column id on the tickets
+ * demo surface defined by {@link allTicketColumnIds}.
+ */
+
+import type { AdapterRequestBody, FilterGroupNode, FilterState } from '@better-tables/core';
+import { flattenFilterNode, isFilterGroupNode } from '@better-tables/core';
+import { allTicketColumnIds } from './columns';
+
+export const TICKETS_DEMO_COLUMN_IDS: ReadonlySet<string> = new Set(allTicketColumnIds);
+
+function collectFilterColumnIds(filters?: FilterState[] | FilterGroupNode): string[] {
+  if (!filters) return [];
+  if (isFilterGroupNode(filters)) {
+    return flattenFilterNode(filters).map((filter) => filter.columnId);
+  }
+  return filters.map((filter) => filter.columnId);
+}
+
+/** Every column id referenced by an adapter request body (facet target + filters/sort/columns). */
+export function collectTicketsAdapterColumnIds(body: AdapterRequestBody): string[] {
+  const ids: string[] = [];
+
+  if (body.method === 'fetchData') {
+    const { filters, sorting, columns } = body.params;
+    ids.push(...collectFilterColumnIds(filters));
+    if (sorting) {
+      for (const sort of sorting) {
+        ids.push(sort.columnId);
+      }
+    }
+    if (columns) {
+      ids.push(...columns);
+    }
+    return ids;
+  }
+
+  ids.push(body.columnId);
+  ids.push(...collectFilterColumnIds(body.params?.filters));
+  return ids;
+}
+
+/** True when every referenced column id is on the tickets demo surface. */
+export function isAllowedTicketsAdapterRequest(body: AdapterRequestBody): boolean {
+  return collectTicketsAdapterColumnIds(body).every((id) => TICKETS_DEMO_COLUMN_IDS.has(id));
+}
+
+/**
+ * Pin `fetchData` to the tickets table. Facet methods are gated by
+ * {@link isAllowedTicketsAdapterRequest} instead (column-id allowlist).
+ */
+export function constrainTicketsAdapterRequest(body: AdapterRequestBody): AdapterRequestBody {
+  if (body.method === 'fetchData') {
+    return {
+      ...body,
+      params: { ...body.params, primaryTable: 'tickets' },
+    };
+  }
+  return body;
+}

--- a/packages/adapters/drizzle/src/drizzle-adapter.ts
+++ b/packages/adapters/drizzle/src/drizzle-adapter.ts
@@ -1475,6 +1475,12 @@ export class DrizzleAdapter<TSchema extends Record<string, unknown>, TDriver ext
     }
 
     const maxSize = this.options?.cache?.maxSize ?? 500;
+    // Non-positive / non-finite capacity means no-cache (clear any residual).
+    if (!Number.isFinite(maxSize) || maxSize <= 0) {
+      this.cache.clear();
+      return;
+    }
+
     if (this.cache.has(key)) {
       this.cache.delete(key);
     }

--- a/packages/adapters/drizzle/src/query-builders/base-query-builder.ts
+++ b/packages/adapters/drizzle/src/query-builders/base-query-builder.ts
@@ -519,11 +519,15 @@ export abstract class BaseQueryBuilder {
    * those against join fan-out is a separate, pre-existing concern outside
    * this plan's scope (facet *counts* specifically).
    */
-  /** Resolve facet value LIMIT: default 100, `null` disables, number overrides. */
+  /**
+   * Resolve facet value LIMIT per {@link FacetQueryParams.limit}:
+   * default 100, `null` disables, positive integers override.
+   * Invalid / non-positive / non-integer values fall back to 100.
+   */
   protected resolveFacetLimit(limit?: number | null): number | null {
     if (limit === null) return null;
-    if (typeof limit === 'number' && Number.isFinite(limit) && limit >= 0) {
-      return Math.floor(limit);
+    if (typeof limit === 'number' && Number.isFinite(limit) && Number.isInteger(limit) && limit > 0) {
+      return limit;
     }
     return 100;
   }
@@ -568,7 +572,8 @@ export abstract class BaseQueryBuilder {
     const joinedQuery = this.applyJoins(baseQuery, joinOrder);
     const query = this.applyFilters(joinedQuery, filters || [], primaryTable, [isNotNull(column)]);
 
-    const grouped = query.groupBy(column).orderBy(desc(aggregateFn));
+    // Secondary `asc(column)` makes equal-count ties repeatable across runs.
+    const grouped = query.groupBy(column).orderBy(desc(aggregateFn), asc(column));
     const resolvedLimit = this.resolveFacetLimit(limit);
     return resolvedLimit === null ? grouped : grouped.limit(resolvedLimit);
   }
@@ -616,7 +621,8 @@ export abstract class BaseQueryBuilder {
     const joinedQuery = this.applyJoins(baseQuery, joinOrder);
     const query = this.applyFilters(joinedQuery, filters || [], primaryTable, [isNotNull(column)]);
 
-    const grouped = query.groupBy(column).orderBy(desc(countFn));
+    // Secondary `asc(column)` makes equal-count ties repeatable across runs.
+    const grouped = query.groupBy(column).orderBy(desc(countFn), asc(column));
     const resolvedLimit = this.resolveFacetLimit(limit);
     return resolvedLimit === null ? grouped : grouped.limit(resolvedLimit);
   }

--- a/packages/adapters/drizzle/src/types.ts
+++ b/packages/adapters/drizzle/src/types.ts
@@ -904,7 +904,10 @@ export interface DrizzleAdapterOptions {
   cache?: {
     enabled: boolean;
     ttl: number;
-    /** Max cached entries (LRU eviction). Default 500. */
+    /**
+     * Max cached entries (LRU eviction). Default 500.
+     * Non-positive values disable caching (no entries retained).
+     */
     maxSize?: number;
   };
 

--- a/packages/adapters/drizzle/src/utils/drizzle-schema-utils.ts
+++ b/packages/adapters/drizzle/src/utils/drizzle-schema-utils.ts
@@ -103,8 +103,11 @@ export interface ColumnInfo {
  * malformed or invalid schemas by returning an empty array rather than throwing errors.
  * It never throws - if the schema is invalid, it returns an empty array instead.
  */
-/** Memoize schema-derived column lists by table object identity (immutable). */
-const tableColumnsCache = new WeakMap<object, ColumnInfo[]>();
+/**
+ * Memoize schema-derived column lists by table object identity.
+ * Callers receive a shallow copy so mutations cannot corrupt the cache.
+ */
+const tableColumnsCache = new WeakMap<object, readonly ColumnInfo[]>();
 
 export function getTableColumns(tableSchema: AnyTableType): ColumnInfo[] {
   if (!tableSchema || typeof tableSchema !== 'object') {
@@ -113,7 +116,7 @@ export function getTableColumns(tableSchema: AnyTableType): ColumnInfo[] {
 
   const cached = tableColumnsCache.get(tableSchema as object);
   if (cached) {
-    return cached;
+    return cached.slice();
   }
 
   const tableObj = tableSchema as unknown as Record<string, AnyColumnType>;
@@ -140,7 +143,7 @@ export function getTableColumns(tableSchema: AnyTableType): ColumnInfo[] {
   }
 
   tableColumnsCache.set(tableSchema as object, columns);
-  return columns;
+  return columns.slice();
 }
 
 /**

--- a/packages/adapters/drizzle/tests/adapter-perf-cache-facets.test.ts
+++ b/packages/adapters/drizzle/tests/adapter-perf-cache-facets.test.ts
@@ -18,10 +18,18 @@ const items = sqliteTable('items', {
 const schema = { items };
 
 describe('Plan 040 — getTableColumns memoization', () => {
-  it('returns the same array reference for the same table object', () => {
+  it('memoizes introspection but returns a defensive copy', () => {
     const a = getTableColumns(items);
     const b = getTableColumns(items);
-    expect(a).toBe(b);
+    expect(a).not.toBe(b);
+    expect(a).toEqual(b);
+
+    a.pop();
+    a[0] = { ...a[0]!, name: 'mutated' };
+    const c = getTableColumns(items);
+    expect(c).toEqual(b);
+    expect(c.map((col) => col.name)).toContain('id');
+    expect(c.map((col) => col.name)).not.toContain('mutated');
   });
 });
 
@@ -98,6 +106,23 @@ describe('Plan 040 — bounded LRU cache', () => {
     // Expired entry deleted on access; a fresh entry may be written.
     expect(shortTtl.getCacheSizeForTests()).toBeLessThanOrEqual(1);
   });
+
+  it('maxSize: 0 disables caching (keeps zero entries)', async () => {
+    const noCache = drizzleAdapter(drizzle(sqlite, { schema }), {
+      driver: 'sqlite',
+      schema,
+      options: {
+        defaultPrimaryTable: 'items',
+        cache: { enabled: true, ttl: 60_000, maxSize: 0 },
+      },
+    });
+    await noCache.fetchData({
+      primaryTable: 'items',
+      columns: ['category'],
+      pagination: { page: 1, limit: 10 },
+    });
+    expect(noCache.getCacheSizeForTests()).toBe(0);
+  });
 });
 
 describe('Plan 040 — facet LIMIT top-100 default', () => {
@@ -147,5 +172,46 @@ describe('Plan 040 — facet LIMIT top-100 default', () => {
   it('limit: 5 returns five values', async () => {
     const facets = await adapter.getFacetedValues('category', { limit: 5 });
     expect(facets.size).toBe(5);
+  });
+
+  it('invalid limits (0, fraction, negative, NaN) fall back to default top-100', async () => {
+    for (const limit of [0, 1.9, -3, Number.NaN, Number.POSITIVE_INFINITY]) {
+      const facets = await adapter.getFacetedValues('category', { limit });
+      expect(facets.size).toBe(100);
+    }
+  });
+});
+
+describe('Plan 040 — facet equal-count tie ordering', () => {
+  let sqlite: Database;
+  let adapter: ReturnType<typeof drizzleAdapter>;
+
+  beforeEach(async () => {
+    sqlite = new Database(':memory:');
+    const db = drizzle(sqlite, { schema });
+    db.run(sql`CREATE TABLE items (id INTEGER PRIMARY KEY, category TEXT NOT NULL)`);
+    // All categories appear once → equal counts; secondary value order must be stable.
+    const rows = ['zeta', 'alpha', 'mu', 'beta', 'gamma'].map((category, i) => ({
+      id: i + 1,
+      category,
+    }));
+    await db.insert(items).values(rows);
+    adapter = drizzleAdapter(db, {
+      driver: 'sqlite',
+      schema,
+      options: { defaultPrimaryTable: 'items', cache: { enabled: false, ttl: 0 } },
+    });
+  });
+
+  afterEach(() => {
+    sqlite.close();
+  });
+
+  it('orders equal-count ties by value ascending for repeatable top-N', async () => {
+    const first = await adapter.getFacetedValues('category', { limit: 3 });
+    const second = await adapter.getFacetedValues('category', { limit: 3 });
+    const keys = [...first.keys()];
+    expect(keys).toEqual(['alpha', 'beta', 'gamma']);
+    expect([...second.keys()]).toEqual(keys);
   });
 });

--- a/packages/adapters/drizzle/tests/date-filter-operators.test.ts
+++ b/packages/adapters/drizzle/tests/date-filter-operators.test.ts
@@ -146,12 +146,5 @@ describe('DrizzleAdapter — date operators on a timestamp column', () => {
       const res = await fetch(untypedFilter('notBetween', endpoints));
       expect(res.total).toBe(2);
     });
-
-    it('typed date between/notBetween agree with the untyped fallback counts', async () => {
-      const typedBetween = await fetch(dateFilter('between', endpoints));
-      const typedNotBetween = await fetch(dateFilter('notBetween', endpoints));
-      expect(typedBetween.total).toBe(3);
-      expect(typedNotBetween.total).toBe(2);
-    });
   });
 });

--- a/packages/adapters/drizzle/tests/drizzle-predicate-emitter.test.ts
+++ b/packages/adapters/drizzle/tests/drizzle-predicate-emitter.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Unit tests for DrizzlePredicateEmitter.prefersDateSemantics — used by the
+ * filter router for `between`/`notBetween` timestamp fallback when the filter's
+ * `columnType` isn't `'date'`.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { sql } from 'drizzle-orm';
+import { date, datetime, mysqlTable, varchar } from 'drizzle-orm/mysql-core';
+import { pgTable, text as pgText, timestamp } from 'drizzle-orm/pg-core';
+import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { DrizzlePredicateEmitter } from '../src/drizzle-predicate-emitter';
+
+const pgUsers = pgTable('users', {
+  id: timestamp('id').primaryKey(),
+  createdAt: timestamp('created_at'),
+  name: pgText('name'),
+});
+
+const mysqlUsers = mysqlTable('users', {
+  id: datetime('id').primaryKey(),
+  createdAt: datetime('created_at'),
+  bornOn: date('born_on'),
+  name: varchar('name', { length: 64 }),
+});
+
+const sqliteUsers = sqliteTable('users', {
+  id: integer('id').primaryKey(),
+  createdAt: integer('created_at', { mode: 'timestamp' }),
+  name: text('name'),
+  plainInt: integer('plain_int'),
+});
+
+describe('DrizzlePredicateEmitter.prefersDateSemantics', () => {
+  describe('postgres', () => {
+    const emitter = new DrizzlePredicateEmitter({ users: pgUsers }, 'postgres');
+
+    it('returns true for PgTimestamp columns', () => {
+      expect(emitter.prefersDateSemantics(pgUsers.createdAt)).toBe(true);
+      expect(emitter.prefersDateSemantics(pgUsers.id)).toBe(true);
+    });
+
+    it('returns false for text columns', () => {
+      expect(emitter.prefersDateSemantics(pgUsers.name)).toBe(false);
+    });
+
+    it('returns false for SQL expressions', () => {
+      expect(emitter.prefersDateSemantics(sql`now()`)).toBe(false);
+    });
+  });
+
+  describe('mysql', () => {
+    const emitter = new DrizzlePredicateEmitter({ users: mysqlUsers }, 'mysql');
+
+    it('returns true for MySqlDateTime / MySqlDate columns', () => {
+      expect(emitter.prefersDateSemantics(mysqlUsers.createdAt)).toBe(true);
+      expect(emitter.prefersDateSemantics(mysqlUsers.bornOn)).toBe(true);
+    });
+
+    it('returns false for varchar columns', () => {
+      expect(emitter.prefersDateSemantics(mysqlUsers.name)).toBe(false);
+    });
+  });
+
+  describe('sqlite', () => {
+    const emitter = new DrizzlePredicateEmitter({ users: sqliteUsers }, 'sqlite');
+
+    it('returns true for integer columns with mode: timestamp', () => {
+      expect(emitter.prefersDateSemantics(sqliteUsers.createdAt)).toBe(true);
+    });
+
+    it('returns false for plain integer and text columns', () => {
+      expect(emitter.prefersDateSemantics(sqliteUsers.plainInt)).toBe(false);
+      expect(emitter.prefersDateSemantics(sqliteUsers.name)).toBe(false);
+    });
+  });
+});

--- a/packages/adapters/toolkit/src/data-transformer.ts
+++ b/packages/adapters/toolkit/src/data-transformer.ts
@@ -161,17 +161,18 @@ export class DataTransformer<TTable = unknown> {
     const groupedData = this.groupByMainTableKey(flatData, primaryTable);
 
     // Precompute per-query invariants once (paths / pk names / column lists are
-    // row-invariant). Cleared in finally so subsequent transforms start clean.
+    // row-invariant). Cleared in finally so subsequent transforms start clean —
+    // including when precompute or build throws.
     this.columnPathCache = new Map();
     this.primaryKeyNameCache = new WeakMap();
     this.columnNamesCache = new WeakMap();
-    if (columns) {
-      for (const columnId of columns) {
-        this.resolveColumnPathCached(columnId, primaryTable);
-      }
-    }
-
     try {
+      if (columns) {
+        for (const columnId of columns) {
+          this.resolveColumnPathCached(columnId, primaryTable);
+        }
+      }
+
       const nestedData: TData[] = [];
 
       for (const [, records] of groupedData) {

--- a/packages/adapters/toolkit/tests/data-transformer-cache.test.ts
+++ b/packages/adapters/toolkit/tests/data-transformer-cache.test.ts
@@ -31,7 +31,7 @@ function makeColumnPath(columnId: string, primaryTable: string): ColumnPath {
     };
   }
 
-  const [alias, field = ''] = columnId.split('.');
+  const [, field = ''] = columnId.split('.');
   const relationship: RelationshipPath = {
     from: primaryTable,
     to: 'profiles',

--- a/packages/adapters/toolkit/tests/data-transformer-cache.test.ts
+++ b/packages/adapters/toolkit/tests/data-transformer-cache.test.ts
@@ -1,0 +1,286 @@
+/**
+ * @fileoverview Per-transform cache behavior for DataTransformer
+ *
+ * Covers the memoization added for PERF-01 (plan 040):
+ * - resolveColumnPath / getPrimaryKeyName / getColumnNames hit caches within a transform
+ * - caches are cleared in the transform's finally block
+ * - a subsequent transform starts clean (lookups run again)
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { DataTransformer } from '../src/data-transformer';
+import type {
+  ColumnPath,
+  RelationshipManagerPort,
+  RelationshipPath,
+  SchemaIntrospectionPort,
+} from '../src/types';
+
+interface ToyTable {
+  columns: string[];
+  primaryKey: string;
+}
+
+function makeColumnPath(columnId: string, primaryTable: string): ColumnPath {
+  if (!columnId.includes('.')) {
+    return {
+      columnId,
+      table: primaryTable,
+      field: columnId,
+      isNested: false,
+    };
+  }
+
+  const [alias, field = ''] = columnId.split('.');
+  const relationship: RelationshipPath = {
+    from: primaryTable,
+    to: 'profiles',
+    foreignKey: 'userId',
+    localKey: 'id',
+    cardinality: 'one',
+  };
+
+  return {
+    columnId,
+    table: 'profiles',
+    field,
+    isNested: true,
+    relationshipPath: [relationship],
+  };
+}
+
+function createCountingPorts() {
+  const resolveCalls: string[] = [];
+  const primaryKeyCalls: ToyTable[] = [];
+  const columnNameCalls: ToyTable[] = [];
+
+  const relationshipManager: RelationshipManagerPort = {
+    resolveColumnPath(columnId, primaryTable) {
+      resolveCalls.push(`${primaryTable}:${columnId}`);
+      return makeColumnPath(columnId, primaryTable);
+    },
+    getRelationshipByAlias() {
+      return null;
+    },
+    isArrayRelationship() {
+      return false;
+    },
+  };
+
+  const schemaPort: SchemaIntrospectionPort<ToyTable> = {
+    getColumnNames(table) {
+      columnNameCalls.push(table);
+      return table.columns;
+    },
+    getForeignKeyColumns() {
+      return [];
+    },
+    getPrimaryKeyColumns(table) {
+      primaryKeyCalls.push(table);
+      return [{ name: table.primaryKey, column: table.primaryKey }];
+    },
+  };
+
+  return {
+    relationshipManager,
+    schemaPort,
+    resolveCalls,
+    primaryKeyCalls,
+    columnNameCalls,
+  };
+}
+
+function cacheFields(transformer: DataTransformer<ToyTable>) {
+  const internal = transformer as unknown as {
+    columnPathCache: Map<string, ColumnPath> | null;
+    primaryKeyNameCache: WeakMap<object, string> | null;
+    columnNamesCache: WeakMap<object, string[]> | null;
+  };
+  return {
+    columnPathCache: internal.columnPathCache,
+    primaryKeyNameCache: internal.primaryKeyNameCache,
+    columnNamesCache: internal.columnNamesCache,
+  };
+}
+
+describe('DataTransformer per-transform caches', () => {
+  const users: ToyTable = { columns: ['id', 'email'], primaryKey: 'id' };
+  const profiles: ToyTable = { columns: ['id', 'bio', 'userId'], primaryKey: 'id' };
+  const schema = { users, profiles };
+
+  it('memoizes resolveColumnPath within a single transform (cache hits across rows)', () => {
+    const { relationshipManager, schemaPort, resolveCalls } = createCountingPorts();
+    const transformer = new DataTransformer(schema, relationshipManager, schemaPort);
+
+    const flatData = [
+      {
+        id: 1,
+        email: 'a@example.com',
+        profiles_id: 10,
+        profiles_bio: 'Bio A',
+      },
+      {
+        id: 2,
+        email: 'b@example.com',
+        profiles_id: 20,
+        profiles_bio: 'Bio B',
+      },
+    ];
+
+    const columns = ['email', 'profile.bio'];
+    transformer.transformToNested(flatData, 'users', columns);
+
+    // Precompute + row processing should reuse the same path resolutions.
+    // Without a cache this would scale with row count × column references.
+    const emailResolves = resolveCalls.filter((c) => c.endsWith(':email')).length;
+    const profileBioResolves = resolveCalls.filter((c) => c.endsWith(':profile.bio')).length;
+
+    expect(emailResolves).toBe(1);
+    expect(profileBioResolves).toBe(1);
+  });
+
+  it('memoizes primary-key lookups across related rows within a transform', () => {
+    const { schemaPort, primaryKeyCalls } = createCountingPorts();
+
+    // Multiple flat rows for one user → one-to-many style related records,
+    // so getPrimaryKeyNameCached runs per related row without the cache.
+    const posts: ToyTable = { columns: ['id', 'title', 'userId'], primaryKey: 'id' };
+    const manySchema = { users, posts };
+
+    const manyRelationshipManager: RelationshipManagerPort = {
+      resolveColumnPath(columnId, primaryTable) {
+        if (!columnId.includes('.')) {
+          return makeColumnPath(columnId, primaryTable);
+        }
+        const [, field = ''] = columnId.split('.');
+        return {
+          columnId,
+          table: 'posts',
+          field,
+          isNested: true,
+          relationshipPath: [
+            {
+              from: primaryTable,
+              to: 'posts',
+              foreignKey: 'userId',
+              localKey: 'id',
+              cardinality: 'many',
+            },
+          ],
+        };
+      },
+      getRelationshipByAlias() {
+        return null;
+      },
+      isArrayRelationship() {
+        return false;
+      },
+    };
+
+    const manyTransformer = new DataTransformer(manySchema, manyRelationshipManager, schemaPort);
+
+    const flatData = [
+      { id: 1, email: 'a@example.com', posts_id: 1, posts_title: 'Post 1' },
+      { id: 1, email: 'a@example.com', posts_id: 2, posts_title: 'Post 2' },
+      { id: 1, email: 'a@example.com', posts_id: 3, posts_title: 'Post 3' },
+    ];
+
+    manyTransformer.transformToNested(flatData, 'users', ['email', 'posts.title']);
+
+    // groupByMainTableKey hits PK once before caches are armed; the rest of
+    // the transform should reuse the WeakMap memo for posts (3 related rows).
+    const usersPkCalls = primaryKeyCalls.filter((t) => t === users).length;
+    const postsPkCalls = primaryKeyCalls.filter((t) => t === posts).length;
+
+    expect(usersPkCalls).toBeLessThanOrEqual(2);
+    expect(postsPkCalls).toBe(1);
+  });
+
+  it('memoizes getColumnNames for one-to-one related tables within a transform', () => {
+    const { relationshipManager, schemaPort, columnNameCalls } = createCountingPorts();
+    const transformer = new DataTransformer(schema, relationshipManager, schemaPort);
+
+    // Two primary rows each with a profile — processOneToOneColumn calls
+    // getColumnNamesCached per row; the WeakMap should collapse that to 1.
+    const flatData = [
+      { id: 1, email: 'a@example.com', profiles_id: 10, profiles_bio: 'Bio A' },
+      { id: 2, email: 'b@example.com', profiles_id: 20, profiles_bio: 'Bio B' },
+    ];
+
+    transformer.transformToNested(flatData, 'users', ['email', 'profile.bio']);
+
+    const profileColCalls = columnNameCalls.filter((t) => t === profiles).length;
+    expect(profileColCalls).toBe(1);
+  });
+
+  it('clears caches in finally so fields are null after transform returns', () => {
+    const { relationshipManager, schemaPort } = createCountingPorts();
+    const transformer = new DataTransformer(schema, relationshipManager, schemaPort);
+
+    transformer.transformToNested(
+      [{ id: 1, email: 'a@example.com', profiles_id: 10, profiles_bio: 'Bio' }],
+      'users',
+      ['email', 'profile.bio']
+    );
+
+    const after = cacheFields(transformer);
+    expect(after.columnPathCache).toBeNull();
+    expect(after.primaryKeyNameCache).toBeNull();
+    expect(after.columnNamesCache).toBeNull();
+  });
+
+  it('clears caches even when transform throws', () => {
+    const { schemaPort } = createCountingPorts();
+
+    const explodingManager: RelationshipManagerPort = {
+      resolveColumnPath(columnId, primaryTable) {
+        if (columnId === 'profile.bio') {
+          throw new Error('boom');
+        }
+        return makeColumnPath(columnId, primaryTable);
+      },
+      getRelationshipByAlias() {
+        return null;
+      },
+      isArrayRelationship() {
+        return false;
+      },
+    };
+
+    const transformer = new DataTransformer(schema, explodingManager, schemaPort);
+
+    expect(() =>
+      transformer.transformToNested(
+        [{ id: 1, email: 'a@example.com', profiles_id: 10, profiles_bio: 'Bio' }],
+        'users',
+        ['email', 'profile.bio']
+      )
+    ).toThrow('boom');
+
+    const after = cacheFields(transformer);
+    expect(after.columnPathCache).toBeNull();
+    expect(after.primaryKeyNameCache).toBeNull();
+    expect(after.columnNamesCache).toBeNull();
+  });
+
+  it('starts each transform with empty caches (repeated lookups across transforms)', () => {
+    const { relationshipManager, schemaPort, resolveCalls } = createCountingPorts();
+    const transformer = new DataTransformer(schema, relationshipManager, schemaPort);
+
+    const flatData = [
+      { id: 1, email: 'a@example.com', profiles_id: 10, profiles_bio: 'Bio' },
+    ];
+    const columns = ['email', 'profile.bio'];
+
+    transformer.transformToNested(flatData, 'users', columns);
+    const afterFirst = resolveCalls.length;
+
+    transformer.transformToNested(flatData, 'users', columns);
+    const afterSecond = resolveCalls.length;
+
+    // Second transform must re-resolve (caches were cleared), not reuse the
+    // previous transform's Map/WeakMaps.
+    expect(afterFirst).toBeGreaterThan(0);
+    expect(afterSecond).toBe(afterFirst * 2);
+  });
+});

--- a/packages/core/src/adapters/http-handler.ts
+++ b/packages/core/src/adapters/http-handler.ts
@@ -171,6 +171,8 @@ export async function handleAdapterRequest<TData = unknown>(
  *
  * Status mapping: success → 200; `kind: 'bad_request'` (and authorize false)
  * → 400/403; `kind: 'server_error'` → 500. The response is `application/json`.
+ * Throws from `authorize` / `constrainRequest` are caught the same way as
+ * adapter failures (500 + `server_error` envelope + optional `onError`).
  *
  * @example
  * ```ts
@@ -209,27 +211,49 @@ export function createAdapterRouteHandler<TData = unknown>(
       });
     }
 
-    if (routeOptions?.authorize) {
-      const authResult = await routeOptions.authorize(request, body);
-      if (authResult instanceof Response) {
-        return authResult;
+    let constrained: AdapterRequestBody = body;
+    try {
+      if (routeOptions?.authorize) {
+        const authResult = await routeOptions.authorize(request, body);
+        if (authResult instanceof Response) {
+          return authResult;
+        }
+        if (authResult === false) {
+          const envelope: AdapterResponseBody = {
+            ok: false,
+            error: 'Unauthorized.',
+            kind: 'bad_request',
+          };
+          return new Response(JSON.stringify(envelope), {
+            status: 403,
+            headers: { 'content-type': 'application/json' },
+          });
+        }
       }
-      if (authResult === false) {
-        const envelope: AdapterResponseBody = {
-          ok: false,
-          error: 'Unauthorized.',
-          kind: 'bad_request',
-        };
-        return new Response(JSON.stringify(envelope), {
-          status: 403,
-          headers: { 'content-type': 'application/json' },
-        });
-      }
-    }
 
-    const constrained = routeOptions?.constrainRequest
-      ? routeOptions.constrainRequest(body, request)
-      : body;
+      if (routeOptions?.constrainRequest) {
+        constrained = routeOptions.constrainRequest(body, request);
+      }
+    } catch (error) {
+      // Match handleAdapterRequest: never leak authorize/constrain failures
+      // outside the JSON envelope + onError sink.
+      if (routeOptions?.onError) {
+        try {
+          routeOptions.onError(error);
+        } catch {
+          // A throwing logger must not mask the response.
+        }
+      }
+      const envelope: AdapterResponseBody = {
+        ok: false,
+        error: 'Adapter request failed.',
+        kind: 'server_error',
+      };
+      return new Response(JSON.stringify(envelope), {
+        status: 500,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
 
     const envelope = await handleAdapterRequest(
       source,

--- a/packages/core/src/types/adapter.ts
+++ b/packages/core/src/types/adapter.ts
@@ -207,7 +207,11 @@ export interface FacetQueryParams {
   /**
    * Cap distinct facet values returned, ordered by count descending.
    * Default: `100`. Pass `null` to disable the cap (return all values).
-   * A positive number overrides the default.
+   * A positive integer overrides the default.
+   *
+   * Invalid values (`0`, negatives, `NaN`/`Infinity`, or non-integers) are
+   * treated as omitted: adapters SHOULD fall back to the default `100`, not
+   * return an empty list or silently floor (e.g. `1.9` → `1`).
    */
   limit?: number | null;
 }

--- a/packages/core/tests/adapters/http-adapter.test.ts
+++ b/packages/core/tests/adapters/http-adapter.test.ts
@@ -389,6 +389,78 @@ describe('httpAdapter <-> handleAdapterRequest round-trip', () => {
     expect(sent.primaryTable).toBe('tickets');
   });
 
+  it('authorize throws map to 500 server_error and invoke onError', async () => {
+    const seen: unknown[] = [];
+    let built = 0;
+    const handler = createAdapterRouteHandler(
+      () => {
+        built += 1;
+        return makeServerAdapter().adapter;
+      },
+      {
+        authorize: () => {
+          throw new Error('auth boom');
+        },
+        onError: (error) => {
+          seen.push(error);
+        },
+      }
+    );
+
+    const response = await handler(
+      new Request('http://x/api/tables', {
+        method: 'POST',
+        body: JSON.stringify({ method: 'fetchData', params: {} }),
+      })
+    );
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({
+      ok: false,
+      error: 'Adapter request failed.',
+      kind: 'server_error',
+    });
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toBeInstanceOf(Error);
+    expect((seen[0] as Error).message).toBe('auth boom');
+    expect(built).toBe(0);
+  });
+
+  it('constrainRequest throws map to 500 server_error and invoke onError', async () => {
+    const seen: unknown[] = [];
+    let built = 0;
+    const handler = createAdapterRouteHandler(
+      () => {
+        built += 1;
+        return makeServerAdapter().adapter;
+      },
+      {
+        constrainRequest: () => {
+          throw new Error('constrain boom');
+        },
+        onError: (error) => {
+          seen.push(error);
+        },
+      }
+    );
+
+    const response = await handler(
+      new Request('http://x/api/tables', {
+        method: 'POST',
+        body: JSON.stringify({ method: 'fetchData', params: {} }),
+      })
+    );
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({
+      ok: false,
+      error: 'Adapter request failed.',
+      kind: 'server_error',
+    });
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toBeInstanceOf(Error);
+    expect((seen[0] as Error).message).toBe('constrain boom');
+    expect(built).toBe(0);
+  });
+
   it('maps adapter throws to 500 server_error and malformed body to 400', async () => {
     const failing: TableAdapter = {
       meta: TEST_META,

--- a/packages/core/tests/types/adapter.test.ts
+++ b/packages/core/tests/types/adapter.test.ts
@@ -6,10 +6,12 @@ import type {
   DataEvent,
   ExportParams,
   ExportResult,
+  FacetQueryParams,
   FetchDataParams,
   FetchDataResult,
   FilterGroupNode,
   FilterState,
+  MutationOptions,
   TableAdapter,
 } from '../../src/types';
 
@@ -106,13 +108,54 @@ describe('Adapter Types', () => {
       };
 
       expectTypeOf(adapter.createRecord).toMatchTypeOf<
-        | ((data: Partial<{ id: string; name: string }>) => Promise<{ id: string; name: string }>)
+        | ((
+            data: Partial<{ id: string; name: string }>,
+            options?: MutationOptions
+          ) => Promise<{ id: string; name: string }>)
         | undefined
+      >();
+      expectTypeOf(adapter.updateRecord).toMatchTypeOf<
+        | ((
+            id: string,
+            data: Partial<{ id: string; name: string }>,
+            options?: MutationOptions
+          ) => Promise<{ id: string; name: string }>)
+        | undefined
+      >();
+      expectTypeOf(adapter.deleteRecord).toMatchTypeOf<
+        ((id: string, options?: MutationOptions) => Promise<void>) | undefined
       >();
       expectTypeOf(adapter.subscribe).toMatchTypeOf<
         | ((callback: (event: DataEvent<{ id: string; name: string }>) => void) => () => void)
         | undefined
       >();
+    });
+  });
+
+  describe('FacetQueryParams', () => {
+    it('accepts filters, signal, and limit', () => {
+      const params: FacetQueryParams = {
+        filters: [{ columnId: 'status', type: 'option', operator: 'is', values: ['active'] }],
+        signal: new AbortController().signal,
+        limit: 50,
+      };
+
+      expectTypeOf(params.filters).toMatchTypeOf<FilterState[] | FilterGroupNode | undefined>();
+      expectTypeOf(params.signal).toEqualTypeOf<AbortSignal | undefined>();
+      expectTypeOf(params.limit).toEqualTypeOf<number | null | undefined>();
+    });
+
+    it('allows null limit to disable the cap', () => {
+      const params: FacetQueryParams = { limit: null };
+      expectTypeOf(params.limit).toEqualTypeOf<number | null | undefined>();
+    });
+  });
+
+  describe('MutationOptions', () => {
+    it('accepts an optional table target', () => {
+      const options: MutationOptions = { table: 'users' };
+      expectTypeOf(options.table).toEqualTypeOf<string | undefined>();
+      expectTypeOf(options).toMatchTypeOf<{ table?: string }>();
     });
   });
 

--- a/packages/ui/src/hooks/use-table-data.ts
+++ b/packages/ui/src/hooks/use-table-data.ts
@@ -11,9 +11,10 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 // Stable defaults so omitted `filters`/`params` don't recreate `fetchData`'s
 // identity (and retrigger the fetch effect) on every render the way inline
-// `= []` / `= {}` default-parameter literals would.
-const EMPTY_FILTERS: FilterState[] = [];
-const EMPTY_PARAMS: Record<string, unknown> = {};
+// `= []` / `= {}` default-parameter literals would. Frozen so a shared
+// constant can't be mutated via fetchParams (e.g. filters.push).
+const EMPTY_FILTERS = Object.freeze([] as FilterState[]) as FilterState[];
+const EMPTY_PARAMS = Object.freeze({}) as Record<string, unknown>;
 
 export interface UseTableDataOptions<TData = unknown> {
   /** Table adapter for data fetching */

--- a/plans/040-adapter-performance.md
+++ b/plans/040-adapter-performance.md
@@ -4,7 +4,7 @@
 > confirm before moving on. On any STOP condition, stop and report. Update
 > `plans/README.md` when done unless a reviewer maintains the index.
 >
-> **Drift check (run first)**: `git diff --stat 787a816..HEAD -- packages/adapters/toolkit/src/data-transformer.ts packages/adapters/drizzle/src/utils/drizzle-schema-utils.ts packages/adapters/toolkit/src/relationship-manager.ts packages/adapters/drizzle/src/drizzle-adapter.ts packages/adapters/drizzle/src/query-builders/base-query-builder.ts packages/core/src/types/adapter.ts`
+> **Drift check (run first)**: `git diff --stat 787a816..HEAD -- packages/adapters/toolkit/src/data-transformer.ts packages/adapters/drizzle/src/utils/drizzle-schema-utils.ts packages/adapters/drizzle/src/relationship-manager.ts packages/adapters/drizzle/src/drizzle-adapter.ts packages/adapters/drizzle/src/query-builders/base-query-builder.ts packages/core/src/types/adapter.ts`
 
 ## Status
 
@@ -54,7 +54,7 @@ Verified at `787a816`:
 - `packages/adapters/drizzle/src/utils/drizzle-schema-utils.ts:106-135` —
   `getTableColumns` runs `Object.entries(tableObj)` and allocates a fresh
   `ColumnInfo[]` every call; not memoized.
-- `packages/adapters/toolkit/src/relationship-manager.ts:109`
+- `packages/adapters/drizzle/src/relationship-manager.ts:109`
   `resolveColumnPath` — `joinPathCache` covers only multi-level paths, not
   1-/2-part.
 - `packages/adapters/drizzle/src/drizzle-adapter.ts`: `:154`
@@ -85,7 +85,7 @@ Verified at `787a816`:
 **In scope**:
 - `packages/adapters/toolkit/src/data-transformer.ts`
 - `packages/adapters/drizzle/src/utils/drizzle-schema-utils.ts`
-- `packages/adapters/toolkit/src/relationship-manager.ts` (1-/2-part path cache — optional if the transformer precompute covers it)
+- `packages/adapters/drizzle/src/relationship-manager.ts` (1-/2-part path cache — optional if the transformer precompute covers it)
 - `packages/adapters/drizzle/src/drizzle-adapter.ts` (cache eviction)
 - `packages/adapters/drizzle/src/query-builders/base-query-builder.ts` (facet LIMIT)
 - `packages/core/src/types/adapter.ts` (`FacetQueryParams.limit`)

--- a/plans/044-drizzle-module-decomposition.md
+++ b/plans/044-drizzle-module-decomposition.md
@@ -115,8 +115,8 @@ Move the cache into `adapter-cache.ts` as a small class (`AdapterCache` with
 adapter holds an instance. Keep the default-on + TTL + write-invalidation
 semantics identical.
 
-**Verify**: `bun test` → cache tests pass (incl. plan 040's eviction test);
-build exit 0.
+**Verify**: `cd packages/adapters/drizzle && bun test` → cache tests pass
+(incl. plan 040's eviction test); build exit 0.
 
 ### Step 3: Extract the meta tables
 
@@ -125,8 +125,9 @@ core) + `canResolveMutationTable`'s meta-facing logic into `adapter-meta.ts`
 as a function taking the inputs it needs (resolvable-mutation flag, supported
 sets). The adapter calls it.
 
-**Verify**: `bun test` → meta tests pass; `adapter.meta` shape identical
-(add a snapshot-equality assertion if none exists).
+**Verify**: `cd packages/adapters/drizzle && bun test` → meta tests pass;
+`adapter.meta` shape identical (add a snapshot-equality assertion if none
+exists).
 
 ### Step 4: Split `types.ts` behind a barrel
 
@@ -136,8 +137,9 @@ each type group verbatim. Make `types.ts` (or `types/index.ts`, whichever
 keeps `from './types'` resolving) re-export everything so NO import site
 changes. If moving to `types/index.ts`, verify `./types` resolves to it.
 
-**Verify**: `grep -rn "from './types'" src | wc -l` unchanged;
-`bun run typecheck` → exit 0; `bun test` → pass.
+**Verify**: `grep -rn "from './types'" packages/adapters/drizzle/src | wc -l`
+unchanged; `bun run typecheck` → exit 0;
+`cd packages/adapters/drizzle && bun test` → pass.
 
 ### Step 5: Confirm no public surface drift + ledger
 
@@ -145,8 +147,10 @@ Diff the package's built `.d.ts` public exports before/after (or check
 `src/index.ts`'s re-exports are unchanged). Confirm `git diff` shows only
 moves, no logic edits. Update the plan 044 row.
 
-**Verify**: `bun run build` exit 0; the package's public export list is
-unchanged (grep `src/index.ts`); full drizzle SQLite suite green.
+**Verify**: `cd packages/adapters/drizzle && bun run build` exit 0; the
+package's public export list is unchanged
+(`grep` `packages/adapters/drizzle/src/index.ts`); full drizzle SQLite suite
+green (`cd packages/adapters/drizzle && bun test`).
 
 ## Test plan
 
@@ -158,9 +162,9 @@ unchanged (grep `src/index.ts`); full drizzle SQLite suite green.
 ## Done criteria
 
 - [ ] `adapter-cache.ts`, `export-format.ts`, `adapter-meta.ts` exist; `drizzle-adapter.ts` line count dropped ~350
-- [ ] `src/types/` split exists; `types.ts`/`types/index.ts` re-exports all; `grep -rn "from './types'" src | wc -l` unchanged
+- [ ] `src/types/` split exists; `types.ts`/`types/index.ts` re-exports all; `grep -rn "from './types'" packages/adapters/drizzle/src | wc -l` unchanged
 - [ ] `bun run typecheck` exit 0; `cd packages/adapters/drizzle && bun test` SQLite green
-- [ ] `bun run build` exit 0; public export list (`src/index.ts`) unchanged — NO changeset needed
+- [ ] `cd packages/adapters/drizzle && bun run build` exit 0; public export list (`packages/adapters/drizzle/src/index.ts`) unchanged — NO changeset needed
 - [ ] `git diff` shows moves, not logic changes
 - [ ] `plans/README.md` updated
 

--- a/plans/052-ci-toolchain-hygiene.md
+++ b/plans/052-ci-toolchain-hygiene.md
@@ -65,6 +65,7 @@ Verified at `787a816`:
 | Purpose | Command | Expected |
 |---|---|---|
 | Install | `bun install` | exit 0 |
+| Build | `bun run build` | exit 0 |
 | Biome check | `bunx biome check .` | errors → 0 by end |
 | Biome safe-fix | `bunx biome check --write .` (per package or root — see Step) | applies safe fixes |
 | Typecheck | `bun run typecheck` | exit 0 |
@@ -102,12 +103,13 @@ In `test.yml`, add `actions/cache` for `~/.bun/install/cache` keyed on
 `hashFiles('bun.lock')` in each job (or a composite/reusable setup step), and
 a Turbo cache (cache `.turbo` or use a remote-cacheless local `--cache-dir`
 persisted via `actions/cache`) so `typecheck`/`test` skip unchanged packages.
-Consider building core once and reusing it across `test-ui`/`test-adapters`
-via an artifact instead of rebuilding per job.
+Build `@better-tables/core` once and reuse it across `test-ui`/`test-adapters`
+(artifact or shared workspace build) so core is not rebuilt redundantly per job.
 
 **Verify**: workflow YAML is valid; a `git diff` review shows cache keys on
-`bun.lock`. (CI timing is verified on the first real run once the remote is
-restored — note this.)
+`bun.lock`; core is built once and shared (not rebuilt per dependent job).
+(CI timing is verified on the first real run once the remote is restored —
+note this.)
 
 ### Step 2: Align the bun pin
 


### PR DESCRIPTION
## Summary
- Follow-up to Wave A PR #83, which merged before Cubic finished reviewing.
- Addresses Cubic findings across core, marketing, drizzle, toolkit/UI, and plan docs:
  - **P1**: marketing facet allowlist for tickets adapter column ids
  - HTTP `authorize`/`constrain` errors routed through the JSON error contract
  - Facet limit validation + stable ties; schema cache copy; `maxSize: 0` no-cache
  - `prefersDateSemantics` tests, core type tests, toolkit cache tests
  - `EMPTY_FILTERS` freeze; plan doc path/cwd fixes
- **Do not merge until Cubic AI review completes.**

## Test plan
- [ ] CI green on this PR
- [ ] Cubic review finished (not in progress) with no outstanding valid issues
- [ ] Spot-check marketing tickets adapter allowlist behavior
- [ ] Confirm http-handler authorize/constrain error responses match JSON contract


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Follow-up to Wave A to address Cubic findings. Tightens adapter security and error handling, hardens facet limits and caching, and stabilizes facet ordering across `@better-tables/core`, adapters, and the marketing app.

- **Bug Fixes**
  - Marketing tickets route: add a column-id allowlist and pin `primaryTable: 'tickets'`; disallowed columns return a 403 JSON error.
  - `@better-tables/core` HTTP handler: catch `authorize`/`constrainRequest` throws and return a 500 `server_error` JSON envelope; consistent error contract.
  - Drizzle adapter: facet `limit` now requires a positive integer; invalid values fall back to 100. Stabilize equal-count facet ordering with secondary `asc(value)`. `cache.maxSize <= 0` disables caching and clears entries. Schema column cache returns defensive copies.
  - Toolkit/UI: clear `DataTransformer` per-transform caches in `finally` (even on errors). Freeze shared empty defaults in `use-table-data` to prevent mutation.

- **Refactors**
  - Added tests for marketing users error shape, DataTransformer caches, facet limits/tie-ordering, `prefersDateSemantics`, and type coverage for `FacetQueryParams`/`MutationOptions`; removed a duplicate date-operator test.
  - Updated plan docs with correct paths/commands and cache/build guidance; minor toolkit test cleanup.

<sup>Written for commit a129a92dd348203a5c46189babd8b6ac4fc667f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Better-Tables/better-tables/pull/84?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

