### PR TITLE
fix(adapters): correct cross-table predicates, relation presence, and silent filter drops

### DIFF
--- a/.changeset/drizzle-factory-passthrough.md
+++ b/.changeset/drizzle-factory-passthrough.md
@@ -1,0 +1,16 @@
+---
+'@better-tables/adapters-drizzle': patch
+---
+
+`drizzleAdapter()` / `createDrizzleAdapter()` no longer silently drop `computedFields` and `hooks`
+
+`DrizzleAdapterFactoryOptions` had no `computedFields` or `hooks` fields, so
+both factory entry points ignored them without error — an adapter built with
+`drizzleAdapter(db, { computedFields })` had no computed fields at all, and the
+first filter on one failed with "Field … not found in primary table". Only the
+`new DrizzleAdapter({ … })` constructor honored them.
+
+Both options are now part of the factory surface (same shapes as
+`DrizzleAdapterConfig`, via the shared `ComputedFieldsConfig<TSchema>` type)
+and are forwarded to the constructor. Covered by end-to-end tests through
+`fetchData` for both factories.

--- a/.changeset/drizzle-relational-cross-table-predicates.md
+++ b/.changeset/drizzle-relational-cross-table-predicates.md
@@ -1,0 +1,22 @@
+---
+'@better-tables/adapters-drizzle': patch
+---
+
+Fix Postgres queries failing when a computed field's `filterSql` was applied
+
+Drizzle's relational query API (`db.query.<table>.findMany({ where })`) scopes
+predicates to the primary table, so a condition built on a related table's
+column is emitted against the wrong table — `profiles.github` becomes
+`"users"."github"` and the query fails at runtime. Filters and sorts naming a
+related column already fell back to manual joins; computed-field `filterSql`
+conditions did not.
+
+Those conditions reach the query builder as raw SQL in `additionalConditions`,
+never passing through `buildQueryContext`, so the existing guard could not see
+them — and the SQL is opaque, so there is no way to tell whether it references a
+joined table. Any `additionalConditions` now declines the relational path. This
+only affected PostgreSQL: MySQL and SQLite always use manual joins.
+
+Also moves the guard below the `db.query` capability check, so a database built
+without relations keeps its previous silent fallback instead of surfacing a
+`RelationshipError` from an unvalidated context.

--- a/.changeset/drizzle-relational-cross-table-predicates.md
+++ b/.changeset/drizzle-relational-cross-table-predicates.md
@@ -2,7 +2,7 @@
 '@better-tables/adapters-drizzle': patch
 ---
 
-Fix Postgres queries failing when a computed field's `filterSql` was applied
+Route computed-field `filterSql` off the Postgres relational query path
 
 Drizzle's relational query API (`db.query.<table>.findMany({ where })`) scopes
 predicates to the primary table, so a condition built on a related table's
@@ -16,6 +16,15 @@ never passing through `buildQueryContext`, so the existing guard could not see
 them — and the SQL is opaque, so there is no way to tell whether it references a
 joined table. Any `additionalConditions` now declines the relational path. This
 only affected PostgreSQL: MySQL and SQLite always use manual joins.
+
+Scope: this makes the manual-join path the one that runs, which is a
+prerequisite for a `filterSql` predicate to be emitted against the correct
+table. It does **not** make an arbitrary related-table reference work — opaque
+SQL contributes nothing to JOIN planning, so a bare `sql\`${profiles.github} is
+not null\`` still fails when nothing else pulls `profiles` into the query (it
+failed before this change too, just with a different error). `filterSql` must be
+self-contained: reference the primary table, or use a correlated subquery. The
+`filterSql` JSDoc now documents this with a working `EXISTS` example.
 
 Also moves the guard below the `db.query` capability check, so a database built
 without relations keeps its previous silent fallback instead of surfacing a

--- a/.changeset/drizzle-relational-cross-table-predicates.md
+++ b/.changeset/drizzle-relational-cross-table-predicates.md
@@ -2,30 +2,34 @@
 '@better-tables/adapters-drizzle': patch
 ---
 
-Route computed-field `filterSql` off the Postgres relational query path
+Make computed-field `filterSql`/`sortSql` work across related tables
 
-Drizzle's relational query API (`db.query.<table>.findMany({ where })`) scopes
-predicates to the primary table, so a condition built on a related table's
-column is emitted against the wrong table — `profiles.github` becomes
-`"users"."github"` and the query fails at runtime. Filters and sorts naming a
-related column already fell back to manual joins; computed-field `filterSql`
-conditions did not.
+Two layers were broken for a computed-field SQL fragment referencing a related
+table (e.g. `` sql`${profiles.github} is not null` `` on a `users` table):
 
-Those conditions reach the query builder as raw SQL in `additionalConditions`,
-never passing through `buildQueryContext`, so the existing guard could not see
-them — and the SQL is opaque, so there is no way to tell whether it references a
-joined table. Any `additionalConditions` now declines the relational path. This
-only affected PostgreSQL: MySQL and SQLite always use manual joins.
+1. **Postgres relational path.** Drizzle's `db.query.<table>.findMany({ where })`
+   scopes predicates to the primary table, so the condition was emitted against
+   the wrong table (`"users"."github"`). Opaque conditions now always decline
+   the relational path. Postgres-only; MySQL/SQLite always use manual joins.
+2. **Join planning.** On the manual-join path the fragment's text is opaque, so
+   no JOIN was planned for the tables it touches and the query failed with the
+   referenced table missing from FROM. The adapter now walks the fragment's
+   query chunks — the interpolated `Column`/`Table` entities survive — and
+   plans the same JOIN a regular cross-table filter gets, in the data, count,
+   and fan-out pagination queries alike.
 
-Scope: this makes the manual-join path the one that runs, which is a
-prerequisite for a `filterSql` predicate to be emitted against the correct
-table. It does **not** make an arbitrary related-table reference work — opaque
-SQL contributes nothing to JOIN planning, so a bare `sql\`${profiles.github} is
-not null\`` still fails when nothing else pulls `profiles` into the query (it
-failed before this change too, just with a different error). `filterSql` must be
-self-contained: reference the primary table, or use a correlated subquery. The
-`filterSql` JSDoc now documents this with a working `EXISTS` example.
+Rules: a table interpolated as a whole `Table` chunk (a correlated subquery
+like `` sql`exists (select 1 from ${profiles} where …)` ``) supplies its own
+FROM scope and is never force-joined; an already-joined relation is reused, not
+double-joined; a column reference to a table with no direct relationship throws
+a descriptive error instead of emitting broken SQL.
 
-Also moves the guard below the `db.query` capability check, so a database built
-without relations keeps its previous silent fallback instead of surfacing a
-`RelationshipError` from an unvalidated context.
+Also fixed on the sorting side: sorting by a `sortSql`-backed computed field
+that was not simultaneously requested as a column threw a `RelationshipError`
+from join-count metadata, and sorting by a computed field with no `sortSql`
+threw instead of degrading — it is now dropped with a `[better-tables]` warning
+(there is nothing to ORDER BY in SQL), matching the dropped-filter convention.
+
+All of it is covered end to end through `fetchData` by an ungated SQLite suite
+(`computed-field-cross-table-sql.test.ts`) and a Postgres integration mirror of
+the originally reported failure, each verified to fail without its fix.

--- a/.changeset/drizzle-relational-cross-table-predicates.md
+++ b/.changeset/drizzle-relational-cross-table-predicates.md
@@ -20,9 +20,11 @@ table (e.g. `` sql`${profiles.github} is not null` `` on a `users` table):
 
 Rules: a table interpolated as a whole `Table` chunk (a correlated subquery
 like `` sql`exists (select 1 from ${profiles} where …)` ``) supplies its own
-FROM scope and is never force-joined; an already-joined relation is reused, not
-double-joined; a column reference to a table with no direct relationship throws
-a descriptive error instead of emitting broken SQL.
+FROM scope and is never force-joined — tracked PER FRAGMENT, so one computed
+field's subquery cannot suppress the outer JOIN another field's bare reference
+needs; an already-joined relation is reused, not double-joined; a column
+reference to a table with no direct relationship throws a descriptive error
+instead of emitting broken SQL.
 
 Also fixed on the sorting side: sorting by a `sortSql`-backed computed field
 that was not simultaneously requested as a column threw a `RelationshipError`

--- a/.changeset/drizzle-warn-dropped-filters.md
+++ b/.changeset/drizzle-warn-dropped-filters.md
@@ -1,0 +1,22 @@
+---
+'@better-tables/adapters-drizzle': patch
+---
+
+Warn when a filter is dropped because its operator is invalid for its type
+
+A filter leaf whose operator is not valid for its declared type (an unknown
+operator, or one the adapter does not advertise for that type) is skipped so
+partial URL/UI filter state can still fetch. That drop was silent — and because
+dropping a leaf under implicit-AND *widens* the result set, a malformed filter
+returned the full table with no error and no warning. Measured against a live
+database: a filter with a mismatched type returned all 1,000,000 rows instead of
+the 49,937 matching ones.
+
+The fail-soft behavior is unchanged (dropping is deliberate — see plan 038), but
+these drops now emit a `[better-tables]` warning naming the column, operator and
+type. Warnings are value-free, matching the existing `normalizeFilterNode` and
+`deserializeFiltersFromURL` convention.
+
+Genuinely incomplete values on a supported operator — a user who picked a column
+but has not finished typing — remain silent, since warning there would fire on
+every keystroke.

--- a/.changeset/toolkit-relation-presence.md
+++ b/.changeset/toolkit-relation-presence.md
@@ -1,0 +1,22 @@
+---
+'@better-tables/adapters-toolkit': patch
+---
+
+Fix related columns silently rendering blank when a nullable relation column was requested first
+
+`DataTransformer` decided whether a one-to-one related row existed by testing a
+single column — whichever related column the caller happened to list first.
+When that column was `NULL` for a row, the entire related object was replaced
+with `null`, so every other related column rendered blank even though the JOIN
+had returned data for them.
+
+Requesting `['profile.github', 'profile.location', 'profile.bio']` against real
+data lost the whole profile on ~half the page (rows where `github` was NULL),
+while the identical query with `profile.id` listed first returned everything.
+Callers were only safe by accident, depending on column order.
+
+Presence is now derived from the related table's primary key — the same signal
+`processOneToManyColumn` already used — falling back to "any requested related
+column carries a value" when the PK was not selected. Results no longer depend
+on the order columns are requested in. One-to-many relations were never
+affected.

--- a/packages/adapters/drizzle/src/drizzle-adapter.ts
+++ b/packages/adapters/drizzle/src/drizzle-adapter.ts
@@ -672,13 +672,29 @@ export class DrizzleAdapter<TSchema extends Record<string, unknown>, TDriver ext
         }
       }
 
+      // A sort naming a registered computed field WITHOUT sortSql has nothing
+      // to ORDER BY in SQL, and must not leak into join planning as if it were
+      // a relational column path (resolveColumnPath would throw on it). Drop
+      // it loudly — value-free, mirroring the dropped-filter warning.
+      const sortingForQuery = (params.sorting || []).filter((sort) => {
+        const computedField = tableComputedFields.find((cf) => cf.field === sort.columnId);
+        if (computedField && !computedField.sortSql) {
+          // biome-ignore lint/suspicious/noConsole: intentional warning for a dropped computed-field sort
+          console.warn(
+            `[better-tables] Dropped sort on computed field "${sort.columnId}": it has no sortSql, so it cannot be sorted in SQL. Provide sortSql on the computed field to make it sortable.`
+          );
+          return false;
+        }
+        return true;
+      });
+
       // Build queries - pass primaryTable to query builder
       // Include columns that computed fields require (e.g., roles column for enum array filtering)
       // Pass additional SQL conditions from computed field filterSql (applied before pagination)
       const queryParams: Parameters<typeof this.queryBuilder.buildCompleteQuery>[0] = {
         columns: finalColumns,
         filters: processedFilters,
-        sorting: params.sorting || [],
+        sorting: sortingForQuery,
         pagination: params.pagination || { page: 1, limit: 10 },
         primaryTable,
       };
@@ -1528,8 +1544,15 @@ export class DrizzleAdapter<TSchema extends Record<string, unknown>, TDriver ext
     const primaryTable = this.resolvePrimaryTableForRead(params.columns, params.primaryTable);
 
     // Filter out computed fields from columns and sorts before building query context
-    // Computed fields are handled separately and shouldn't be resolved as column paths
-    const computedFieldNames = params.computedFields || [];
+    // Computed fields are handled separately and shouldn't be resolved as column paths.
+    // Union the REGISTERED fields with the requested list: `params.computedFields`
+    // only names fields requested via `columns`, so a sort-only computed field
+    // (e.g. sortSql-backed sorting with the field not displayed) would otherwise
+    // leak into resolveColumnPath here and throw on a perfectly valid fetch.
+    const registeredComputedFields = (this.computedFields[primaryTable] || []).map(
+      (field) => field.field
+    );
+    const computedFieldNames = [...(params.computedFields || []), ...registeredComputedFields];
     const columnsForContext = (params.columns || []).filter(
       (col) => !computedFieldNames.includes(col)
     );

--- a/packages/adapters/drizzle/src/factory.ts
+++ b/packages/adapters/drizzle/src/factory.ts
@@ -166,11 +166,19 @@ export function drizzleAdapter<TDB>(
     ? { ...configWithRelations, relationships: factoryOptions.relationships }
     : configWithRelations;
 
+  // Passthrough parity with the DrizzleAdapter constructor: these used to be
+  // silently dropped, so `drizzleAdapter(db, { computedFields })` produced an
+  // adapter with no computed fields and no error.
+  const configWithComputedFields = factoryOptions?.computedFields
+    ? { ...configWithRelationships, computedFields: factoryOptions.computedFields }
+    : configWithRelationships;
+
+  const finalConfig = factoryOptions?.hooks
+    ? { ...configWithComputedFields, hooks: factoryOptions.hooks }
+    : configWithComputedFields;
+
   return new DrizzleAdapter<ExtractSchemaFromDB<TDB>, ExtractDriverFromDB<TDB>>(
-    configWithRelationships as DrizzleAdapterConfig<
-      ExtractSchemaFromDB<TDB>,
-      ExtractDriverFromDB<TDB>
-    >
+    finalConfig as DrizzleAdapterConfig<ExtractSchemaFromDB<TDB>, ExtractDriverFromDB<TDB>>
   );
 }
 
@@ -236,8 +244,17 @@ export function createDrizzleAdapter<
     ? { ...configWithRelations, relationships: factoryOptions.relationships }
     : configWithRelations;
 
+  // Passthrough parity with the DrizzleAdapter constructor (see drizzleAdapter).
+  const configWithComputedFields = factoryOptions.computedFields
+    ? { ...configWithRelationships, computedFields: factoryOptions.computedFields }
+    : configWithRelationships;
+
+  const finalConfig = factoryOptions.hooks
+    ? { ...configWithComputedFields, hooks: factoryOptions.hooks }
+    : configWithComputedFields;
+
   // Complex generic inference requires boundary assertion
   return new DrizzleAdapter<FilterTablesFromSchema<TSchema>, TDriver>(
-    configWithRelationships as DrizzleAdapterConfig<FilterTablesFromSchema<TSchema>, TDriver>
+    finalConfig as DrizzleAdapterConfig<FilterTablesFromSchema<TSchema>, TDriver>
   );
 }

--- a/packages/adapters/drizzle/src/filter-handler.ts
+++ b/packages/adapters/drizzle/src/filter-handler.ts
@@ -325,9 +325,18 @@ export class FilterHandler {
    * this from {@link handleCrossTableFilters}'s loop body so both the flat
    * path and {@link buildTreeCondition}'s recursive walk share one leaf
    * contract). Returns `undefined` to mean "skip this leaf" — either because
-   * core/adapter validation rejects it (silently, to tolerate partial filter
-   * states from the UI) or because {@link buildFilterCondition} itself found
-   * no condition to build (e.g. empty values).
+   * core/adapter validation rejects it or because {@link buildFilterCondition}
+   * itself found no condition to build (e.g. empty values).
+   *
+   * Two distinct reasons a leaf is skipped, deliberately treated differently:
+   *
+   * - **Incomplete values** for an operator this adapter DOES support (the user
+   *   picked a column but has not finished typing). Skipped silently — this is
+   *   normal mid-edit UI state and warning on it would fire on every keystroke.
+   * - **An operator that is not valid for the filter's type.** Also skipped
+   *   (plan 038 keeps partial URL/UI state fetchable) but WARNS, because
+   *   dropping a leaf widens the result set: under implicit-AND the query then
+   *   returns more rows than the caller asked for.
    *
    * @throws {Error} Wraps any resolution/build error with the offending
    *   `columnId`, surfacing it instead of silently swallowing it.
@@ -373,12 +382,24 @@ export class FilterHandler {
             // Skip invalid filters silently - this allows for partial filter states in UI
             return undefined;
           }
-        } else if (typeof validationResult === 'string') {
-          // Operator is not supported by adapter or validation failed
-          // We skip these silently to allow for partial states
-          return undefined;
         } else {
-          // Skip invalid filters silently for value validation errors
+          // The operator is not valid for this filter's type (unknown operator,
+          // or one this adapter does not advertise for the type).
+          //
+          // This is NOT a partial UI state -- it is a malformed filter, and
+          // dropping it WIDENS the result set: under implicit-AND a dropped
+          // leaf returns MORE rows than asked for, so a scoping filter that is
+          // silently discarded reads as "no restriction". Dropping stays the
+          // behavior (plan 038: partial URL/UI filter state must still fetch),
+          // but it must never be silent.
+          //
+          // Value-free by convention -- never log `filter.values`, matching
+          // `normalizeFilterNode` / `deserializeFiltersFromURL`.
+          // biome-ignore lint/suspicious/noConsole: intentional warning for a dropped filter that widens results
+          console.warn(
+            `[better-tables] Dropped filter on "${filter.columnId}": operator "${filter.operator}" is not valid for type "${filter.type ?? 'unknown'}". ` +
+              'The query will run WITHOUT this filter and may return more rows than intended.'
+          );
           return undefined;
         }
       }

--- a/packages/adapters/drizzle/src/query-builders/base-query-builder.ts
+++ b/packages/adapters/drizzle/src/query-builders/base-query-builder.ts
@@ -1260,8 +1260,21 @@ export abstract class BaseQueryBuilder {
       return;
     }
 
-    const refs = collectSqlTableRefs(fragments);
-    if (refs.columnTableNames.size === 0) {
+    // FROM scope is tracked PER FRAGMENT, not across the batch: one computed
+    // field's correlated subquery (`exists (select 1 from ${profiles} …)`)
+    // must not suppress the outer JOIN that a DIFFERENT field's bare column
+    // reference (`${profiles.bio} is not null`) still needs. A table is
+    // join-exempt only for the fragment that interpolated it as a Table chunk.
+    const tablesNeedingJoin = new Set<string>();
+    for (const fragment of fragments) {
+      const refs = collectSqlTableRefs([fragment]);
+      for (const sqlName of refs.columnTableNames) {
+        if (!refs.fromTableNames.has(sqlName)) {
+          tablesNeedingJoin.add(sqlName);
+        }
+      }
+    }
+    if (tablesNeedingJoin.size === 0) {
       return;
     }
 
@@ -1274,11 +1287,7 @@ export abstract class BaseQueryBuilder {
 
     const relationships = this.relationshipManager.getRelationships();
 
-    for (const sqlName of refs.columnTableNames) {
-      if (refs.fromTableNames.has(sqlName)) {
-        continue; // Correlated subquery brings its own FROM scope.
-      }
-
+    for (const sqlName of tablesNeedingJoin) {
       const schemaKey = schemaKeyBySqlName.get(sqlName);
       if (schemaKey === primaryTable) {
         continue;

--- a/packages/adapters/drizzle/src/query-builders/base-query-builder.ts
+++ b/packages/adapters/drizzle/src/query-builders/base-query-builder.ts
@@ -353,12 +353,18 @@ export abstract class BaseQueryBuilder {
    * first attempt Drizzle's relational query API (nested results) and falls
    * back to this manual-join skeleton; JSON-accessor handling is injected
    * through each dialect's `buildColumnSelections` override.
+   *
+   * `additionalConditions` is unused here (the manual-join skeleton binds them
+   * later, in `applyFilters`) but is part of the signature so the PostgreSQL
+   * override can see opaque SQL predicates it cannot introspect and decline the
+   * relational path -- see `PostgresQueryBuilder.hasCrossTablePredicates`.
    */
   buildSelectQuery(
     context: QueryContext,
     primaryTable: string,
     columns?: string[],
-    computedFields?: Record<string, ComputedFieldWithResolvedSortSql>
+    computedFields?: Record<string, ComputedFieldWithResolvedSortSql>,
+    _additionalConditions?: (SQL | SQLWrapper)[]
   ): {
     query: QueryBuilderWithJoins;
     columnMetadata: {
@@ -937,7 +943,8 @@ export abstract class BaseQueryBuilder {
         context,
         primaryTable,
         columns,
-        computedFields
+        computedFields,
+        additionalConditions
       );
       const primaryKeyInCondition = inArray(primaryKeyInfo.column, keys);
       let phase2Query = this.applyFilters(phase2SelectResult.query, filters, primaryTable, [
@@ -1275,7 +1282,8 @@ export abstract class BaseQueryBuilder {
       context,
       params.primaryTable,
       columnsForSelect,
-      params.computedFields
+      params.computedFields,
+      params.additionalConditions
     );
     const { columnMetadata, isNested } = selectResult;
 

--- a/packages/adapters/drizzle/src/query-builders/base-query-builder.ts
+++ b/packages/adapters/drizzle/src/query-builders/base-query-builder.ts
@@ -31,6 +31,7 @@ import {
   countDistinct,
   desc,
   eq,
+  getTableName,
   inArray,
   isNotNull,
   max,
@@ -62,6 +63,7 @@ import {
   getForeignKeyColumns,
   getPrimaryKeyColumns,
 } from '../utils/drizzle-schema-utils';
+import { collectSqlTableRefs } from '../utils/sql-table-refs';
 
 /**
  * Minimal structural view of a Drizzle database's `select().from()` entry
@@ -1217,6 +1219,119 @@ export abstract class BaseQueryBuilder {
   }
 
   /**
+   * Plan JOINs for tables referenced inside opaque SQL predicates.
+   *
+   * Computed-field `filterSql` conditions (delivered via
+   * `additionalConditions`) and pre-resolved `sortSql` expressions never pass
+   * through `buildQueryContext` — they are raw `SQL` fragments. Their text is
+   * opaque, but the `Column`/`Table` entities interpolated into them survive
+   * as typed query chunks, so the tables they touch are recoverable. Without
+   * this, a predicate referencing a related table is emitted against a FROM
+   * clause that never joined it, and the query fails at the database.
+   *
+   * Rules, in order:
+   * - A table interpolated as a whole `Table` chunk supplies its own FROM
+   *   scope (a correlated subquery) — never force-join it; a LEFT JOIN on a
+   *   one-to-many relation would multiply rows the subquery never asked for.
+   * - A table referenced only through `Column` chunks binds to the outer
+   *   query, so it must be joined. The joinPaths entry is keyed by the
+   *   relation ALIAS (found by scanning the relationship map for a direct
+   *   relationship targeting that table), which keeps every downstream
+   *   consumer — `optimizeJoinOrder`, `computeAutoEmbedColumns`, the
+   *   transform — on the exact code path a regular cross-table filter uses.
+   * - A referenced table that is already joined (any planned path targets
+   *   it) is skipped, so this never double-joins.
+   * - A referenced table with no direct relationship cannot be joined
+   *   predictably: fail fast with guidance instead of emitting broken SQL.
+   */
+  protected planJoinsForOpaqueSqlConditions(
+    context: QueryContext,
+    primaryTable: string,
+    additionalConditions?: (SQL | SQLWrapper)[],
+    computedFields?: Record<string, ComputedFieldWithResolvedSortSql>
+  ): void {
+    const fragments: unknown[] = [...(additionalConditions ?? [])];
+    if (computedFields) {
+      for (const field of Object.values(computedFields)) {
+        fragments.push(field.__resolvedSortSql);
+      }
+    }
+    if (fragments.length === 0) {
+      return;
+    }
+
+    const refs = collectSqlTableRefs(fragments);
+    if (refs.columnTableNames.size === 0) {
+      return;
+    }
+
+    // SQL table name -> schema key (they can differ, e.g. a table declared
+    // as pgTable('user_profiles', …) living under the schema key `profiles`).
+    const schemaKeyBySqlName = new Map<string, string>();
+    for (const [key, table] of Object.entries(this.schema)) {
+      schemaKeyBySqlName.set(getTableName(table), key);
+    }
+
+    const relationships = this.relationshipManager.getRelationships();
+
+    for (const sqlName of refs.columnTableNames) {
+      if (refs.fromTableNames.has(sqlName)) {
+        continue; // Correlated subquery brings its own FROM scope.
+      }
+
+      const schemaKey = schemaKeyBySqlName.get(sqlName);
+      if (schemaKey === primaryTable) {
+        continue;
+      }
+      if (!schemaKey) {
+        throw new QueryError(
+          `Computed-field SQL references table "${sqlName}", which is not part of this adapter's schema. ` +
+            'Add the table to the schema, or scope the reference inside a correlated subquery ' +
+            '(e.g. EXISTS (SELECT 1 FROM <table> WHERE …)) so it does not depend on the outer query.',
+          { referencedTable: sqlName, primaryTable }
+        );
+      }
+
+      const alreadyJoined = [...context.joinPaths.values()].some((path) =>
+        path.some((relationship) => relationship.to === schemaKey)
+      );
+      if (alreadyJoined) {
+        continue;
+      }
+
+      // Find the direct relationship's alias so the joinPaths key matches
+      // what a regular `alias.column` filter would have produced.
+      let alias: string | null = null;
+      let relationshipPath: RelationshipPath | null = null;
+      const prefix = `${primaryTable}.`;
+      for (const [key, relationship] of Object.entries(relationships)) {
+        if (
+          key.startsWith(prefix) &&
+          relationship.from === primaryTable &&
+          relationship.to === schemaKey
+        ) {
+          alias = key.slice(prefix.length);
+          relationshipPath = relationship;
+          break;
+        }
+      }
+
+      if (!alias || !relationshipPath) {
+        throw new QueryError(
+          `Computed-field SQL references table "${sqlName}", but no direct relationship from ` +
+            `"${primaryTable}" to it is defined, so the JOIN cannot be planned. ` +
+            'Define the relationship (Drizzle relations / manual relationships), or scope the reference ' +
+            'inside a correlated subquery (e.g. EXISTS (SELECT 1 FROM <table> WHERE …)).',
+          { referencedTable: sqlName, primaryTable }
+        );
+      }
+
+      context.requiredTables.add(alias);
+      context.joinPaths.set(alias, [relationshipPath]);
+    }
+  }
+
+  /**
    * Build complete query with all parameters
    */
   buildCompleteQuery(params: {
@@ -1265,6 +1380,18 @@ export abstract class BaseQueryBuilder {
         sorts: sortsForContext,
       },
       params.primaryTable
+    );
+
+    // Opaque computed-field SQL (filterSql via additionalConditions, resolved
+    // sortSql) is invisible to buildQueryContext — recover its table
+    // references from the SQL chunks and plan the same JOINs a regular
+    // cross-table filter would get, so the data, count, and fan-out queries
+    // all carry the table the predicate binds to.
+    this.planJoinsForOpaqueSqlConditions(
+      context,
+      params.primaryTable,
+      params.additionalConditions,
+      params.computedFields
     );
 
     // Auto-embed (finding 10): fold in synthetic columns for any relation

--- a/packages/adapters/drizzle/src/query-builders/postgres-query-builder.ts
+++ b/packages/adapters/drizzle/src/query-builders/postgres-query-builder.ts
@@ -213,13 +213,58 @@ export class PostgresQueryBuilder extends BaseQueryBuilder {
   }
 
   /**
+   * True when a WHERE/ORDER BY predicate cannot be scoped to the primary table.
+   *
+   * Drizzle's relational `findMany({ where })` only scopes predicates to the
+   * primary table — a condition built on `profiles.github` is rewritten as
+   * `"users"."github"`, which fails at runtime. Manual joins apply the same
+   * SQL against the joined alias correctly.
+   *
+   * Two sources of such predicates:
+   *
+   * 1. Filters/sorts naming a related column, visible via `context`.
+   * 2. `additionalConditions` — raw SQL from a computed field's `filterSql`
+   *    (`DrizzleAdapter.fetchData`). These never pass through
+   *    `buildQueryContext`, so `context` cannot see them, and the SQL is opaque:
+   *    there is no way to tell whether it references a joined table. Treat ANY
+   *    such condition as cross-table. Joins are also no-ops on the relational
+   *    path, so a `filterSql` naming a joined table would have nothing to bind
+   *    to even if the rewrite were correct.
+   */
+  private hasCrossTablePredicates(
+    context: QueryContext | undefined,
+    primaryTable: string,
+    additionalConditions?: (SQL | SQLWrapper)[]
+  ): boolean {
+    // Opaque SQL — cannot be introspected, so never risk the relational path.
+    if (additionalConditions && additionalConditions.length > 0) {
+      return true;
+    }
+
+    if (!context) return false;
+
+    for (const columnId of context.filters) {
+      if (this.relationshipManager.resolveColumnPath(columnId, primaryTable).isNested) {
+        return true;
+      }
+    }
+    for (const columnId of context.sorts) {
+      if (this.relationshipManager.resolveColumnPath(columnId, primaryTable).isNested) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
    * Build relational query using Drizzle's relational query API
    * This returns nested objects instead of flattened fields
    */
   private buildRelationalQuery(
     primaryTable: string,
     columns?: string[],
-    context?: QueryContext
+    context?: QueryContext,
+    additionalConditions?: (SQL | SQLWrapper)[]
   ): {
     query: PostgresQueryBuilderWithJoins;
     columnMetadata: {
@@ -228,10 +273,20 @@ export class PostgresQueryBuilder extends BaseQueryBuilder {
     };
     isNested: boolean; // Flag to indicate data is already nested
   } | null {
-    // Check if db.query is available (requires schema with relations passed to drizzle())
+    // Capability check first (requires schema with relations passed to drizzle()).
+    // This must precede the cross-table guard: on a db built without relations
+    // there is no relational path to decline, and `resolveColumnPath` can throw
+    // for an unvalidated context — which would turn a previously-silent fallback
+    // into an exception for external callers of this public builder.
     const dbWithQuery = this.db as unknown as { query?: Record<string, unknown> };
     if (!dbWithQuery.query || !dbWithQuery.query[primaryTable]) {
       return null; // Relational query API not available, fall back to manual joins
+    }
+
+    // Related-table WHERE/ORDER BY cannot ride on the relational API (see
+    // hasCrossTablePredicates). Selecting nested columns alone is fine.
+    if (this.hasCrossTablePredicates(context, primaryTable, additionalConditions)) {
+      return null;
     }
 
     const tableQuery = dbWithQuery.query[primaryTable] as {
@@ -425,7 +480,8 @@ export class PostgresQueryBuilder extends BaseQueryBuilder {
     context: QueryContext,
     primaryTable: string,
     columns?: string[],
-    computedFields?: Record<string, ComputedFieldWithResolvedSortSql>
+    computedFields?: Record<string, ComputedFieldWithResolvedSortSql>,
+    additionalConditions?: (SQL | SQLWrapper)[]
   ): ReturnType<BaseQueryBuilder['buildSelectQuery']> {
     const primaryTableSchema = this.schema[primaryTable];
     if (!primaryTableSchema) {
@@ -443,7 +499,7 @@ export class PostgresQueryBuilder extends BaseQueryBuilder {
     // But skip if we have computed fields that need SQL expressions
     const relationalQuery = hasComputedFieldsForSorting
       ? null
-      : this.buildRelationalQuery(primaryTable, columns, context);
+      : this.buildRelationalQuery(primaryTable, columns, context, additionalConditions);
     if (relationalQuery) {
       return {
         query: relationalQuery.query,

--- a/packages/adapters/drizzle/src/types/computed-fields.ts
+++ b/packages/adapters/drizzle/src/types/computed-fields.ts
@@ -78,6 +78,34 @@ export interface ComputedFieldConfig<TData = Record<string, unknown>> {
    *
    * If both `filter` and `filterSql` are provided, `filterSql` takes precedence.
    *
+   * ## The returned SQL must be self-contained
+   *
+   * The condition is applied as an opaque predicate: the query planner cannot
+   * introspect it, so it does NOT contribute to JOIN planning. Referencing a
+   * related table's column directly produces SQL whose `FROM` clause lacks that
+   * table, and the query fails:
+   *
+   * ```typescript
+   * // BROKEN -- `profiles` is never joined, so this emits
+   * // `select … from "users" where "profiles"."github" is not null`
+   * filterSql: () => sql`${profiles.github} is not null`
+   * ```
+   *
+   * Reference only the primary table, or pull the related table into the
+   * condition's own scope with a correlated subquery:
+   *
+   * ```typescript
+   * // WORKS -- `profiles` lives in the subquery's own FROM clause
+   * filterSql: () => sql`exists (
+   *   select 1 from ${profiles}
+   *   where ${profiles.userId} = ${users.id} and ${profiles.github} is not null
+   * )`
+   * ```
+   *
+   * (Filtering by a plain relation path -- `profile.github` -- needs none of
+   * this; the adapter plans that JOIN itself. `filterSql` is for expressions
+   * the column layer cannot express.)
+   *
    * @example
    * ```typescript
    * filterSql: async (filter, context) => {

--- a/packages/adapters/drizzle/src/types/computed-fields.ts
+++ b/packages/adapters/drizzle/src/types/computed-fields.ts
@@ -78,33 +78,38 @@ export interface ComputedFieldConfig<TData = Record<string, unknown>> {
    *
    * If both `filter` and `filterSql` are provided, `filterSql` takes precedence.
    *
-   * ## The returned SQL must be self-contained
+   * ## Referencing related tables
    *
-   * The condition is applied as an opaque predicate: the query planner cannot
-   * introspect it, so it does NOT contribute to JOIN planning. Referencing a
-   * related table's column directly produces SQL whose `FROM` clause lacks that
-   * table, and the query fails:
+   * The SQL text is opaque, but the `Column`/`Table` entities interpolated
+   * into it are not — the adapter walks the fragment's query chunks and plans
+   * JOINs for what it finds, so a related-column reference works like any
+   * other cross-table filter:
    *
    * ```typescript
-   * // BROKEN -- `profiles` is never joined, so this emits
-   * // `select … from "users" where "profiles"."github" is not null`
+   * // `profiles` has a direct relationship to the primary table: the adapter
+   * // LEFT JOINs it automatically, in the data, count, and fan-out queries.
    * filterSql: () => sql`${profiles.github} is not null`
    * ```
    *
-   * Reference only the primary table, or pull the related table into the
-   * condition's own scope with a correlated subquery:
+   * A correlated subquery also works — interpolating the table itself
+   * (`${profiles}`) marks the fragment as supplying its own FROM scope, so no
+   * outer JOIN is added (important for one-to-many relations, where a forced
+   * LEFT JOIN would multiply rows the subquery never asked for):
    *
    * ```typescript
-   * // WORKS -- `profiles` lives in the subquery's own FROM clause
    * filterSql: () => sql`exists (
    *   select 1 from ${profiles}
    *   where ${profiles.userId} = ${users.id} and ${profiles.github} is not null
    * )`
    * ```
    *
-   * (Filtering by a plain relation path -- `profile.github` -- needs none of
-   * this; the adapter plans that JOIN itself. `filterSql` is for expressions
-   * the column layer cannot express.)
+   * Two constraints remain: only interpolated Drizzle entities are visible
+   * (a table named via a raw string contributes nothing to join planning),
+   * and a column reference to a table with no DIRECT relationship to the
+   * primary table throws a descriptive error — use a correlated subquery
+   * there. (Filtering by a plain relation path — `profile.github` — needs
+   * none of this; `filterSql` is for expressions the column layer cannot
+   * express.)
    *
    * @example
    * ```typescript

--- a/packages/adapters/drizzle/src/types/operations.ts
+++ b/packages/adapters/drizzle/src/types/operations.ts
@@ -167,6 +167,21 @@ export interface SQLiteQueryBuilderWithJoins extends QueryBuilderWithJoins {
   groupBy(...columns: (AnyColumnType | SQL | SQLWrapper)[]): SQLiteQueryBuilderWithJoins;
 }
 
+/**
+ * Computed/virtual field configurations keyed by table.
+ *
+ * Shared between {@link DrizzleAdapterConfig} (the `new DrizzleAdapter(...)`
+ * constructor) and {@link DrizzleAdapterFactoryOptions} (the `drizzleAdapter()`
+ * factory) so both entry points accept the identical shape.
+ */
+export type ComputedFieldsConfig<TSchema> = {
+  [K in keyof FilterTablesFromSchema<TSchema>]?: K extends string
+    ? FilterTablesFromSchema<TSchema>[K] extends AnyTableType
+      ? ComputedFieldConfig<InferSelectModel<FilterTablesFromSchema<TSchema>[K]>>[]
+      : never
+    : never;
+};
+
 export interface DrizzleAdapterConfig<
   TSchema extends Record<string, unknown>,
   TDriver extends DatabaseDriver,
@@ -190,13 +205,7 @@ export interface DrizzleAdapterConfig<
   relationships?: RelationshipMap;
 
   /** Computed/virtual fields that don't exist in the database schema */
-  computedFields?: {
-    [K in keyof FilterTablesFromSchema<TSchema>]?: K extends string
-      ? FilterTablesFromSchema<TSchema>[K] extends AnyTableType
-        ? ComputedFieldConfig<InferSelectModel<FilterTablesFromSchema<TSchema>[K]>>[]
-        : never
-      : never;
-  };
+  computedFields?: ComputedFieldsConfig<TSchema>;
 
   /** Adapter options */
   options?: DrizzleAdapterOptions;
@@ -331,8 +340,21 @@ export interface DrizzleAdapterFactoryOptions<
   /** Whether to auto-detect relationships (default: true) */
   autoDetectRelationships?: boolean;
 
+  /**
+   * Computed/virtual fields that don't exist in the database schema.
+   * Same shape as {@link DrizzleAdapterConfig.computedFields} — the factory
+   * used to silently drop this, forcing consumers onto the class constructor.
+   */
+  computedFields?: ComputedFieldsConfig<TSchema>;
+
   /** Adapter options */
   options?: DrizzleAdapterOptions;
+
+  /**
+   * Filter handler hooks for customizing filter behavior.
+   * Same as {@link DrizzleAdapterConfig.hooks} — previously factory-dropped.
+   */
+  hooks?: FilterHandlerHooks;
 
   /** Adapter metadata */
   meta?: Partial<AdapterMeta>;

--- a/packages/adapters/drizzle/src/utils/sql-table-refs.ts
+++ b/packages/adapters/drizzle/src/utils/sql-table-refs.ts
@@ -79,6 +79,12 @@ function walk(node: unknown, refs: SqlTableRefs, depth: number): void {
  * so a fragment written entirely with raw identifier strings contributes
  * nothing (and correctly so: nothing in it can bind to Drizzle's join
  * planner either).
+ *
+ * Scope semantics are PER CALL: `fromTableNames` marks a table as
+ * self-scoped for everything passed in this invocation. Callers deciding
+ * join exemption per fragment (join planning does — one fragment's
+ * correlated subquery must not exempt another fragment's bare column
+ * reference) must call this once per fragment rather than batching.
  */
 export function collectSqlTableRefs(nodes: readonly unknown[]): SqlTableRefs {
   const refs: SqlTableRefs = {

--- a/packages/adapters/drizzle/src/utils/sql-table-refs.ts
+++ b/packages/adapters/drizzle/src/utils/sql-table-refs.ts
@@ -1,0 +1,94 @@
+/**
+ * @fileoverview Table-reference extraction from opaque Drizzle SQL fragments
+ * @module @better-tables/drizzle-adapter/utils/sql-table-refs
+ *
+ * @description
+ * Computed-field `filterSql`/`sortSql` hand the adapter raw `SQL` fragments.
+ * Their text is opaque, but the fragments are built from template literals
+ * whose interpolations survive as typed query chunks — `Column` and `Table`
+ * instances are still individually addressable inside `SQL.queryChunks`.
+ * Walking the chunks recovers which tables a fragment touches, which is what
+ * lets join planning treat these predicates like any other cross-table filter
+ * instead of emitting SQL whose FROM clause is missing a table.
+ */
+
+import { Column, getTableName, is, SQL, Table } from 'drizzle-orm';
+
+/**
+ * Tables referenced by a set of SQL fragments, split by how they appear.
+ */
+export interface SqlTableRefs {
+  /**
+   * SQL table names referenced through interpolated `Column` chunks
+   * (e.g. `sql`${profiles.bio} is not null`` contributes `profiles`).
+   * These columns bind to the OUTER query scope, so their table must be
+   * present in the outer FROM/JOIN list.
+   */
+  columnTableNames: Set<string>;
+
+  /**
+   * SQL table names interpolated as whole `Table` chunks (e.g.
+   * `sql`exists (select 1 from ${profiles} where …)``). A table chunk means
+   * the fragment supplies its own FROM scope for that table — a correlated
+   * subquery — so the outer query must NOT be forced to join it (a LEFT JOIN
+   * on a one-to-many relation would multiply rows the subquery never asked
+   * for).
+   */
+  fromTableNames: Set<string>;
+}
+
+function walk(node: unknown, refs: SqlTableRefs, depth: number): void {
+  // Cycle/degenerate-input guard; real predicates are a handful of levels deep.
+  if (depth > 32 || node === null || node === undefined) {
+    return;
+  }
+
+  if (is(node, Column)) {
+    refs.columnTableNames.add(getTableName(node.table));
+    return;
+  }
+
+  if (is(node, Table)) {
+    refs.fromTableNames.add(getTableName(node));
+    return;
+  }
+
+  if (is(node, SQL.Aliased)) {
+    walk(node.sql, refs, depth + 1);
+    return;
+  }
+
+  if (is(node, SQL)) {
+    for (const chunk of node.queryChunks) {
+      walk(chunk, refs, depth + 1);
+    }
+    return;
+  }
+
+  // Any other SQLWrapper (subquery wrappers, views, …): unwrap via getSQL().
+  const wrapper = node as { getSQL?: () => unknown };
+  if (typeof wrapper.getSQL === 'function') {
+    walk(wrapper.getSQL(), refs, depth + 1);
+  }
+}
+
+/**
+ * Collect the tables referenced by a set of opaque SQL fragments.
+ *
+ * String content is never parsed — only interpolated Drizzle entities count,
+ * so a fragment written entirely with raw identifier strings contributes
+ * nothing (and correctly so: nothing in it can bind to Drizzle's join
+ * planner either).
+ */
+export function collectSqlTableRefs(nodes: readonly unknown[]): SqlTableRefs {
+  const refs: SqlTableRefs = {
+    columnTableNames: new Set(),
+    fromTableNames: new Set(),
+  };
+
+  for (const node of nodes) {
+    walk(node, refs, 0);
+  }
+
+  return refs;
+}

--- a/packages/adapters/drizzle/tests/adapter-postgres.test.ts
+++ b/packages/adapters/drizzle/tests/adapter-postgres.test.ts
@@ -1239,6 +1239,56 @@ describe.skipIf(!process.env.POSTGRES_TEST_URL)(
     // Consider adding a validation mode: strict for API calls, lenient for URL state.
     //
     // Related: packages/adapters/drizzle/src/filter-handler.ts:672-710 (commit 3f04f60)
+    describe('Computed-field filterSql with the relational query API available', () => {
+      it('filters on a related table end to end (the reported homepage failure)', async () => {
+        // The suite's shared db is created WITHOUT `{ schema }`, so `db.query`
+        // does not exist and Drizzle's relational path never runs. The
+        // reported production failure required it present: the relational
+        // path rewrote `profiles.bio` onto `users`. Reproduce that config —
+        // a relational db on the same connection — and verify the adapter
+        // declines the relational path AND plans the profiles JOIN for the
+        // opaque predicate.
+        const relationalDb = drizzlePostgres(client, {
+          schema: {
+            ...testSchema,
+            usersRelations: testRelations.users,
+            profilesRelations: testRelations.profiles,
+            postsRelations: testRelations.posts,
+            commentsRelations: testRelations.comments,
+          },
+        });
+
+        const relationalAdapter = new DrizzleAdapter<typeof testSchema, 'postgres'>({
+          db: relationalDb as unknown as DrizzleDatabase<'postgres'>,
+          schema: testSchema,
+          driver: 'postgres',
+          autoDetectRelationships: true,
+          relations: testRelations,
+          options: { defaultPrimaryTable: 'users' },
+          computedFields: {
+            users: [
+              {
+                field: 'hasBio',
+                compute: () => null,
+                filterSql: () => sql`${testSchema.profiles.bio} is not null`,
+              },
+            ],
+          },
+        });
+
+        const result = await relationalAdapter.fetchData({
+          columns: ['id', 'name'],
+          filters: [
+            { columnId: 'hasBio', type: 'text', operator: 'contains', values: ['x'] },
+          ] as unknown as FilterState[],
+        });
+
+        // Users 1 and 2 have profiles with a bio; user 3 has none.
+        expect(result.total).toBe(2);
+        expect(result.data).toHaveLength(2);
+      });
+    });
+
     describe.skip('Error Handling (mirror of the reconciled SQLite suite — unskip after verifying against a live DB; see plan 033)', () => {
       it('should handle invalid column references', async () => {
         await expect(

--- a/packages/adapters/drizzle/tests/adapter-postgres.test.ts
+++ b/packages/adapters/drizzle/tests/adapter-postgres.test.ts
@@ -1250,20 +1250,25 @@ describe.skipIf(!process.env.POSTGRES_TEST_URL)(
         ).rejects.toThrow();
       });
 
-      it('should handle invalid filter operators', async () => {
-        // adapter.fetchData throws a QueryError for unsupported operators
-        await expect(
-          adapter.fetchData({
-            filters: [
-              {
-                columnId: 'name',
-                type: 'text',
-                operator: 'invalidOp' as FilterOperator,
-                values: ['test'],
-              },
-            ] as unknown as FilterState[],
-          })
-        ).rejects.toThrow();
+      it('should fail-soft (not throw) for invalid filter operators', async () => {
+        // This expectation used to read `rejects.toThrow()`, contradicting both
+        // the ungated SQLite mirror ('should fail-soft for unsupported filter
+        // operators') and the sibling test above for text `notEquals`. It never
+        // ran (outer skipIf + this describe.skip), so the contradiction went
+        // unnoticed. An unsupported operator is DROPPED, not thrown -- see
+        // filter-handler.buildLeafCondition. The drop now warns, because
+        // dropping a leaf widens the result set.
+        const result = await adapter.fetchData({
+          filters: [
+            {
+              columnId: 'name',
+              type: 'text',
+              operator: 'invalidOp' as FilterOperator,
+              values: ['test'],
+            },
+          ] as unknown as FilterState[],
+        });
+        expect(Array.isArray(result.data)).toBe(true);
       });
 
       it('should throw error for invalid filter values', async () => {

--- a/packages/adapters/drizzle/tests/adapter-postgres.test.ts
+++ b/packages/adapters/drizzle/tests/adapter-postgres.test.ts
@@ -1258,6 +1258,12 @@ describe.skipIf(!process.env.POSTGRES_TEST_URL)(
         // unnoticed. An unsupported operator is DROPPED, not thrown -- see
         // filter-handler.buildLeafCondition. The drop now warns, because
         // dropping a leaf widens the result set.
+        // Compare against the UNFILTERED baseline. Asserting only that rows came
+        // back would also pass if the operator had been translated into some
+        // narrower filter -- the assertion has to pin that the leaf was dropped
+        // entirely, which is precisely the widening that makes the drop worth
+        // warning about.
+        const baseline = await adapter.fetchData({ filters: [] });
         const result = await adapter.fetchData({
           filters: [
             {
@@ -1268,7 +1274,9 @@ describe.skipIf(!process.env.POSTGRES_TEST_URL)(
             },
           ] as unknown as FilterState[],
         });
-        expect(Array.isArray(result.data)).toBe(true);
+
+        expect(result.total).toBe(baseline.total);
+        expect(result.data.length).toBe(baseline.data.length);
       });
 
       it('should throw error for invalid filter values', async () => {

--- a/packages/adapters/drizzle/tests/base-query-builder.test.ts
+++ b/packages/adapters/drizzle/tests/base-query-builder.test.ts
@@ -940,4 +940,113 @@ describe('BaseQueryBuilder', () => {
       }
     });
   });
+
+  describe('planJoinsForOpaqueSqlConditions (tests join planning for computed-field SQL)', () => {
+    // The method is protected; unit tests reach it via a structural cast. The
+    // same behavior is exercised end to end through fetchData in
+    // computed-field-cross-table-sql.test.ts — these tests pin the context
+    // mutation itself: which joinPaths entries appear, keyed by which alias.
+    type PlannerAccess = {
+      planJoinsForOpaqueSqlConditions: (
+        context: ReturnType<RelationshipManager['buildQueryContext']>,
+        primaryTable: string,
+        additionalConditions?: unknown[],
+        computedFields?: Record<string, unknown>
+      ) => void;
+    };
+
+    function freshContext() {
+      return relationshipManager.buildQueryContext({ columns: ['name'] }, 'users');
+    }
+
+    function plan(
+      context: ReturnType<RelationshipManager['buildQueryContext']>,
+      additionalConditions?: unknown[],
+      computedFields?: Record<string, unknown>
+    ) {
+      (queryBuilder as unknown as PlannerAccess).planJoinsForOpaqueSqlConditions(
+        context,
+        'users',
+        additionalConditions,
+        computedFields
+      );
+    }
+
+    it('adds a joinPaths entry, keyed by the relation ALIAS, for a bare column reference', () => {
+      const context = freshContext();
+      expect(context.joinPaths.size).toBe(0);
+
+      plan(context, [sql`${schema.profiles.bio} is not null`]);
+
+      // Keyed by the alias ('profile'), not the table name, so downstream
+      // consumers (optimizeJoinOrder, auto-embed) stay on the regular path.
+      expect(context.joinPaths.has('profile')).toBe(true);
+      expect(context.joinPaths.get('profile')?.[0]?.to).toBe('profiles');
+      expect(context.requiredTables.has('profile')).toBe(true);
+    });
+
+    it('does not add a join for a table the fragment interpolates as a Table chunk', () => {
+      const context = freshContext();
+
+      plan(context, [
+        sql`exists (select 1 from ${schema.profiles} where ${schema.profiles.userId} = ${schema.users.id})`,
+      ]);
+
+      expect(context.joinPaths.size).toBe(0);
+    });
+
+    it('tracks FROM-scope exemption PER FRAGMENT, not across the batch', () => {
+      const context = freshContext();
+
+      // Fragment A scopes profiles itself; fragment B references it bare.
+      // B still needs the outer JOIN — A's Table chunk must not exempt it.
+      plan(context, [
+        sql`exists (select 1 from ${schema.profiles} where ${schema.profiles.userId} = ${schema.users.id})`,
+        sql`${schema.profiles.bio} is not null`,
+      ]);
+
+      expect(context.joinPaths.has('profile')).toBe(true);
+    });
+
+    it('does not double-plan a relation the context already joins', () => {
+      const context = relationshipManager.buildQueryContext(
+        { columns: ['name', 'profile.bio'] },
+        'users'
+      );
+      const before = context.joinPaths.size;
+      expect(context.joinPaths.has('profile')).toBe(true);
+
+      plan(context, [sql`${schema.profiles.bio} is not null`]);
+
+      expect(context.joinPaths.size).toBe(before);
+    });
+
+    it('plans joins for computed-field sortSql expressions too', () => {
+      const context = freshContext();
+
+      plan(context, undefined, {
+        profileBio: { __resolvedSortSql: sql`coalesce(${schema.profiles.bio}, '')` },
+      });
+
+      expect(context.joinPaths.has('profile')).toBe(true);
+    });
+
+    it('throws a descriptive QueryError for a table with no direct relationship', () => {
+      const context = freshContext();
+
+      // `surveys` is in the schema but unrelated to `users`.
+      expect(() => plan(context, [sql`${schema.surveys.status} = 'published'`])).toThrow(
+        /no direct relationship/
+      );
+    });
+
+    it('is a no-op with no fragments or no column references', () => {
+      const context = freshContext();
+
+      plan(context, []);
+      plan(context, [sql`1 = 1`]);
+
+      expect(context.joinPaths.size).toBe(0);
+    });
+  });
 });

--- a/packages/adapters/drizzle/tests/computed-field-cross-table-sql.test.ts
+++ b/packages/adapters/drizzle/tests/computed-field-cross-table-sql.test.ts
@@ -160,6 +160,39 @@ describe('computed-field SQL referencing related tables (e2e through fetchData)'
       expect(first.profile?.bio).toBeDefined();
     });
 
+    it('plans the JOIN when one field references a table bare and ANOTHER scopes the same table in a subquery', async () => {
+      // FROM-scope exemption must be per fragment: hasBioSub's `${profiles}`
+      // Table chunk exempts profiles for ITS OWN fragment only. hasBio's bare
+      // column reference still needs the outer JOIN — an aggregate exemption
+      // across fragments would emit `"profiles"."bio"` with no join and fail.
+      const adapter = createAdapter({
+        users: [
+          {
+            field: 'hasBio',
+            compute: () => null,
+            filterSql: () => sql`${schema.profiles.bio} is not null`,
+          },
+          {
+            field: 'hasBioSub',
+            compute: () => null,
+            filterSql: () =>
+              sql`exists (select 1 from ${schema.profiles} where ${schema.profiles.userId} = ${schema.users.id} and ${schema.profiles.bio} is not null)`,
+          },
+        ],
+      });
+
+      const result = await adapter.fetchData({
+        columns: ['id', 'name'],
+        filters: [
+          { columnId: 'hasBio', type: 'text', operator: 'contains', values: ['x'] },
+          { columnId: 'hasBioSub', type: 'text', operator: 'contains', values: ['x'] },
+        ] as unknown as FilterState[],
+      });
+
+      expect(result.total).toBe(2);
+      expect(result.data).toHaveLength(2);
+    });
+
     it('fails fast with guidance when the referenced table has no relationship', async () => {
       const adapter = createAdapter({
         users: [

--- a/packages/adapters/drizzle/tests/computed-field-cross-table-sql.test.ts
+++ b/packages/adapters/drizzle/tests/computed-field-cross-table-sql.test.ts
@@ -1,0 +1,325 @@
+/**
+ * @fileoverview End-to-end coverage for computed-field SQL that touches
+ * related tables, exercised through `fetchData` against a real database.
+ *
+ * The gap this closes: `filterSql`/`sortSql` used to be tested only by
+ * invoking the callback in isolation, so nothing verified the SQL actually
+ * executed. A predicate referencing a related table (e.g.
+ * `sql`${profiles.bio} is not null``) produced a query whose FROM clause never
+ * joined that table and failed at the database — invisibly to the suite.
+ *
+ * Join planning now recovers table references from the SQL chunks
+ * (`planJoinsForOpaqueSqlConditions` in the base query builder) and joins the
+ * referenced relation exactly like a regular cross-table filter would. These
+ * tests run on SQLite (always the manual-join path, no env gating) so the
+ * shared logic is exercised in CI; the Drizzle relational-path decline that
+ * routes Postgres onto this same path is unit-tested in
+ * postgres-query-builder.test.ts.
+ *
+ * Seed (helpers/test-fixtures.ts): users 1-3; profiles only for users 1-2
+ * (bio 'Software developer' / 'Designer'); published posts for users 1-2.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import type { FilterState } from '@better-tables/core';
+import { sql } from 'drizzle-orm';
+import { DrizzleAdapter } from '../src/drizzle-adapter';
+import { createDrizzleAdapter, drizzleAdapter } from '../src/factory';
+import type { DrizzleAdapterConfig, DrizzleDatabase } from '../src/types';
+import { closeDatabase, createTestDatabase, setupTestDatabase } from './helpers/test-fixtures';
+import { relationsSchema, schema } from './helpers/test-schema';
+
+type ComputedFields = NonNullable<DrizzleAdapterConfig<typeof schema, 'sqlite'>['computedFields']>;
+
+describe('computed-field SQL referencing related tables (e2e through fetchData)', () => {
+  let testDb: ReturnType<typeof createTestDatabase>['db'];
+  let sqlite: ReturnType<typeof createTestDatabase>['sqlite'];
+
+  beforeEach(async () => {
+    const { db, sqlite: sqliteDb } = createTestDatabase();
+    testDb = db;
+    sqlite = sqliteDb;
+    await setupTestDatabase(db);
+  });
+
+  afterEach(() => {
+    closeDatabase(sqlite);
+  });
+
+  function createAdapter(computedFields: ComputedFields): DrizzleAdapter<typeof schema, 'sqlite'> {
+    // Same bun:sqlite-as-'sqlite' cast the shared fixtures use (see the note
+    // in createSQLiteAdapter) — runtime query surfaces are identical.
+    return new DrizzleAdapter<typeof schema, 'sqlite'>({
+      db: testDb as unknown as DrizzleDatabase<'sqlite'>,
+      schema,
+      driver: 'sqlite',
+      autoDetectRelationships: true,
+      relations: relationsSchema,
+      options: { defaultPrimaryTable: 'users' },
+      computedFields,
+    });
+  }
+
+  /** The computed-field filter itself carries no SQL — filterSql supplies it. */
+  const hasBioFilter = [
+    { columnId: 'hasBio', type: 'text', operator: 'contains', values: ['x'] },
+  ] as unknown as FilterState[];
+
+  describe('filterSql', () => {
+    it('plans the JOIN for a bare related-column reference (one-to-one)', async () => {
+      const adapter = createAdapter({
+        users: [
+          {
+            field: 'hasBio',
+            compute: () => null,
+            filterSql: () => sql`${schema.profiles.bio} is not null`,
+          },
+        ],
+      });
+
+      const result = await adapter.fetchData({
+        columns: ['id', 'name'],
+        filters: hasBioFilter,
+      });
+
+      // Users 1 and 2 have profiles with a bio; user 3 has no profile row.
+      const names = (result.data as Array<{ name: string }>).map((row) => row.name).sort();
+      expect(names).toEqual(['Jane Smith', 'John Doe']);
+      // The count query must carry the same JOIN — data and total agree.
+      expect(result.total).toBe(2);
+    });
+
+    it('counts distinct primary rows for a one-to-many reference', async () => {
+      const adapter = createAdapter({
+        users: [
+          {
+            field: 'hasPublishedPost',
+            compute: () => null,
+            filterSql: () => sql`${schema.posts.published} = 1`,
+          },
+        ],
+      });
+
+      const result = await adapter.fetchData({
+        columns: ['id', 'name'],
+        filters: [
+          { columnId: 'hasPublishedPost', type: 'text', operator: 'contains', values: ['x'] },
+        ] as unknown as FilterState[],
+      });
+
+      // Published posts belong to users 1 and 2. The posts JOIN fans out
+      // (user 1 has two posts), so both total and the page must deduplicate.
+      expect(result.total).toBe(2);
+      expect(result.data).toHaveLength(2);
+    });
+
+    it('does not force-join a table the SQL scopes via a correlated subquery', async () => {
+      const adapter = createAdapter({
+        users: [
+          {
+            field: 'hasBio',
+            compute: () => null,
+            // `${schema.profiles}` appears as a Table chunk — the fragment
+            // brings its own FROM scope, so no outer JOIN may be added.
+            filterSql: () =>
+              sql`exists (select 1 from ${schema.profiles} where ${schema.profiles.userId} = ${schema.users.id} and ${schema.profiles.bio} is not null)`,
+          },
+        ],
+      });
+
+      const result = await adapter.fetchData({
+        columns: ['id', 'name'],
+        filters: hasBioFilter,
+      });
+
+      expect(result.total).toBe(2);
+      expect(result.data).toHaveLength(2);
+    });
+
+    it('does not double-join a relation that is already selected', async () => {
+      const adapter = createAdapter({
+        users: [
+          {
+            field: 'hasBio',
+            compute: () => null,
+            filterSql: () => sql`${schema.profiles.bio} is not null`,
+          },
+        ],
+      });
+
+      // `profile.bio` in columns already plans the profiles JOIN; the opaque
+      // reference must reuse it. A second JOIN of the same unaliased table
+      // would fail at prepare time.
+      const result = await adapter.fetchData({
+        columns: ['id', 'name', 'profile.bio'],
+        filters: hasBioFilter,
+      });
+
+      expect(result.total).toBe(2);
+      const first = result.data[0] as { profile?: { bio?: string } };
+      expect(first.profile?.bio).toBeDefined();
+    });
+
+    it('fails fast with guidance when the referenced table has no relationship', async () => {
+      const adapter = createAdapter({
+        users: [
+          {
+            field: 'impossible',
+            compute: () => null,
+            // `surveys` is in the schema but has no relationship to `users`.
+            filterSql: () => sql`${schema.surveys.status} = 'published'`,
+          },
+        ],
+      });
+
+      await expect(
+        adapter.fetchData({
+          columns: ['id', 'name'],
+          filters: [
+            { columnId: 'impossible', type: 'text', operator: 'contains', values: ['x'] },
+          ] as unknown as FilterState[],
+        })
+      ).rejects.toThrow(/no direct relationship|correlated subquery/);
+    });
+  });
+
+  describe('sortSql', () => {
+    it('plans the JOIN for a related-column sort expression', async () => {
+      const adapter = createAdapter({
+        users: [
+          {
+            field: 'profileBio',
+            compute: () => null,
+            sortSql: () => sql`coalesce(${schema.profiles.bio}, '')`,
+          },
+        ],
+      });
+
+      const result = await adapter.fetchData({
+        columns: ['id', 'name'],
+        sorting: [{ columnId: 'profileBio', direction: 'asc' }],
+      });
+
+      // '' (Bob, no profile) < 'Designer' (Jane) < 'Software developer' (John)
+      const ids = (result.data as Array<{ id: number }>).map((row) => row.id);
+      expect(ids).toEqual([3, 2, 1]);
+    });
+
+    it('drops (with a warning) a sort on a computed field that has no sortSql', async () => {
+      const adapter = createAdapter({
+        users: [
+          {
+            field: 'displayOnly',
+            compute: () => 'x',
+            // no sortSql — nothing to ORDER BY in SQL
+          },
+        ],
+      });
+
+      const warnings: string[] = [];
+      const originalWarn = console.warn;
+      console.warn = (...args: unknown[]) => {
+        warnings.push(String(args[0]));
+      };
+      try {
+        // Used to throw from join planning: the sort columnId leaked into
+        // resolveColumnPath as if it were a relational column path.
+        const result = await adapter.fetchData({
+          columns: ['id', 'name'],
+          sorting: [{ columnId: 'displayOnly', direction: 'asc' }],
+        });
+
+        expect(result.total).toBe(3);
+        expect(result.data).toHaveLength(3);
+        expect(warnings.some((w) => w.includes('displayOnly') && w.includes('sortSql'))).toBe(true);
+      } finally {
+        console.warn = originalWarn;
+      }
+    });
+  });
+
+  describe('factory passthrough (drizzleAdapter / createDrizzleAdapter)', () => {
+    it('drizzleAdapter forwards computedFields instead of silently dropping them', async () => {
+      const adapter = drizzleAdapter(
+        testDb as unknown as DrizzleDatabase<'sqlite'>,
+        {
+          schema,
+          driver: 'sqlite',
+          relations: relationsSchema,
+          options: { defaultPrimaryTable: 'users' },
+          computedFields: {
+            users: [
+              {
+                field: 'hasBio',
+                compute: () => null,
+                filterSql: () => sql`${schema.profiles.bio} is not null`,
+              },
+            ],
+          },
+        } as never
+      ) as unknown as DrizzleAdapter<typeof schema, 'sqlite'>;
+
+      // Before the passthrough fix this threw
+      // "Field 'hasBio' not found in primary table 'users'".
+      const result = await adapter.fetchData({
+        columns: ['id', 'name'],
+        filters: hasBioFilter,
+      });
+
+      expect(result.total).toBe(2);
+    });
+
+    it('createDrizzleAdapter forwards computedFields', async () => {
+      const adapter = createDrizzleAdapter<typeof schema, 'sqlite'>(testDb, {
+        schema,
+        driver: 'sqlite',
+        relations: relationsSchema,
+        options: { defaultPrimaryTable: 'users' },
+        computedFields: {
+          users: [
+            {
+              field: 'hasBio',
+              compute: () => null,
+              filterSql: () => sql`${schema.profiles.bio} is not null`,
+            },
+          ],
+        },
+      });
+
+      const result = await adapter.fetchData({
+        columns: ['id', 'name'],
+        filters: hasBioFilter,
+      });
+
+      expect(result.total).toBe(2);
+    });
+
+    it('drizzleAdapter forwards hooks instead of silently dropping them', async () => {
+      const seen: string[] = [];
+      const adapter = drizzleAdapter(
+        testDb as unknown as DrizzleDatabase<'sqlite'>,
+        {
+          schema,
+          driver: 'sqlite',
+          relations: relationsSchema,
+          options: { defaultPrimaryTable: 'users' },
+          hooks: {
+            beforeBuildFilterCondition: (filter: FilterState) => {
+              seen.push(filter.columnId);
+              return filter;
+            },
+          },
+        } as never
+      ) as unknown as DrizzleAdapter<typeof schema, 'sqlite'>;
+
+      await adapter.fetchData({
+        columns: ['id', 'name'],
+        filters: [
+          { columnId: 'name', type: 'text', operator: 'contains', values: ['John'] },
+        ] as unknown as FilterState[],
+      });
+
+      expect(seen).toContain('name');
+    });
+  });
+});

--- a/packages/adapters/drizzle/tests/filter-drop-visibility.test.ts
+++ b/packages/adapters/drizzle/tests/filter-drop-visibility.test.ts
@@ -1,0 +1,128 @@
+/**
+ * @fileoverview Dropped-filter visibility
+ *
+ * A filter leaf that cannot be translated is skipped rather than thrown
+ * (plan 038: partial URL/UI filter state must still fetch). But dropping a leaf
+ * WIDENS the result set -- under implicit-AND the query returns more rows than
+ * the caller asked for -- so a drop caused by a malformed filter must never be
+ * silent. Verified live against Postgres before this test existed: a filter
+ * with a mismatched type returned the full 1,000,000-row table instead of the
+ * 49,937 matching rows, with no error and no warning.
+ *
+ * Deliberately asymmetric:
+ * - malformed (operator not valid for the type) -> dropped WITH a warning
+ * - incomplete values for a supported operator  -> dropped SILENTLY (normal
+ *   mid-edit UI state; warning here would fire on every keystroke)
+ */
+
+import { describe, expect, it, spyOn } from 'bun:test';
+import type { FilterOperator, FilterState } from '@better-tables/core';
+import { pgTable, text, uuid } from 'drizzle-orm/pg-core';
+import { FilterHandler } from '../src/filter-handler';
+import { RelationshipManager } from '../src/relationship-manager';
+
+const users = pgTable('users', {
+  id: uuid('id').primaryKey(),
+  name: text('name'),
+  role: text('role'),
+});
+
+const schema = { users };
+
+function createHandler() {
+  const relationshipManager = new RelationshipManager(schema, {});
+  return new FilterHandler(schema, relationshipManager, 'postgres');
+}
+
+function captureWarnings<T>(run: () => T): { result: T; warnings: string[] } {
+  const spy = spyOn(console, 'warn').mockImplementation(() => {});
+  try {
+    const result = run();
+    const warnings = spy.mock.calls.map((call) => String(call[0]));
+    return { result, warnings };
+  } finally {
+    spy.mockRestore();
+  }
+}
+
+describe('dropped filter visibility', () => {
+  it('warns when an operator is not valid for the filter type', () => {
+    const handler = createHandler();
+    // `is` belongs to OPTION_OPERATORS, not TEXT_OPERATORS.
+    const filters = [
+      { columnId: 'role', type: 'text', operator: 'is' as FilterOperator, values: ['admin'] },
+    ] as unknown as FilterState[];
+
+    const { result, warnings } = captureWarnings(() =>
+      handler.handleCrossTableFilters(filters, 'users')
+    );
+
+    // Still dropped (fail-soft preserved) ...
+    expect(result.conditions).toHaveLength(0);
+    // ... but no longer silent.
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('role');
+    expect(warnings[0]).toContain('not valid for type');
+  });
+
+  it('warns for an entirely unknown operator', () => {
+    const handler = createHandler();
+    const filters = [
+      {
+        columnId: 'name',
+        type: 'text',
+        operator: 'notARealOperator' as FilterOperator,
+        values: ['x'],
+      },
+    ] as unknown as FilterState[];
+
+    const { result, warnings } = captureWarnings(() =>
+      handler.handleCrossTableFilters(filters, 'users')
+    );
+
+    expect(result.conditions).toHaveLength(0);
+    expect(warnings).toHaveLength(1);
+  });
+
+  it('never logs filter values (value-free warning convention)', () => {
+    const handler = createHandler();
+    const secret = 'super-secret-value';
+    const filters = [
+      { columnId: 'name', type: 'text', operator: 'is' as FilterOperator, values: [secret] },
+    ] as unknown as FilterState[];
+
+    const { warnings } = captureWarnings(() => handler.handleCrossTableFilters(filters, 'users'));
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).not.toContain(secret);
+  });
+
+  it('stays silent for incomplete values on a supported operator (partial UI state)', () => {
+    const handler = createHandler();
+    // `contains` IS valid for text; the user simply has not typed a value yet.
+    const filters: FilterState[] = [
+      { columnId: 'name', type: 'text', operator: 'contains', values: [] },
+    ];
+
+    const { result, warnings } = captureWarnings(() =>
+      handler.handleCrossTableFilters(filters, 'users')
+    );
+
+    expect(result.conditions).toHaveLength(0);
+    expect(warnings).toHaveLength(0);
+  });
+
+  it('does not warn for a valid, complete filter', () => {
+    const handler = createHandler();
+    const filters: FilterState[] = [
+      { columnId: 'name', type: 'text', operator: 'contains', values: ['ada'] },
+    ];
+
+    const { result, warnings } = captureWarnings(() =>
+      handler.handleCrossTableFilters(filters, 'users')
+    );
+
+    expect(result.conditions).toHaveLength(1);
+    expect(warnings).toHaveLength(0);
+  });
+});

--- a/packages/adapters/drizzle/tests/postgres-query-builder.test.ts
+++ b/packages/adapters/drizzle/tests/postgres-query-builder.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
-import type { SQL } from 'drizzle-orm';
+import { type SQL, sql } from 'drizzle-orm';
 import { pgTable, uuid, varchar } from 'drizzle-orm/pg-core';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { PostgresQueryBuilder } from '../src/query-builders/postgres-query-builder';
@@ -772,13 +772,10 @@ describe('PostgresQueryBuilder', () => {
         // The where should be an and() combination, not just the last condition
       });
 
-      it('should include relationships from context.joinPaths in relational query', () => {
+      it('should fallback to manual joins when filters reference related columns', () => {
         const mockQueryApi = {
-          findMany: async (_options?: {
-            with?: Record<string, unknown>;
-            columns?: Record<string, boolean>;
-          }) => {
-            return [];
+          findMany: async () => {
+            throw new Error('relational path must not run for cross-table filters');
           },
         };
 
@@ -787,6 +784,7 @@ describe('PostgresQueryBuilder', () => {
             from: () => ({
               where: () => ({}),
               leftJoin: () => ({}),
+              innerJoin: () => ({}),
               execute: async () => [],
             }),
           }),
@@ -801,20 +799,139 @@ describe('PostgresQueryBuilder', () => {
           relationshipManager
         );
 
-        // Create context with joinPaths (simulating filter on related table)
+        // Filtering on a related column cannot use findMany({ where }) —
+        // Drizzle rewrites related columns onto the primary table
+        // (e.g. `"users"."bio"`), so we fall back to manual joins.
         const context = relationshipManager.buildQueryContext(
           {
-            columns: ['name', 'email'],
+            columns: ['name', 'email', 'profile.bio'],
             filters: [{ columnId: 'profile.bio' }],
           },
           'users'
         );
 
-        const result = builder.buildSelectQuery(context, 'users', ['name', 'email']);
+        const result = builder.buildSelectQuery(context, 'users', ['name', 'email', 'profile.bio']);
 
-        // Should use relational query and include profile relationship from joinPaths
+        expect(result.isNested).toBe(false);
         expect(result.query).toBeDefined();
-        // The relational query should include profile in the with object
+      });
+
+      it('should fallback to manual joins when sorts reference related columns', () => {
+        const mockQueryApi = {
+          findMany: async () => {
+            throw new Error('relational path must not run for cross-table sorts');
+          },
+        };
+
+        const dbWithQuery = {
+          select: () => ({
+            from: () => ({
+              where: () => ({}),
+              leftJoin: () => ({}),
+              innerJoin: () => ({}),
+              execute: async () => [],
+            }),
+          }),
+          query: {
+            users: mockQueryApi,
+          },
+        } as unknown as PostgresJsDatabase<typeof schema>;
+
+        const builder = new PostgresQueryBuilder(
+          dbWithQuery as unknown as PostgresJsDatabase<typeof schema>,
+          schema,
+          relationshipManager
+        );
+
+        const context = relationshipManager.buildQueryContext(
+          {
+            columns: ['name', 'profile.bio'],
+            sorts: [{ columnId: 'profile.bio' }],
+          },
+          'users'
+        );
+
+        const result = builder.buildSelectQuery(context, 'users', ['name', 'profile.bio']);
+
+        expect(result.isNested).toBe(false);
+      });
+
+      // A computed field's `filterSql` reaches the query builder as raw SQL in
+      // `additionalConditions`, never through `buildQueryContext` — so `context`
+      // cannot see it and the SQL itself is opaque. If it references a joined
+      // table, the relational API rewrites it onto the primary table exactly
+      // like a related-column filter does. Any such condition must decline the
+      // relational path.
+      it('should fallback to manual joins when additionalConditions are present', () => {
+        const mockQueryApi = {
+          findMany: async () => {
+            throw new Error('relational path must not run with additionalConditions');
+          },
+        };
+
+        const dbWithQuery = {
+          select: () => ({
+            from: () => ({
+              where: () => ({}),
+              leftJoin: () => ({}),
+              innerJoin: () => ({}),
+              execute: async () => [],
+            }),
+          }),
+          query: {
+            users: mockQueryApi,
+          },
+        } as unknown as PostgresJsDatabase<typeof schema>;
+
+        const builder = new PostgresQueryBuilder(
+          dbWithQuery as unknown as PostgresJsDatabase<typeof schema>,
+          schema,
+          relationshipManager
+        );
+
+        // No related columns anywhere — only the opaque SQL condition, which is
+        // what the pre-fix guard was blind to.
+        const context = relationshipManager.buildQueryContext(
+          { columns: ['name', 'email'] },
+          'users'
+        );
+
+        const result = builder.buildSelectQuery(context, 'users', ['name', 'email'], undefined, [
+          sql`${schema.profiles.bio} is not null`,
+        ]);
+
+        expect(result.isNested).toBe(false);
+      });
+
+      it('should still use the relational path when no additionalConditions are present', () => {
+        const dbWithQuery = {
+          select: () => ({
+            from: () => ({
+              where: () => ({}),
+              leftJoin: () => ({}),
+              innerJoin: () => ({}),
+              execute: async () => [],
+            }),
+          }),
+          query: {
+            users: { findMany: async () => [] },
+          },
+        } as unknown as PostgresJsDatabase<typeof schema>;
+
+        const builder = new PostgresQueryBuilder(
+          dbWithQuery as unknown as PostgresJsDatabase<typeof schema>,
+          schema,
+          relationshipManager
+        );
+
+        const context = relationshipManager.buildQueryContext(
+          { columns: ['name', 'profile.bio'] },
+          'users'
+        );
+
+        const result = builder.buildSelectQuery(context, 'users', ['name', 'profile.bio']);
+
+        expect(result.isNested).toBe(true);
       });
     });
 

--- a/packages/adapters/drizzle/tests/sql-table-refs.test.ts
+++ b/packages/adapters/drizzle/tests/sql-table-refs.test.ts
@@ -1,0 +1,96 @@
+/**
+ * @fileoverview Unit tests for the opaque-SQL table-reference walker.
+ *
+ * `collectSqlTableRefs` is what join planning trusts to decide which tables a
+ * computed-field `filterSql`/`sortSql` fragment touches, and whether each is
+ * outer-scoped (needs a JOIN) or self-scoped (a correlated subquery's own
+ * FROM). These tests pin the chunk-walk classification directly; the
+ * end-to-end consequences run in computed-field-cross-table-sql.test.ts.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { sql } from 'drizzle-orm';
+import { collectSqlTableRefs } from '../src/utils/sql-table-refs';
+import { schema } from './helpers/test-schema';
+
+describe('collectSqlTableRefs', () => {
+  it('classifies an interpolated column under columnTableNames', () => {
+    const refs = collectSqlTableRefs([sql`${schema.profiles.bio} is not null`]);
+
+    expect([...refs.columnTableNames]).toEqual(['profiles']);
+    expect(refs.fromTableNames.size).toBe(0);
+  });
+
+  it('classifies an interpolated table under fromTableNames', () => {
+    const refs = collectSqlTableRefs([
+      sql`exists (select 1 from ${schema.profiles} where ${schema.profiles.userId} = ${schema.users.id})`,
+    ]);
+
+    expect(refs.fromTableNames.has('profiles')).toBe(true);
+    // Column chunks are still reported — scope policy is the caller's.
+    expect(refs.columnTableNames.has('profiles')).toBe(true);
+    expect(refs.columnTableNames.has('users')).toBe(true);
+  });
+
+  it('collects references from multiple tables in one fragment', () => {
+    const refs = collectSqlTableRefs([
+      sql`${schema.profiles.bio} is not null and ${schema.posts.published} = 1`,
+    ]);
+
+    expect([...refs.columnTableNames].sort()).toEqual(['posts', 'profiles']);
+  });
+
+  it('walks nested SQL fragments', () => {
+    const inner = sql`${schema.profiles.bio} is not null`;
+    const refs = collectSqlTableRefs([sql`(${inner}) and ${schema.users.age} > 18`]);
+
+    expect(refs.columnTableNames.has('profiles')).toBe(true);
+    expect(refs.columnTableNames.has('users')).toBe(true);
+  });
+
+  it('unwraps aliased fragments', () => {
+    const aliased = sql`${schema.profiles.bio}`.as('bio_alias');
+    const refs = collectSqlTableRefs([aliased]);
+
+    expect(refs.columnTableNames.has('profiles')).toBe(true);
+  });
+
+  it('unwraps generic SQLWrapper objects via getSQL()', () => {
+    const wrapper = { getSQL: () => sql`${schema.posts.title} like '%x%'` };
+    const refs = collectSqlTableRefs([wrapper]);
+
+    expect(refs.columnTableNames.has('posts')).toBe(true);
+  });
+
+  it('sees nothing in fragments built from raw identifier strings', () => {
+    // Raw strings never bind to Drizzle entities — nothing to plan against.
+    const refs = collectSqlTableRefs([sql.raw(`profiles.bio is not null`)]);
+
+    expect(refs.columnTableNames.size).toBe(0);
+    expect(refs.fromTableNames.size).toBe(0);
+  });
+
+  it('handles null/undefined nodes and empty input', () => {
+    expect(collectSqlTableRefs([]).columnTableNames.size).toBe(0);
+    const refs = collectSqlTableRefs([null, undefined]);
+    expect(refs.columnTableNames.size).toBe(0);
+    expect(refs.fromTableNames.size).toBe(0);
+  });
+
+  it('terminates on self-referential getSQL wrappers (depth guard)', () => {
+    const cyclic: { getSQL: () => unknown } = { getSQL: () => cyclic };
+
+    const refs = collectSqlTableRefs([cyclic]);
+    expect(refs.columnTableNames.size).toBe(0);
+  });
+
+  it('keeps scope per call: separate invocations do not share fromTableNames', () => {
+    // The join planner calls once per fragment precisely so one fragment's
+    // Table chunk cannot exempt another fragment's bare column reference.
+    const bare = collectSqlTableRefs([sql`${schema.profiles.bio} is not null`]);
+    const scoped = collectSqlTableRefs([sql`exists (select 1 from ${schema.profiles})`]);
+
+    expect(bare.fromTableNames.has('profiles')).toBe(false);
+    expect(scoped.fromTableNames.has('profiles')).toBe(true);
+  });
+});

--- a/packages/adapters/toolkit/src/data-transformer.ts
+++ b/packages/adapters/toolkit/src/data-transformer.ts
@@ -851,23 +851,39 @@ export class DataTransformer<TTable = unknown> {
       ? columnId.split('.')[0] || ''
       : columnPath.table || '';
 
-    // Find the first record with data for this relationship
-    // Use generateAlias utility to construct the correct alias based on relationship path
-    const testKey = generateAlias(relationshipPath, columnPath.field);
-    const relatedRecord = records.find(
-      (record) => record[testKey] !== null && record[testKey] !== undefined
+    const relatedTableSchema = this.schema[realTableName];
+    const relatedColumns = relatedTableSchema ? this.getColumnNamesCached(relatedTableSchema) : [];
+
+    // Decide whether the related row EXISTS.
+    //
+    // This must not hinge on one arbitrary column. `processColumn` is invoked
+    // once per relationship with `cols[0]` (see the second pass in
+    // `buildNestedRecord`), so keying presence off `columnPath.field` made
+    // whichever related column the caller happened to list first a sentinel:
+    // when that column was NULL for a row, the ENTIRE related object was
+    // discarded and every other related column silently rendered blank, even
+    // though the join had returned data for them.
+    //
+    // Prefer the related table's primary key -- the same signal
+    // `processOneToManyColumn` uses -- since a PK is never NULL for a row that
+    // exists. Fall back to "any related column carries a value" when the PK was
+    // not selected, so presence never depends on a single nullable column.
+    const primaryKeyName = relatedTableSchema
+      ? this.getPrimaryKeyNameCached(relatedTableSchema)
+      : undefined;
+    const pkFlatKey = primaryKeyName ? generateAlias(relationshipPath, primaryKeyName) : undefined;
+    const presenceKeys =
+      pkFlatKey && records.some((record) => record[pkFlatKey] !== undefined)
+        ? [pkFlatKey]
+        : relatedColumns.map((col) => generateAlias(relationshipPath, col));
+
+    const relatedRecord = records.find((record) =>
+      presenceKeys.some((key) => record[key] !== null && record[key] !== undefined)
     );
 
     if (relatedRecord) {
       // Build nested object for the related table
       const relatedData: Record<string, unknown> = {};
-
-      // Extract only columns that are present in the record (requested columns)
-      // Instead of extracting all columns, only extract what's actually in the record
-      const relatedTableSchema = this.schema[realTableName];
-      const relatedColumns = relatedTableSchema
-        ? this.getColumnNamesCached(relatedTableSchema)
-        : [];
 
       for (const col of relatedColumns) {
         const flatKey = generateAlias(relationshipPath, col);

--- a/packages/adapters/toolkit/tests/data-transformer-relation-presence.test.ts
+++ b/packages/adapters/toolkit/tests/data-transformer-relation-presence.test.ts
@@ -1,0 +1,145 @@
+/**
+ * @fileoverview One-to-one relation presence detection in DataTransformer
+ *
+ * Regression coverage for the "blank related columns" defect: presence of a
+ * related row used to be decided by whichever related column the caller listed
+ * FIRST (`processColumn` is invoked once per relationship with `cols[0]`). When
+ * that one column was NULL for a row, the entire related object was replaced
+ * with `null` and every other related column rendered blank in the UI, even
+ * though the JOIN had returned data for them.
+ *
+ * Presence now keys off the related table's primary key -- the same signal
+ * `processOneToManyColumn` uses -- falling back to "any related column carries
+ * a value" when the PK was not selected.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { DataTransformer } from '../src/data-transformer';
+import type {
+  ColumnPath,
+  RelationshipManagerPort,
+  RelationshipPath,
+  SchemaIntrospectionPort,
+} from '../src/types';
+
+interface ToyTable {
+  columns: string[];
+  primaryKey: string;
+}
+
+const schema: Record<string, ToyTable> = {
+  users: { columns: ['id', 'name'], primaryKey: 'id' },
+  profiles: { columns: ['id', 'userId', 'bio', 'avatar'], primaryKey: 'id' },
+};
+
+const profileRelationship: RelationshipPath = {
+  from: 'users',
+  to: 'profiles',
+  foreignKey: 'userId',
+  localKey: 'id',
+  cardinality: 'one',
+};
+
+const relationshipManager: RelationshipManagerPort = {
+  resolveColumnPath(columnId, primaryTable): ColumnPath {
+    if (!columnId.includes('.')) {
+      return { columnId, table: primaryTable, field: columnId, isNested: false };
+    }
+    const [, field = ''] = columnId.split('.');
+    return {
+      columnId,
+      table: 'profiles',
+      field,
+      isNested: true,
+      relationshipPath: [profileRelationship],
+    };
+  },
+  getRelationshipByAlias() {
+    return null;
+  },
+  isArrayRelationship() {
+    return false;
+  },
+};
+
+const schemaPort: SchemaIntrospectionPort<ToyTable> = {
+  getColumnNames(table) {
+    return table.columns;
+  },
+  getForeignKeyColumns() {
+    return [];
+  },
+  getPrimaryKeyColumns(table) {
+    return [{ name: table.primaryKey, column: table.primaryKey }];
+  },
+};
+
+function transform(flatRow: Record<string, unknown>, columns: string[]) {
+  const transformer = new DataTransformer<ToyTable>(schema, relationshipManager, schemaPort);
+  const result = transformer.transformToNested([flatRow], 'users', columns);
+  return result[0] as Record<string, unknown>;
+}
+
+describe('DataTransformer one-to-one relation presence', () => {
+  it('keeps the related object when the FIRST requested related column is NULL', () => {
+    const record = transform(
+      {
+        id: 1,
+        name: 'John Doe',
+        profiles_id: 10,
+        profiles_avatar: null,
+        profiles_bio: 'Software developer',
+      },
+      // `profile.avatar` is listed first and is NULL for this row.
+      ['name', 'profile.avatar', 'profile.bio']
+    );
+
+    expect(record.profile).not.toBeNull();
+    expect((record.profile as Record<string, unknown>).bio).toBe('Software developer');
+  });
+
+  it('is order-independent: same row, related columns requested in either order', () => {
+    const row = {
+      id: 1,
+      name: 'John Doe',
+      profiles_id: 10,
+      profiles_avatar: null,
+      profiles_bio: 'Software developer',
+    };
+
+    const avatarFirst = transform(row, ['name', 'profile.avatar', 'profile.bio']);
+    const bioFirst = transform(row, ['name', 'profile.bio', 'profile.avatar']);
+
+    expect(avatarFirst.profile).toEqual(bioFirst.profile as Record<string, unknown>);
+  });
+
+  it('falls back to any non-null related column when the related PK is not selected', () => {
+    const record = transform(
+      {
+        id: 1,
+        name: 'John Doe',
+        profiles_avatar: null,
+        profiles_bio: 'Software developer',
+      },
+      ['name', 'profile.avatar', 'profile.bio']
+    );
+
+    expect(record.profile).not.toBeNull();
+    expect((record.profile as Record<string, unknown>).bio).toBe('Software developer');
+  });
+
+  it('still nulls the related object when the related row genuinely has no data', () => {
+    const record = transform(
+      {
+        id: 1,
+        name: 'John Doe',
+        profiles_id: null,
+        profiles_avatar: null,
+        profiles_bio: null,
+      },
+      ['name', 'profile.avatar', 'profile.bio']
+    );
+
+    expect(record.profile).toBeNull();
+  });
+});

--- a/plans/056-toolkit-typecheck-ordering.md
+++ b/plans/056-toolkit-typecheck-ordering.md
@@ -1,0 +1,216 @@
+# Plan 056: Make root `bun run typecheck` deterministic (toolkit race)
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat 27c59b9..HEAD -- turbo.json .github/workflows/test.yml`
+> If either file changed since this plan was written, compare the "Current
+> state" excerpts against the live code before proceeding; on a mismatch,
+> treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P2
+- **Effort**: S
+- **Risk**: LOW (one-line task-graph change; worst case is slightly longer wall-clock for the root typecheck)
+- **Depends on**: none
+- **Category**: dx
+- **Planned at**: commit `27c59b9`, 2026-07-20
+
+## Why this matters
+
+`bun run typecheck` at the repo root intermittently fails with
+`Failed: @better-tables/adapters-toolkit#typecheck` while the very same
+`cd packages/adapters/toolkit && bun run typecheck` passes standalone. It was
+observed failing twice in one session on 2026-07-19/20 and then passing on
+later runs with no code change. A flaky root gate trains people to re-run
+until green, which eventually masks a real type error. CI runs the same turbo
+task (`.github/workflows/test.yml:112` → `bun run typecheck`), so the same
+latent race exists there even though it has not been observed to fire in CI
+yet.
+
+## Current state
+
+Verified at `27c59b9`:
+
+- `turbo.json` — the `typecheck` task depends only on **upstream** builds,
+  not the package's own build:
+
+  ```json
+  "test": {
+    "dependsOn": ["build"],
+    ...
+  },
+  "typecheck": {
+    "dependsOn": ["^build"],
+    "outputs": []
+  },
+  ```
+
+  Note the asymmetry: `test` already depends on the package's **own**
+  `build` (`"build"`), while `typecheck` depends only on `^build`
+  (upstream packages' builds).
+
+- Because of that, turbo schedules a package's `typecheck` **concurrently
+  with its own `build`**. Captured live from a root run at `27c59b9` (log
+  order):
+
+  ```
+  @better-tables/adapters-toolkit:build: cache miss, executing 43727fc847fdfa26
+  @better-tables/adapters-toolkit:typecheck: cache miss, executing 477f65ab801ed6b4
+  @better-tables/adapters-toolkit:build: $ tsdown
+  @better-tables/adapters-toolkit:typecheck: $ tsc --noEmit
+  @better-tables/adapters-toolkit:build: ℹ Cleaning 8 files
+  ```
+
+  `tsdown` **deletes** the package's `dist/` ("Cleaning 8 files") and then
+  rewrites it while `tsc --noEmit` is running in the same package. Any file
+  the typecheck resolves out of a `dist/` directory that is being cleaned or
+  half-rewritten at that moment produces spurious errors.
+
+- `packages/adapters/toolkit/tsconfig.json` — `"include": ["src/**/*",
+  "tests"]`, `"exclude": ["node_modules", "dist"]`. The `exclude` only
+  filters the include globs; files reached through **module resolution**
+  (e.g. `@better-tables/core` → `packages/core/dist/index.d.mts`, per core's
+  `package.json` `types` field) are still read from `dist/` directories.
+
+- The exact tsc error text was not captured when the failure fired (only
+  turbo's `Failed: @better-tables/adapters-toolkit#typecheck` summary
+  line). Step 1 captures it if the race reproduces.
+
+- Repo conventions: `turbo.json` is small and hand-maintained; match its
+  existing style (the `test` task is the exemplar for "depends on own
+  build").
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---|---|---|
+| Root typecheck | `bun run typecheck` | exit 0, `Tasks: 10 successful` |
+| Forced (no cache) | `bunx turbo typecheck --force` | exit 0 |
+| Toolkit standalone | `cd packages/adapters/toolkit && bun run typecheck` | exit 0 |
+| Full test suite | `bun run test` | all pass |
+
+## Scope
+
+**In scope** (the only files you should modify):
+- `turbo.json`
+
+**Out of scope** (do NOT touch, even though they look related):
+- `packages/adapters/toolkit/tsconfig.json` — its include/exclude is correct;
+  the race is a task-ordering problem, not a tsconfig problem.
+- `packages/*/package.json` `types`/`exports` fields — resolving types from
+  `dist/` is the intended published-package shape.
+- `.github/workflows/test.yml` — it runs the same root command; it inherits
+  the fix automatically.
+- Any `tsdown.config.ts` — do not disable cleaning.
+
+## Git workflow
+
+- Branch: continue on the current working branch unless the operator says
+  otherwise; commit message style: `Plan 056: make typecheck depend on own
+  build` (repo uses plain imperative subjects, see `git log --oneline -10`).
+
+## Steps
+
+### Step 1: Try to reproduce and capture the error text (time-boxed)
+
+Run up to 10 forced, uncached root typechecks and save output:
+
+```bash
+for i in $(seq 1 10); do
+  bunx turbo typecheck --force > "/tmp/typecheck-run-$i.log" 2>&1 || { echo "FAILED on run $i"; break; }
+done
+grep -l "Failed" /tmp/typecheck-run-*.log
+```
+
+If a run fails, extract the toolkit error lines
+(`grep -A20 "adapters-toolkit:typecheck" /tmp/typecheck-run-N.log`) and paste
+them into this plan file under a new "## Captured failure" heading — that
+recording is the reproduction evidence. If no run fails, that's fine (the
+race is timing-dependent); proceed to Step 2 regardless — the ordering fix
+is correct whether or not the race fires today.
+
+**Verify**: the loop ran; any captured error text is recorded in this file.
+
+### Step 2: Order each package's typecheck after its own build
+
+In `turbo.json`, change the `typecheck` task to also depend on the package's
+own `build`, matching the existing `test` task convention:
+
+```json
+"typecheck": {
+  "dependsOn": ["build", "^build"],
+  "outputs": []
+},
+```
+
+This removes every window in which `tsdown` cleans/rewrites a `dist/` that a
+concurrently running `tsc --noEmit` in the same graph may resolve into:
+within a package, typecheck now runs strictly after its own build; across
+packages, `^build` (already present) plus the build graph's own `^build`
+chain guarantees upstream `dist/` directories are complete before any
+dependent's typecheck starts.
+
+**Verify**: `bun run typecheck` → exit 0. Inspect the log: for the toolkit
+package, the `build` task's output must complete before
+`adapters-toolkit:typecheck: $ tsc --noEmit` appears.
+
+### Step 3: Stability loop
+
+```bash
+for i in $(seq 1 10); do bunx turbo typecheck --force >/dev/null 2>&1 || echo "FAILED on run $i"; done; echo done
+```
+
+**Verify**: prints only `done` — zero `FAILED` lines.
+
+### Step 4: Confirm no regression in wall-clock or tests
+
+- Time one cold root typecheck (`time bunx turbo typecheck --force`) and
+  record the number in your report — expect low tens of seconds; the added
+  serialization is per-package only.
+- `bun run test` → all suites pass (turbo graph unchanged for tests).
+
+**Verify**: both commands exit 0.
+
+## Test plan
+
+No unit tests — this is build-graph configuration. The verification is the
+Step 3 stability loop (10 consecutive forced runs green). Record the loop
+output in the PR/commit description.
+
+## Done criteria
+
+Machine-checkable. ALL must hold:
+
+- [ ] `turbo.json` `typecheck.dependsOn` equals `["build", "^build"]`
+- [ ] `bun run typecheck` exits 0
+- [ ] 10 consecutive `bunx turbo typecheck --force` runs exit 0 (Step 3 loop prints no FAILED)
+- [ ] `bun run test` exits 0
+- [ ] No files outside `turbo.json` modified (`git status`)
+- [ ] `plans/README.md` status row updated
+
+## STOP conditions
+
+Stop and report back (do not improvise) if:
+
+- A Step 3 run fails **after** the Step 2 change — capture the full toolkit
+  error text. That would falsify the same-package-ordering diagnosis and
+  point at turbo cache **restoration** corruption instead (a cached
+  `dist/**` being replayed non-atomically); the fix for that is different
+  (investigate `outputs` correctness / turbo version bump), and it should be
+  decided by a human, not improvised.
+- The Step 2 change makes the root typecheck take dramatically longer
+  (> ~2× the Step 1 baseline) — report the timing rather than reverting
+  silently.
+
+## Maintenance notes
+
+- If a future task ever needs "typecheck without building" (e.g. a fast CI
+  lane), add a separate task name rather than weakening this ordering.
+- Reviewer scrutiny: just the one-line diff and the recorded stability loop.
+- Related but deliberately untouched: `tsdown`'s clean step. If tsdown ever
+  gains an atomic-write mode, the ordering here is still correct — keep it.

--- a/plans/057-contract-surface-truth.md
+++ b/plans/057-contract-surface-truth.md
@@ -1,0 +1,307 @@
+# Plan 057: Remove the dead reserved surface from TableConfig/TableFeatures
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat 27c59b9..HEAD -- packages/core/src/types/table.ts packages/ui/src/components/table/table.tsx apps/marketing/content/docs/better-table.mdx apps/marketing/content/docs/selection-and-actions.mdx`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P2
+- **Effort**: M
+- **Risk**: LOW-MED (breaking type removals — sanctioned by the standing 0.6 release policy; risk is missing a stray consumer)
+- **Depends on**: none. **Coordinate with**: 058 (owns `FetchDataParams.search` — do NOT touch it here), 059 (owns `actionsConfig`/`bulkActions` reintroduction decisions), 050 (owns export UI; `exportData`/`ExportParams` on the adapter contract STAY).
+- **Category**: tech-debt
+- **Planned at**: commit `27c59b9`, 2026-07-20
+
+## Why this matters
+
+`TableConfig`/`TableFeatures` in core declare a set of fields that **no code
+reads**: `defaultFilters`, `actionsConfig`, `exportOptions`, `theme`,
+`loadingState`, and the feature flags `bulkActions`, `export`,
+`columnResizing`, `virtualScrolling`, `realTimeUpdates`, `rowExpansion`.
+Because `BetterTableProps` extends `TableConfig`, all of them typecheck as
+props — users set them, nothing happens, and the docs have to carry a
+"contract-only, not working" disclaimer
+(`apps/marketing/content/docs/better-table.mdx`, "Contract-only props"
+section). The repo's standing release policy
+(`plans/README.md`, "Maintainer policies"): *"No deprecation cycles, no
+compat shims … replaced surface is removed outright"* — the 0.6 window is
+the sanctioned moment to delete this surface. Each capability comes back
+only when a real implementation lands (several already have plans: export →
+050, actions-as-module → 059, search → 058).
+
+## Current state
+
+Verified at `27c59b9`. The single source of the dead fields is
+`packages/core/src/types/table.ts`:
+
+```
+:66   defaultFilters?: FilterState[] | FilterGroupNode;
+:78   actionsConfig?: ActionsConfig;
+:81   exportOptions?: ExportConfig<TData>;
+:87   theme?: TableTheme;
+:90   features?: TableFeatures;
+:96   emptyState?: EmptyStateConfig;      ← WIRED, keep
+:99   loadingState?: LoadingStateConfig;
+:102  errorState?: ErrorStateConfig;      ← WIRED, keep
+```
+
+`TableFeatures` (same file):
+
+```
+:139  bulkActions?: boolean;
+:142  export?: boolean;
+:145  columnResizing?: boolean;
+:159  virtualScrolling?: boolean;
+:162  realTimeUpdates?: boolean;
+:168  rowExpansion?: boolean;
+```
+
+What the copied UI actually consumes (the ground truth for keep vs delete),
+`packages/ui/src/components/table/table.tsx`:
+
+```
+:698  const {
+        filtering = true,
+        sorting: sortingEnabled = true,
+        pagination: paginationEnabled = true,
+        rowSelection = false,
+        headerContextMenu,
+        columnReordering = false,
+      } = features;
+:721  const shouldShowRowSelection = actions.length > 0 || rowSelection;
+:1251 showColumnVisibility={features.columnVisibility !== false}
+```
+
+So the LIVE `TableFeatures` set is exactly: `filtering`, `sorting`,
+`pagination`, `rowSelection`, `headerContextMenu`, `columnReordering`,
+`columnVisibility`. Everything else in the interface is dead.
+
+Other verified facts you will rely on:
+
+- `grep -rn "defaultFilters\|exportOptions\|actionsConfig\|loadingState" packages/ui/src --include='*.ts*'`
+  → zero non-comment matches. `theme` matches in
+  `packages/ui/src/components/filters/filter-bar.tsx:62` are a **local**
+  `FilterBarTheme` prop unrelated to `TableConfig.theme` (BetterTable never
+  passes it — `grep -n "theme=" packages/ui/src/components/table/table.tsx`
+  → nothing). Leave `FilterBarTheme` alone.
+- The real initial-filters seam is the `initialFilters` prop
+  (`table.tsx:169`), not `TableConfig.defaultFilters`.
+- The real virtualization seam is the `virtualized` prop
+  (`table.tsx:150`), not `features.virtualScrolling`.
+- The real loading seam is the `loading` boolean prop (`table.tsx:160`),
+  not `loadingState`.
+- Adapter-contract surface that STAYS (do not remove): `exportData?()` and
+  `ExportParams`/`ExportResult` (`packages/core/src/types/adapter.ts:537`,
+  `:219`) — plan 050 ships the UI for the already-working drizzle
+  implementation. `subscribe?()` (`adapter.ts:555`) also STAYS: the drizzle
+  adapter genuinely implements it (subscriber list at
+  `drizzle-adapter.ts:159`, `subscribe` at `:1337`, and mutations emit
+  events via `this.emit(...)` at `:1161/:1196/:1227/:1259/:1290`). Only the
+  UI-side `realTimeUpdates` flag is dead.
+- `FetchDataParams.search` (`adapter.ts:55`) is dead too but is **owned by
+  plan 058** (which turns search into a real feature) — out of scope here.
+- Docs that must change with the removals:
+  `apps/marketing/content/docs/better-table.mdx` — the `## Contract-only
+  props` section and the feature-flags paragraph ("The `TableFeatures` type
+  also declares `bulkActions`, `export`, `columnResizing`,
+  `virtualScrolling`, `realTimeUpdates`, and `rowExpansion` — those flags
+  are contract-only today…"); `selection-and-actions.mdx` — the trailing
+  `ActionsConfig`-is-contract-only paragraph.
+- Repo conventions: breaking changesets use `minor` on `@better-tables/core`
+  pre-1.0 (release policy). Changeset files live in `.changeset/*.md` — see
+  `.changeset/memory-adapter-filter-fixes.md` for the format.
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---|---|---|
+| Core tests | `cd packages/core && bun test` | all pass |
+| UI tests | `cd packages/ui && bun test` | all pass |
+| Marketing tests | `cd apps/marketing && bun test` | all pass |
+| Typecheck (root) | `bun run typecheck` | exit 0 |
+| Lint (scoped) | `bunx biome check packages/core packages/ui apps/marketing` | 0 errors |
+
+## Scope
+
+**In scope**:
+- `packages/core/src/types/table.ts` (field + now-orphaned interface removals)
+- `packages/core/src/types/index.ts` / `packages/core/src/index.ts` (drop
+  exports that become orphaned, e.g. `TableTheme`, `LoadingStateConfig`,
+  `ExportConfig`, `ActionsConfig` — verify each with grep before deleting)
+- `packages/core/tests/**` (update any test that references removed fields)
+- `packages/ui/src/**` only if a stray type import of a removed name exists
+  (grep first; expected: none)
+- `apps/marketing/content/docs/better-table.mdx`,
+  `apps/marketing/content/docs/selection-and-actions.mdx`
+- `.changeset/contract-surface-truth.md` (create)
+- `plans/README.md` (status row)
+
+**Out of scope** (do NOT touch):
+- `FetchDataParams.search` — plan 058's opening move.
+- `exportData`/`ExportParams`/`ExportResult`/`subscribe`/`DataEvent` on the
+  adapter contract — real, working surface (see Current state).
+- `AdapterFeatures` on `AdapterMeta` (`create/read/update/delete/
+  bulkOperations/realTimeUpdates/export/transactions`) — those are honest
+  adapter capability declarations consumed by the editing gate
+  (`features.update`); leave them.
+- `emptyState`/`errorState` configs and their interfaces — wired.
+- `FilterBarTheme` in `filter-bar.tsx` — local component prop, reachable by
+  consumers using `FilterBar` directly.
+- The `actions` prop and `TableAction` type — live feature (plan 059 decides
+  its packaging, not this plan).
+
+## Git workflow
+
+- Branch: current working branch unless the operator says otherwise.
+- One commit per step group is fine; subject style: plain imperative
+  (`Remove dead reserved surface from TableConfig/TableFeatures`).
+
+## Steps
+
+### Step 1: Confirm each field is still dead (guard against drift)
+
+For each of: `defaultFilters`, `actionsConfig`, `exportOptions`,
+`loadingState`, `bulkActions`, `columnResizing`, `virtualScrolling`,
+`realTimeUpdates`, `rowExpansion`, plus `TableConfig`-level `theme`:
+
+```bash
+grep -rn "<name>" packages/ui/src packages/core/src --include='*.ts*' | grep -v "types/table.ts" | grep -v "\.test\."
+```
+
+Expected: only comment/docs hits, no functional reads (for `theme`, ignore
+`filter-bar.tsx`'s local `FilterBarTheme`; for `features.export`, search
+`features.export\|features?.export` to avoid matching `exportData`).
+
+**Verify**: paste the grep results into your report; all functional-read
+counts are zero.
+
+### Step 2: Delete the dead fields
+
+In `packages/core/src/types/table.ts` remove the fields listed in Current
+state (`:66,:78,:81,:87,:99` and the six `TableFeatures` flags), including
+their JSDoc blocks and any `@example` usages of them in the file-top JSDoc
+(`:35` `defaultFilters`, `:39` `exportOptions`, `:41` `theme` appear in the
+`TableConfig` doc example — update the example to only show live fields).
+
+**Verify**: `cd packages/core && bun run typecheck` → the ONLY errors (if
+any) are now-orphaned interfaces/imports inside core, which Step 3 removes.
+
+### Step 3: Remove now-orphaned types and exports
+
+For each of `ActionsConfig`, `ExportConfig`, `TableTheme`,
+`LoadingStateConfig` (and anything else Step 2 orphaned):
+
+```bash
+grep -rn "<TypeName>" packages --include='*.ts*' | grep -v node_modules | grep -v dist
+```
+
+If the only remaining references are its own definition + barrel exports +
+tests of the type's mere existence, delete the definition, the barrel
+export, and update the tests. If a REAL consumer shows up, STOP (see STOP
+conditions). Note: `LoadingStateConfig`'s interface is around
+`types/table.ts:321`; `EmptyStateConfig` (~`:262`) and `ErrorStateConfig`
+(~`:343`) stay.
+
+**Verify**: `bun run typecheck` (root) → exit 0.
+
+### Step 4: Update tests
+
+`grep -rn "defaultFilters\|exportOptions\|actionsConfig\|loadingState\|virtualScrolling\|realTimeUpdates\|rowExpansion\|columnResizing\|bulkActions" packages/core/tests packages/ui/tests`
+and fix every hit (most likely: type-shape tests asserting the config
+compiles). Do not weaken behavioral assertions — only remove references to
+deleted fields.
+
+**Verify**: `cd packages/core && bun test` and `cd packages/ui && bun test`
+→ all pass.
+
+### Step 5: Update the docs
+
+- `better-table.mdx`: delete the `## Contract-only props` section entirely;
+  rewrite the `TableFeatures` paragraph to list ONLY the live flags
+  (`filtering`, `sorting`, `pagination`, `rowSelection`,
+  `headerContextMenu`, `columnReordering`, `columnVisibility`) with the
+  note that bulk-action visibility is driven by `actions` being non-empty.
+- `selection-and-actions.mdx`: delete the trailing "`ActionsConfig` … is
+  contract-only" paragraph (the type no longer exists).
+- Grep the whole docs content for removed names:
+  `grep -rn "exportOptions\|actionsConfig\|loadingState\|defaultFilters\|virtualScrolling\|realTimeUpdates\|rowExpansion\|columnResizing" apps/marketing/content/docs/` → fix every hit.
+
+**Verify**: the grep above returns zero hits; `cd apps/marketing && bun test`
+passes; `cd apps/marketing && bun run typecheck` exits 0.
+
+### Step 6: Changeset + ledger
+
+Create `.changeset/contract-surface-truth.md`:
+
+```md
+---
+"@better-tables/core": minor
+---
+
+Remove reserved-but-unimplemented config surface (0.6 policy: replaced
+surface is removed outright, no compat shims): `TableConfig.defaultFilters`
+(use the `initialFilters` prop), `.actionsConfig`, `.exportOptions`,
+`.theme`, `.loadingState` (use the `loading` prop), and the `TableFeatures`
+flags `bulkActions`, `export`, `columnResizing`, `virtualScrolling` (use the
+`virtualized` prop), `realTimeUpdates`, `rowExpansion`. Each capability
+returns only with a real implementation (export UI, actions module, etc.).
+The adapter contract (`exportData`, `subscribe`, `AdapterFeatures`) is
+unchanged.
+```
+
+Update this plan's row in `plans/README.md`.
+
+**Verify**: `bunx biome check .changeset/` → clean.
+
+## Test plan
+
+- No new behavior — the tests are the existing suites staying green after
+  the removals, plus updated type-shape tests in
+  `packages/core/tests/types/` (pattern: `packages/core/tests/types/column.test.ts`).
+- Add ONE negative type test (in `packages/core/tests/types/`, using
+  `@ts-expect-error`) asserting `features: { virtualScrolling: true }` no
+  longer typechecks — this pins the removal.
+
+## Done criteria
+
+Machine-checkable. ALL must hold:
+
+- [ ] `grep -n "defaultFilters\|actionsConfig\|exportOptions\|loadingState" packages/core/src/types/table.ts` → no matches
+- [ ] `grep -n "bulkActions\|columnResizing\|virtualScrolling\|realTimeUpdates\|rowExpansion" packages/core/src/types/table.ts` → no matches; `grep -n "export?:" packages/core/src/types/table.ts` → no match inside `TableFeatures`
+- [ ] `bun run typecheck` exits 0; core, ui, marketing test suites pass
+- [ ] Docs greps (Step 5) return zero hits; the `@ts-expect-error` pin test exists and passes
+- [ ] `.changeset/contract-surface-truth.md` exists
+- [ ] `plans/README.md` status row updated
+
+## STOP conditions
+
+Stop and report back (do not improvise) if:
+
+- Step 1 finds a REAL read of any listed field (the codebase drifted — e.g.
+  plan 059/050 landed first and wired one). Remove only the still-dead ones
+  and report which were skipped.
+- Step 3 finds a real consumer of an orphaned type outside tests/barrels.
+- Removing `theme` breaks `packages/ui` compilation (would mean a stray
+  `TableConfig['theme']` import this recon missed).
+- You find yourself wanting to delete anything from
+  `packages/core/src/types/adapter.ts` — that file is out of scope.
+
+## Maintenance notes
+
+- Plans 050 (export UI), 058 (search), 059 (actions module) REINTRODUCE
+  surface in these areas deliberately, shaped by their implementations —
+  reviewers should not read those later additions as reverting this
+  cleanup.
+- `columnResizing` and `rowExpansion` are recorded in `plans/README.md`
+  under "Deferred by decision" as future feature plans; if either is
+  prioritized, its plan reintroduces the flag together with the feature.
+- Reviewer scrutiny: the diff should be almost purely deletions +
+  docs/tests; any ADDED runtime code is a red flag.

--- a/plans/058-global-search.md
+++ b/plans/058-global-search.md
@@ -1,0 +1,336 @@
+# Plan 058: Ship global search as sugar over the filter pipeline
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat 27c59b9..HEAD -- packages/core/src/types/adapter.ts packages/core/src/types/factory.ts packages/core/src/factory.ts packages/ui/src packages/cli/src/lib/file-operations.ts`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P2
+- **Effort**: M-L
+- **Risk**: MED (touches the fetch path and the copied-UI manifest; mitigated by reusing the existing filter pipeline instead of new query machinery)
+- **Depends on**: none (parallel-safe with 057, which explicitly leaves `FetchDataParams.search` to this plan)
+- **Category**: direction
+- **Planned at**: commit `27c59b9`, 2026-07-20
+
+## Why this matters
+
+A search box is the single most-expected control on a data table, and the
+contract has promised one since day one: `FetchDataParams.search?: string`
+(`packages/core/src/types/adapter.ts:55`, "Global search query"). Nothing
+consumes it — not the Drizzle adapter
+(`grep -n "params.search" packages/adapters/drizzle/src/drizzle-adapter.ts`
+→ nothing), not the memory adapter, not the UI (the only "search" in
+`packages/ui/src/components/filters/filter-bar.tsx:74` is the
+column-picker's internal search). The docs currently teach that
+`.searchable()` "does not add the column to a separate global search"
+(`apps/marketing/content/docs/filtering.mdx:64`).
+
+The key insight this plan is built on: **global search needs no new query
+machinery**. "Search for q" is exactly `OR(contains(col, q) for each
+searchable column)` — a `FilterGroupNode` — ANDed with the existing
+filters. Both first-party adapters already execute arbitrary
+`FilterGroupNode` trees (Drizzle group translation landed in plan 017;
+`memoryAdapter`'s `matchesNode` walks trees), relation-path columns already
+JOIN through the filter path, and the HTTP wire already carries trees. So
+search becomes: one pure helper in core, desugaring at the two entry points
+that know the column definitions, one small UI input, URL sync of a plain
+string.
+
+## Current state
+
+Verified at `27c59b9`:
+
+- `packages/core/src/types/adapter.ts:54-55` —
+
+  ```ts
+    /** Global search query */
+    search?: string;
+  ```
+
+  Adapter-level, unconsumed. This plan REMOVES it from the adapter contract
+  (adapters never see "search"; they see filters) and adds sugar at the
+  layers that own column definitions.
+
+- `packages/core/src/types/factory.ts:207` —
+  `export type TableScopedFetchDataParams = Omit<FetchDataParams, 'primaryTable'>;`
+  — the params type for `tables.fetchData(tableDef, params)`. The instance
+  fetch path, `packages/core/src/factory.ts:112-120`:
+
+  ```ts
+  instance.fetchData = (async (
+    table: TableDefinition<string, unknown>,
+    params?: TableScopedFetchDataParams
+  ) => {
+    return asTableAdapter(config.database).fetchData({
+      ...params,
+      primaryTable: table.tableName,
+    });
+  }) as unknown as BetterTablesInstance<TAdapter>['fetchData'];
+  ```
+
+  This is the choke point that HAS the table definition (`table.columns`) —
+  the right place to desugar `search` for server-side callers.
+
+- Filter shapes: `FilterState` / `FilterGroupNode` in
+  `packages/core/src/types/filter.ts`; a bare `FilterState[]` is implicit
+  AND, `{ kind: 'group', logic: 'or' | 'and', children }` nests
+  (`packages/core/src/types/adapter.ts:42-52` documents that adapters must
+  accept both shapes — core does NOT canonicalize).
+
+- `.searchable()` semantics today: text-family filter sugar. Column defs
+  carry `searchable?: boolean` (see `packages/core/src/types/column.ts`) and
+  builders set it via `.searchable(config?)`. The homepage demo marks
+  `profile.bio`, `profile.location` etc. searchable
+  (`apps/marketing/src/lib/columns/user-columns.tsx`).
+
+- UI composition points:
+  - `packages/ui/src/components/table/table.tsx` — `BetterTableInner`
+    renders `<FilterBar ...>` and builds adapter fetch params through
+    `packages/ui/src/hooks/use-table-data.ts`.
+  - The table store (`getOrCreateTableStore`, core `stores/table-store.ts`)
+    holds `filters`; search should be SEPARATE state (it must not render as
+    a removable chip in `active-filters.tsx`).
+  - URL sync: `packages/ui/src/hooks/use-table-url-sync.ts` +
+    `UrlSyncConfig` and `serializeTableStateToUrl` /
+    `deserializeTableStateFromUrl` in core (`packages/core/src/utils/`).
+    Simple values (page/limit) are plain string params — search follows
+    that pattern (param name `search`, plain string, no `c:` compression).
+
+- CLI copy manifest: `packages/cli/src/lib/file-operations.ts`
+  `UI_SOURCE_FILES` — any new file under `packages/ui/src` MUST be added
+  there; `packages/cli/tests/ui-source-manifest.test.ts` fails on any drift
+  in either direction (this is deliberate — let it guide you).
+
+- Docs to update (all under `apps/marketing/content/docs/`):
+  `filtering.mdx:64` (the "does not add to a global search" note),
+  `better-table.mdx` (props reference), `columns/index.mdx` (`.searchable()`
+  row), `adapters/custom.mdx:37` (the "`search` param is declared on the
+  contract but not yet consumed" sentence — the param will be GONE from the
+  contract).
+
+- Conventions: changesets in `.changeset/*.md` (`@better-tables/core`
+  minor — contract change in the 0.6 window; `@better-tables/cli` patch for
+  the manifest). Tests: core in `packages/core/tests/`, UI in
+  `packages/ui/tests/` (component-test pattern:
+  `packages/ui/tests/components/table-initial-filter-tree.test.tsx`).
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---|---|---|
+| Core tests | `cd packages/core && bun test` | all pass |
+| UI tests | `cd packages/ui && bun test` | all pass |
+| CLI tests (manifest drift) | `cd packages/cli && bun test` | all pass |
+| Drizzle sqlite tests | `cd packages/adapters/drizzle && bun test` | all pass (pg/mysql suites skip without env) |
+| Typecheck | `bun run typecheck` | exit 0 |
+| Live check | `cd apps/marketing && bun run dev` → type in the search box on `/` | rows narrow; URL gains `?search=` |
+
+## Scope
+
+**In scope**:
+- `packages/core/src/types/adapter.ts` (remove `search` from
+  `FetchDataParams`)
+- `packages/core/src/types/factory.ts` + `packages/core/src/factory.ts`
+  (add `search?: string` to the TABLE-SCOPED params; desugar in
+  `instance.fetchData`)
+- `packages/core/src/utils/` (new `build-search-filter-group.ts` + barrel
+  export; URL serialization of `search`)
+- `packages/core/src/stores/table-store.ts` + state types (a `searchQuery`
+  field with setter, separate from `filters`)
+- `packages/ui/src/components/filters/search-input.tsx` (new),
+  `packages/ui/src/components/filters/index.ts`,
+  `packages/ui/src/components/table/table.tsx`,
+  `packages/ui/src/hooks/use-table-data.ts`,
+  `packages/ui/src/hooks/use-table-url-sync.ts`
+- `packages/cli/src/lib/file-operations.ts` (manifest)
+- Tests in core/ui/cli/drizzle; docs pages listed above;
+  `.changeset/global-search.md`; `plans/README.md`
+
+**Out of scope** (do NOT touch):
+- Adapter query builders — Drizzle and memory MUST work unchanged; if they
+  don't, the design premise failed (see STOP conditions).
+- `packages/core/src/adapters/http-*` — the wire carries filters; search
+  never crosses it as a distinct field.
+- Filter-bar chips (`active-filters.tsx`) — search is not a chip.
+- Fuzzy matching, ranking, highlighting — out of v1; `contains` only.
+
+## Git workflow
+
+- Branch: current working branch unless the operator says otherwise; plain
+  imperative commit subjects (`Add global search over the filter pipeline`).
+
+## Steps
+
+### Step 1: Core helper — `buildSearchFilterGroup`
+
+New `packages/core/src/utils/build-search-filter-group.ts`:
+
+```ts
+export function buildSearchFilterGroup(
+  columns: ReadonlyArray<Pick<ColumnDefinition, 'id' | 'type' | 'searchable'>>,
+  query: string
+): FilterGroupNode | null
+```
+
+Behavior: trim `query`; return `null` for empty. Include columns where
+`searchable` is truthy AND `type` is in the text family
+(`text | email | url | phone`). Return
+`{ kind: 'group', logic: 'or', children: [{ columnId, type: 'text', operator: 'contains', values: [query] }, …] }`.
+Return `null` when no columns qualify. Export from the core barrel.
+
+**Verify**: `cd packages/core && bun test tests/utils/` → new unit tests
+pass (cases: empty query → null; no searchable columns → null; mixed types
+→ only text-family included; relation-path ids pass through untouched).
+
+### Step 2: Move `search` from the adapter contract to the table-scoped sugar
+
+1. Delete `search?: string` from `FetchDataParams`
+   (`types/adapter.ts:54-55`).
+2. In `types/factory.ts`, extend the table-scoped params:
+   `export type TableScopedFetchDataParams = Omit<FetchDataParams, 'primaryTable'> & { search?: string };`
+3. In `factory.ts` `instance.fetchData`: if `params.search` is non-empty,
+   build the group from `table.columns` via `buildSearchFilterGroup`; when
+   it returns non-null, AND it with existing filters:
+   - no existing filters → pass the OR-group directly;
+   - existing `FilterState[]` → `{ kind: 'group', logic: 'and', children: [...existing, orGroup] }`;
+   - existing `FilterGroupNode` → `{ kind: 'group', logic: 'and', children: [existing, orGroup] }`.
+   Strip `search` before delegating to the adapter (adapters must never
+   receive it).
+
+**Verify**: `bun run typecheck` → exit 0 (proves nothing else consumed the
+adapter-level field). New core test: `betterTables({ database: memoryAdapter(rows) })`
++ a table def with one searchable text column — `tables.fetchData(def, { search: 'ali' })`
+returns only matching rows, and combining `search` with an existing filter
+narrows further (AND semantics).
+
+### Step 3: Store state + UI input
+
+1. Table store: add `searchQuery: string` + `setSearchQuery(q)` (kept
+   SEPARATE from `filters` so chips don't render it). Follow the existing
+   store-field pattern in `packages/core/src/stores/table-store.ts`.
+2. New `packages/ui/src/components/filters/search-input.tsx`: a debounced
+   input (reuse `packages/ui/src/hooks/use-debounce.ts`, default 300ms)
+   bound to the store's `searchQuery`; placeholder "Search…"; renders only
+   when at least one column qualifies per `buildSearchFilterGroup`'s rules
+   (export a tiny `hasSearchableColumns(columns)` alongside the helper or
+   compute inline).
+3. `table.tsx`: render `<SearchInput/>` in the toolbar row next to
+   `<FilterBar/>` when `filtering` is enabled and searchable columns exist.
+4. `use-table-data.ts`: when building adapter fetch params, merge
+   `searchQuery` into `filters` using `buildSearchFilterGroup` + the same
+   AND-composition as Step 2 (client-side the adapter gets FILTERS ONLY —
+   this is what keeps `httpAdapter` working with zero wire changes).
+5. Add the new file to `UI_SOURCE_FILES` in
+   `packages/cli/src/lib/file-operations.ts` (filters group, alphabetical).
+
+**Verify**: `cd packages/cli && bun test` → the manifest drift test passes.
+`cd packages/ui && bun test` → new component test passes: render
+`BetterTable` with a searchable column + `memoryAdapter`-style data flow
+(follow `packages/ui/tests/components/table-initial-filter-tree.test.tsx`
+for scaffolding), type into the search input, assert the displayed rows
+narrow and that NO chip appears in the active-filters region.
+
+### Step 4: URL sync
+
+- `UrlSyncConfig` gains `search?: boolean`.
+- `serializeTableStateToUrl`/`deserializeTableStateFromUrl` +
+  `use-table-url-sync.ts`: plain string param named `search` (match the
+  page/limit plain-param pattern; no `c:` prefix), hydrating the store's
+  `searchQuery` and included in the URL signature so back/forward works.
+
+**Verify**: core serialization round-trip test (`search` in →
+serialized param → deserialized out); UI url-sync test if the existing
+suite covers flags (pattern: whatever `use-table-url-sync` tests exist —
+if none cover flags, the core round-trip test suffices; note that in your
+report).
+
+### Step 5: Drizzle proof (no adapter changes)
+
+Add ONE integration test in `packages/adapters/drizzle/tests/` (sqlite
+suite pattern): a table-scoped `tables.fetchData(def, { search })` where the
+searchable set includes a RELATION path (e.g. `customer.company`) — assert
+matching rows return and the JOIN happened (existing sqlite suites show how
+to seed + assert; model after the relationship-filtering tests).
+
+**Verify**: `cd packages/adapters/drizzle && bun test` → passes with zero
+`src/` changes in the drizzle package (`git status packages/adapters/drizzle/src` → clean).
+
+### Step 6: Docs + changesets + ledger
+
+- `filtering.mdx`: replace the ":64" note — `.searchable()` now ALSO opts
+  the column into global search; add a short "Search" section showing the
+  UI box, `tables.fetchData(def, { search })`, and the
+  `buildSearchFilterGroup` recipe for raw-adapter callers.
+- `better-table.mdx`: document the search box + store field + URL flag.
+- `columns/index.mdx`: update the `.searchable()` row.
+- `adapters/custom.mdx:37`: replace the "declared but not consumed"
+  sentence — the adapter contract has NO search field; adapters receive
+  filters.
+- Changesets: `@better-tables/core` **minor** (removes
+  `FetchDataParams.search`, adds table-scoped `search` sugar + helper +
+  store field + URL flag); `@better-tables/cli` **patch** (manifest).
+- Update this plan's row in `plans/README.md`.
+
+**Verify**: `grep -rn "FetchDataParams" apps/marketing/content/docs/ | grep -i search`
+→ no stale claims; `bunx biome check .changeset/` clean.
+
+## Test plan
+
+- Core: helper unit tests (Step 1); factory desugar + AND-composition tests
+  against `memoryAdapter` (Step 2 — this doubles as the memory-adapter
+  proof); URL round-trip (Step 4).
+- UI: search-input interaction test (Step 3), no-chip assertion.
+- CLI: manifest drift test already exists — it enforces Step 3.5.
+- Drizzle: one relation-path search integration test (Step 5).
+- Patterns: `packages/core/tests/utils/filter-serialization.test.ts`,
+  `packages/ui/tests/components/table-initial-filter-tree.test.tsx`.
+
+## Done criteria
+
+Machine-checkable. ALL must hold:
+
+- [ ] `grep -n "search" packages/core/src/types/adapter.ts` → no `search?:` field on `FetchDataParams`
+- [ ] `tables.fetchData(def, { search })` narrows rows via `memoryAdapter` in a passing core test
+- [ ] UI search box renders, narrows rows, produces no filter chip (passing UI test)
+- [ ] Drizzle relation-path search test passes with `git status packages/adapters/drizzle/src` clean
+- [ ] `cd packages/cli && bun test` passes (manifest updated)
+- [ ] `bun run typecheck` exit 0; core/ui/drizzle suites pass
+- [ ] Both changesets exist; docs greps clean; `plans/README.md` updated
+
+## STOP conditions
+
+Stop and report back (do not improvise) if:
+
+- Step 2's typecheck reveals a real consumer of adapter-level
+  `params.search` (drift since `27c59b9`).
+- The Drizzle relation-path search test FAILS without adapter changes —
+  that falsifies the "search is pure filter sugar" premise (most likely a
+  group-translation gap); report the failing SQL/error instead of patching
+  the adapter ad hoc.
+- The store change requires modifying `FilterManager`'s filter semantics —
+  search state must stay OUTSIDE the filter tree; if it can't, the design
+  needs review.
+- Debounce/urlsync interactions cause update loops (watch
+  `use-table-url-sync`'s hydration guard) — report rather than adding
+  effect workarounds.
+
+## Maintenance notes
+
+- Search quality upgrades (per-column operator overrides, number/date
+  coercion, ranking, ILIKE vs LIKE tuning) all happen INSIDE
+  `buildSearchFilterGroup` or the adapters' existing `contains` handling —
+  the composition contract (OR-group ANDed with filters) should not change.
+- Plan 059's module system may later move the search input into an optional
+  module; it composes the same way (it's one component + store field).
+- Reviewer scrutiny: the AND-composition in both desugar sites must be
+  identical (consider extracting `composeSearchIntoFilters(filters, group)`
+  used by both factory and use-table-data); adapters receiving a `search`
+  key is a contract leak.

--- a/plans/059-ui-modules-and-actions-extraction.md
+++ b/plans/059-ui-modules-and-actions-extraction.md
@@ -1,0 +1,344 @@
+# Plan 059: UI modules — an opt-in module tier for the copied UI, with actions as the first extraction
+
+> **Executor instructions**: DESIGN + BUILD plan. Step 1 produces a short
+> design record and validates the slot contract against TWO consumers
+> before any extraction. Run every verification command and confirm the
+> expected result before moving on. If anything in the "STOP conditions"
+> section occurs, stop and report — do not improvise. When done, update the
+> status row in `plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat 27c59b9..HEAD -- packages/ui/src/components/table/table.tsx packages/cli/src/lib/file-operations.ts packages/cli/src/commands packages/cli/tests/ui-source-manifest.test.ts`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P2
+- **Effort**: L
+- **Risk**: MED (changes what `init` ships by default; the slot seam must not break existing consumers of the copied UI)
+- **Depends on**: none to start. **Coordinate with**: 049 (core "plugins" tier — different layer, shared vocabulary rules below), 050 (its `ExportButton` must ride this plan's slot seam — see Maintenance), 057 (removes `TableConfig.actionsConfig`/`features.bulkActions`; this plan decides what, if anything, returns as module-local props).
+- **Category**: direction
+- **Planned at**: commit `27c59b9`, 2026-07-20
+- **Maintainer decision (2026-07-20)**: the actions toolbar ("action
+  builder") should be a plugin, NOT part of the default `init` set. The
+  plugin system deserves deep thought — this plan is that design plus its
+  first proof.
+
+## Why this matters
+
+Better Tables has two extension surfaces that are currently conflated under
+the word "plugin":
+
+1. **Core data plugins** — `betterTables({ plugins: [...] })`, an
+   instance-level, npm-distributed seam (`beforeFetch`/`afterFetch`; plan
+   049 executes it). No UI involved.
+2. **UI capability groups** — components the CLI copies into the consumer's
+   app (shadcn model). Today this tier has no structure: `init` copies ONE
+   flat set (`UI_SOURCE_FILES`), so every consumer gets the bulk-actions
+   toolbar, whether or not they want row actions, and every future
+   capability (export button, saved views, filter-group builder from plan
+   048) would bloat the default further.
+
+This plan gives tier 2 a real shape — **modules**: named, independently
+copyable groups with a typed seam in the core table so an absent module is
+a clean no-op, plus a `better-tables add <module>` command. The actions
+toolbar is the first extraction because it is the maintainer's explicit
+call, it has a small blast radius (2 files, 2 integration points), and it
+forces the seam design to be real rather than speculative. Plan 050's
+`ExportButton` becomes the second consumer, which is what keeps the seam
+honest (same lock-against-real-consumers rule plan 049 uses at the core
+tier).
+
+**Vocabulary rule** (to prevent permanent confusion): core tier keeps the
+name **plugins** (npm packages, data hooks). The copied-UI tier is
+**modules** (`better-tables add <module>`). Docs and code comments must use
+these words consistently.
+
+## Current state
+
+Verified at `27c59b9`:
+
+- The actions feature's full UI integration is two files plus three lines
+  in `packages/ui/src/components/table/table.tsx`:
+
+  ```
+  :49    import { ActionsToolbar } from './actions-toolbar';
+  :721   const shouldShowRowSelection = actions.length > 0 || rowSelection;
+  :1292  {actions.length > 0 && (
+  :1293    <ActionsToolbar ... />
+  ```
+
+  The two module files: `packages/ui/src/components/table/actions-toolbar.tsx`
+  (renders bulk-action buttons over the current selection) and
+  `packages/ui/src/components/table/action-confirmation-dialog.tsx`
+  (confirm dialog used by the toolbar).
+
+- `TableAction` (the `actions` prop's item type) lives in core types —
+  `grep -rn "TableAction" packages/core/src/types/table.ts` (`actions?: TableAction<TData>[]`
+  on `TableConfig`, ~`:74`). Types are cheap; they STAY in core regardless
+  of where the components live.
+
+- Row selection is a core table feature (`features.rowSelection`,
+  checkbox column) — it stays in the core module. Note the coupling at
+  `:721`: passing `actions` implies selection. That behavior is preserved.
+
+- CLI copy machinery: `packages/cli/src/lib/file-operations.ts` —
+  `UI_SOURCE_FILES` is a flat manifest (components.table[],
+  components.filters[], hooks[], lib[]); `generateFileMappings()` walks it;
+  `packages/cli/tests/ui-source-manifest.test.ts` pins the manifest to the
+  real `packages/ui/src` tree **in both directions** (missing file or
+  unlisted file both fail). Any restructure must keep that drift test's
+  guarantee.
+
+- CLI command structure: `packages/cli/src/commands/` has `init.ts`,
+  `docs.ts`, `help.ts`; commands are registered via a typed registry
+  (`packages/cli/src/lib/command-factory.ts`, see `docs.ts:25-31` for the
+  pattern of building a command from the registry definition). A new `add`
+  command follows the same pattern.
+
+- `init` flow (init.ts): shadcn check → required-packages check (core,
+  zustand, @dnd-kit/*) → config resolve → copy via `copyAllFiles` →
+  next-steps output. `--components-path`, `--yes`, `--cwd`, `--skip-shadcn`
+  flags exist.
+
+- Core-tier plugin sketch (for vocabulary alignment only — do not build it
+  here): `plans/design/table-definition-dx.md:309-352` and plan 049.
+
+- Design records live in `plans/design/` (existing examples:
+  `table-definition-dx.md`, `core-contract-v2.md`) — Step 1 adds one.
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---|---|---|
+| CLI tests | `cd packages/cli && bun test` | all pass |
+| UI tests | `cd packages/ui && bun test` | all pass |
+| Typecheck | `bun run typecheck` | exit 0 |
+| Manual init smoke | scratch dir: `bun /path/to/repo/packages/cli/src/index.ts init -y --cwd <scratch>` | copies core module only |
+| Manual add smoke | `... add actions --cwd <scratch>` | copies the 2 actions files |
+
+## Scope
+
+**In scope**:
+- `plans/design/ui-modules.md` (create — Step 1's design record)
+- `packages/ui/src/components/table/table.tsx` (slot seam)
+- `packages/ui/src/components/table/index.ts` (exports)
+- `packages/cli/src/lib/file-operations.ts` (module-shaped manifest)
+- `packages/cli/src/commands/add.ts` (create) + command registry +
+  `packages/cli/src/commands/init.ts` (default set + output text)
+- `packages/cli/tests/**` (manifest drift test per module; add-command
+  tests)
+- `packages/ui/tests/**` (slot behavior)
+- Docs: `apps/marketing/content/docs/ui-and-cli.mdx`,
+  `selection-and-actions.mdx`, `troubleshooting.mdx`
+- `apps/marketing/src/components/home/users-table-client.tsx` (dogfood: the
+  homepage uses actions — it wires the slot)
+- `.changeset/*.md`; `plans/README.md`
+
+**Out of scope** (do NOT touch):
+- Core-tier plugins (`betterTables({ plugins })`) — plan 049's territory.
+- Building the export/saved-views/filter-builder modules — later plans ride
+  this seam (050, 048).
+- `TableAction` type relocation — stays in core.
+- Row-selection behavior/checkbox column — core, unchanged.
+- npm packaging of UI modules — modules are copied source, full stop.
+
+## Git workflow
+
+- Branch: current working branch unless the operator says otherwise; plain
+  imperative commit subjects (`Plan 059 Step N: …` is fine for multi-step).
+
+## Steps
+
+### Step 1: Design record — slot contract + module manifest (validate against TWO consumers)
+
+Write `plans/design/ui-modules.md` (1–2 pages) deciding, with rationale:
+
+1. **The seam**: a `slots` prop on `BetterTable`:
+
+   ```ts
+   interface BetterTableSlots<TData> {
+     /** Renders when actions.length > 0. Installed by the actions module. */
+     actionsToolbar?: ComponentType<ActionsToolbarSlotProps<TData>>;
+     /** Reserved for plan 050's ExportButton and future toolbar controls. */
+     toolbarExtra?: ComponentType<ToolbarExtraSlotProps<TData>>;
+   }
+   ```
+
+   The slot-props types must give the module everything the current inline
+   render at `table.tsx:1293` passes to `ActionsToolbar` (read that call
+   site and enumerate: actions, selection state/count, clear-selection,
+   selected row data, …). **Validation rule**: sketch BOTH the actions
+   toolbar and plan 050's ExportButton against the slot types; if the
+   export button can't express its needs (it needs current
+   filters/sorting/columns to hand to `exportData`), adjust
+   `ToolbarExtraSlotProps` NOW. Do not add more slot points than these two
+   — same minimalism rule as plan 049.
+
+2. **Absent-module behavior**: `actions` provided but no
+   `slots.actionsToolbar` → render nothing, `console.warn` once in dev
+   naming the fix (`better-tables add actions` + wire the slot). Follow the
+   existing one-time-dev-warn pattern in `table.tsx` (`warnFilterTreeDropped`,
+   ~`:976` — keyed, production-gated).
+
+3. **Module manifest schema** in the CLI:
+
+   ```ts
+   const UI_MODULES = {
+     core: { /* today's UI_SOURCE_FILES minus the 2 actions files */ },
+     actions: {
+       components: { table: ['actions-toolbar.tsx', 'action-confirmation-dialog.tsx'] },
+     },
+   } as const;
+   ```
+
+   Every file in `packages/ui/src` belongs to EXACTLY ONE module; the drift
+   test enforces the union and the disjointness.
+
+4. **Command surface**: `better-tables add <module…>` (reuses init's
+   config/paths/conflict machinery; no shadcn re-check beyond config read);
+   `init` copies `core` only and prints available modules;
+   `init --modules actions` opts in at init time. `add` with an unknown
+   module lists valid ones and exits 1.
+
+5. **Vocabulary**: the plugins-vs-modules rule from "Why this matters",
+   stated for docs authors.
+
+**Verify**: the design record exists and contains the two slot-props
+sketches (actions + export). If the export sketch forced a slot-shape
+change, the record says what changed and why.
+
+### Step 2: Slot seam in the copied UI
+
+Implement `slots` per the design record: add the prop to
+`BetterTableProps`, replace the direct import/render
+(`table.tsx:49`, `:1292-1293`) with the slot render + the one-time dev
+warn. Keep `shouldShowRowSelection` (`:721`) exactly as is. Move nothing
+yet — `ActionsToolbar` still exists; the default behavior change is ONLY
+that the table renders it via slot.
+
+**Verify**: `cd packages/ui && bun test` — new tests: (a) actions + slot
+wired → toolbar renders on selection; (b) actions + NO slot → nothing
+renders, exactly one dev warn; (c) no actions → no warn. Pattern:
+`packages/ui/tests/components/table-initial-filter-tree.test.tsx`.
+
+### Step 3: Module-shaped CLI manifest + drift test
+
+Restructure `UI_SOURCE_FILES` → `UI_MODULES` (design record schema), update
+`generateFileMappings(resolvedPaths, componentsOutputPath, modules)` to take
+the selected module names, and rewrite
+`packages/cli/tests/ui-source-manifest.test.ts` to assert: union of all
+modules' files === the real tree (both directions, same exclusions), AND
+modules are pairwise disjoint. Keep `getUiSourceFilePaths()` (or a
+per-module successor) exported for the test.
+
+**Verify**: `cd packages/cli && bun test` → drift + new manifest tests
+pass.
+
+### Step 4: `add` command + init default change
+
+- New `packages/cli/src/commands/add.ts` per the registry pattern
+  (`docs.ts` as exemplar): args `<modules…>`, flags `--cwd`, `--yes`,
+  `--components-path` (must match the init-time path — read it from the
+  same config resolution init uses).
+- `init`: copies `core` only by default; `--modules <names>` opts modules
+  in; next-steps output lists available modules with one-liners
+  ("actions — bulk-action toolbar over selected rows: `bunx better-tables add actions`").
+- Update `init`'s copy-confirmation dir list if it enumerates files.
+
+**Verify**: CLI tests for: default init excludes the 2 actions files; `add
+actions` maps exactly those 2 files into `<components>/better-tables-ui/table/`;
+unknown module exits 1 listing valid names. Manual smoke (scratch dir) per
+Commands table.
+
+### Step 5: Dogfood the homepage
+
+`apps/marketing/src/components/home/users-table-client.tsx` passes
+`actions` today — wire the slot there
+(`slots={{ actionsToolbar: ActionsToolbar }}` with a direct import; the
+marketing app consumes `@better-tables/ui` workspace-style, so the import
+stays package-internal).
+
+**Verify**: `cd apps/marketing && bun test` passes;
+`cd apps/marketing && bun run dev` → on `/`, selecting rows still shows the
+bulk-actions toolbar and actions still execute.
+
+### Step 6: Docs + changesets + ledger
+
+- `ui-and-cli.mdx`: new "Modules" section — what modules are, the
+  plugins-vs-modules vocabulary, `add` usage, the module list (core,
+  actions).
+- `selection-and-actions.mdx`: opening install step
+  (`bunx better-tables add actions`) + the slot wiring line; note that
+  plain row selection needs no module.
+- `troubleshooting.mdx`: "actions don't render" entry (module not added /
+  slot not wired — quote the dev warn text).
+- Changesets: `@better-tables/cli` **minor** (`add` command; init default
+  set change). The `@better-tables/ui` package is private/copied — no
+  changeset, but note the slot prop in the cli changeset body since that's
+  the user-visible surface.
+- Update this plan's row + add a note to plan 050's row in
+  `plans/README.md`: "ExportButton rides 059's `toolbarExtra` slot —
+  refresh 050 against the design record before executing."
+
+**Verify**:
+`grep -rn "add actions" apps/marketing/content/docs/ | wc -l` ≥ 2;
+`bunx biome check .changeset/` clean.
+
+## Test plan
+
+- UI: slot render / absent-slot warn / no-actions cases (Step 2).
+- CLI: module manifest union+disjoint drift tests (Step 3); add-command
+  behavior incl. unknown module (Step 4); init default-set test (Step 4).
+- Dogfood: homepage manual smoke with selection + action execution
+  (Step 5).
+- Patterns: `packages/cli/tests/ui-source-manifest.test.ts`,
+  `packages/cli/tests/init.test.ts`,
+  `packages/ui/tests/components/table-initial-filter-tree.test.tsx`.
+
+## Done criteria
+
+Machine-checkable. ALL must hold:
+
+- [ ] `plans/design/ui-modules.md` exists with both slot-consumer sketches
+- [ ] `grep -n "import { ActionsToolbar }" packages/ui/src/components/table/table.tsx` → no match (slot render instead)
+- [ ] Default `init` copy set excludes `actions-toolbar.tsx` and `action-confirmation-dialog.tsx` (CLI test asserts)
+- [ ] `add actions` copies exactly those two files (CLI test asserts)
+- [ ] Manifest drift test enforces union === tree AND module disjointness
+- [ ] Homepage bulk actions still work via the slot (marketing tests + manual smoke)
+- [ ] `bun run typecheck` exit 0; ui + cli + marketing suites pass
+- [ ] Changeset exists; docs updated; `plans/README.md` rows for 059 AND 050 updated
+
+## STOP conditions
+
+Stop and report back (do not improvise) if:
+
+- The ExportButton sketch in Step 1 cannot be expressed against
+  `toolbarExtra` without a THIRD slot point — report the needed shape
+  instead of adding slots speculatively.
+- Step 2 reveals `ActionsToolbar` reaches into table internals not passable
+  through props (hidden store coupling) — enumerate what it reads and
+  report; do not widen the slot to expose raw store handles without review.
+- The `add` command needs to duplicate more than ~30 lines of init's
+  config/paths logic — extract a shared helper instead; if that helper
+  refactor grows beyond `file-operations.ts`/a new `lib/` file, report.
+- Anything requires changing `packages/core` runtime (this plan should
+  touch types-consuming UI/CLI only; `TableAction` stays where it is).
+
+## Maintenance notes
+
+- Plan 050 MUST be refreshed against `plans/design/ui-modules.md` before
+  execution (its ExportButton becomes the `toolbarExtra` slot's first
+  occupant and ships as an `export` module; its csvExport() core plugin
+  half still rides 049).
+- Plan 048's filter-group builder is a natural third module — when planned,
+  it follows the same manifest+add path; the slot question there is
+  different (it replaces the filter bar rather than adding toolbar
+  content) — design that then, not now.
+- Future core-tier hooks (049) and UI modules stay ORTHOGONAL: a capability
+  like saved views may ship as plugin + module pair; keep the vocabulary
+  rule.
+- Reviewer scrutiny: the absent-module path (no crash, one warn), drift
+  test disjointness, and that `init` output actually tells users modules
+  exist (discoverability is the cost of opt-in).

--- a/plans/060-derived-aggregate-columns.md
+++ b/plans/060-derived-aggregate-columns.md
@@ -1,0 +1,398 @@
+# Plan 060: Server-derived columns — filterable, sortable aggregates ("how many posts does this user have")
+
+> **Executor instructions**: DESIGN + BUILD plan. Step 1 writes the design
+> record; do not start Step 2 until its decisions are recorded. Run every
+> verification command and confirm the expected result before moving on. If
+> anything in the "STOP conditions" section occurs, stop and report — do
+> not improvise. When done, update the status row in `plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat 27c59b9..HEAD -- packages/core/src/builders packages/core/src/types packages/core/src/factory.ts packages/core/src/adapters/memory-adapter.ts packages/adapters/drizzle/src packages/adapters/toolkit/src/types.ts apps/marketing/src/lib/columns/user-columns.tsx`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P2 (maintainer-requested direction centerpiece)
+- **Effort**: L
+- **Risk**: MED-HIGH (touches the fetch/filter/sort pipeline in core + drizzle; mitigated by phasing and by lowering into the adapter's EXISTING computed-fields machinery)
+- **Depends on**: none to start. **Coordinate with**: 057 (contract removals — disjoint fields), 058 (both extend the instance fetch path in `factory.ts`; land in either order, rebase the second), 048 (filter-group UI — no file overlap, but this plan's tree-walk closes a gap 048 benefits from).
+- **Category**: direction
+- **Planned at**: commit `27c59b9`, 2026-07-20
+
+## Why this matters
+
+The flagship pitch is "define columns once, the adapter turns them into
+SQL" — but the moment a column is *derived* ("posts count", "days since
+last order"), the story collapses. Today:
+
+- `t.computed(id, accessor)` is client-only display sugar, yet its builder
+  inherits `filterable: true` / `sortable: true` defaults
+  (`packages/core/src/builders/column-builder.ts:82-83`), so derived
+  columns silently offer filter/sort controls that send a non-existent
+  column id to the SQL layer. The homepage demo had to hand-disable both
+  (`apps/marketing/src/lib/columns/user-columns.tsx`, `hasBio`/`roleTags`
+  with `.filterable(false).sortable(false)` and a comment explaining why).
+- The Drizzle adapter ALREADY has a full server-side derived-field engine —
+  `ComputedFieldConfig` with `compute`, `filter` (FilterState
+  substitution), `filterSql` (WHERE-clause SQL), and `sortSql`
+  (`packages/adapters/drizzle/src/types/computed-fields.ts:61-81`; sorting
+  resolution at `drizzle-adapter.ts:625-637`; per-table registration at
+  `:165`, `:238-241`, `:451-460`) — but it is (a) adapter-config-only,
+  invisible from `defineTable`, (b) zero-dogfooded
+  (`grep -rn computedFields apps/marketing/src` → nothing), and (c)
+  flat-filters-only: a computed-field filter inside a `FilterGroupNode`
+  throws (`drizzle-adapter.ts:1430`) with advice ("flatten the tree at the
+  call site") that is WRONG for OR trees — flattening turns a union into an
+  intersection.
+- The toolkit's `AggregateColumn` type
+  (`packages/adapters/toolkit/src/types.ts:129` — `{ columnId, function:
+  'count'|'sum'|'avg'|'min'|'max'|'distinct', field, relationshipPath }`)
+  and drizzle's `AggregateFunction`
+  (`packages/adapters/drizzle/src/types/aggregates.ts`) exist but nothing
+  produces or consumes them end-to-end.
+
+This plan connects the three: a declarative, **serializable** derived-column
+spec on the column definition (`t.count('posts')`), carried through the
+fetch params, lowered by the Drizzle adapter into correlated-subquery
+SELECT/WHERE/ORDER BY (reusing the computed-fields pipeline), interpreted
+by `memoryAdapter` over nested arrays, and honest-by-default client
+computeds everywhere else. The acceptance scenario is the maintainer's own
+phrasing: **a users table with a `postsCount` column you can render, filter
+("more than 5 posts"), and sort — defined in one builder line.**
+
+## Current state
+
+Verified at `27c59b9` (all excerpts re-read at that commit):
+
+- `packages/core/src/builders/column-builder.ts:82-86` — builder defaults:
+
+  ```ts
+  sortable: true,
+  filterable: true,
+  ...
+  nullable: false,
+  ```
+
+- `packages/core/src/builders/path-builders.ts:305-310` — `t.computed`
+  constructs `new ColumnBuilder<TRow, TValue, TId>('custom')` (runtime type
+  `'custom'`; the honest-runtime note is at `:124-150`). `t.custom()` at
+  `:313` shares the class.
+
+- Drizzle derived-field engine:
+  - `packages/adapters/drizzle/src/types/computed-fields.ts:61-81` —
+    `ComputedFieldConfig { field; compute(row, ctx); filter?(filter, ctx) → FilterState[]; filterSql?(…) }`
+    (`filterSql` takes precedence; doc comment at `:74-80` explains it
+    applies in WHERE before pagination). `sortSql` exists — resolution at
+    `drizzle-adapter.ts:625-637` (`computedFieldsForSorting`,
+    `computedField?.sortSql`).
+  - Registration: `drizzle-adapter.ts:165` (`private computedFields`),
+    `:238-241` (from `config.computedFields`), `:451-460` (fetch-path
+    inclusion incl. `includeByDefault` handling).
+  - Tree gap: `drizzle-adapter.ts:1430` throws
+    `Computed-field filters inside a FilterGroupNode are not supported yet (columnId: "…"). Use a flat FilterState[] (implicit AND) for computed-field filters, or flatten the tree at the call site.`
+    — the comment at `:1414` says the substitution should learn to "walk
+    `FilterGroupNode`". Plan 051 item 5 investigated and deferred exactly
+    this (see `plans/README.md`, reconcile notes).
+- `packages/core/src/adapters/memory-adapter.ts` — single-table, no
+  relations; `describeColumns` samples row values; filter evaluation in
+  `matchesNode` handles trees. Memory rows MAY carry nested arrays (e.g.
+  `{ id, name, posts: [...] }`) — nothing uses them today.
+- `memoryAdapter` meta (`memory-adapter.ts:580-601`) — `supportedColumnTypes`
+  / `supportedOperators` derived from `FILTER_OPERATORS`; a
+  capability-declaration precedent for Step 2's `aggregates` meta field.
+- Design vocabulary (from `plans/design/table-definition-dx.md:309-352`):
+  capability contributions like `{ aggregates: ['count','sum'] }` merged
+  into `AdapterMeta` were explicitly reserved — use the word
+  **capabilities** and the key **aggregates**.
+- Dogfood target: the marketing demo schema has `posts` with
+  `postsRelations` (`apps/marketing/src/lib/db/schema.ts:47-62`,
+  `posts.user_id` FK in `src/lib/db/index.ts:58-68`), and the users demo is
+  fully on `defineTable<UsersTables>()` path builders
+  (`user-columns.tsx:40`).
+- Conventions: breaking/feature changesets `minor` on core/drizzle in the
+  0.6 window; integration tests for drizzle live in
+  `packages/adapters/drizzle/tests/` (sqlite suites run with no setup).
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---|---|---|
+| Core tests | `cd packages/core && bun test` | all pass |
+| Drizzle tests (sqlite) | `cd packages/adapters/drizzle && bun test` | all pass |
+| UI tests | `cd packages/ui && bun test` | all pass |
+| Marketing tests | `cd apps/marketing && bun test` | all pass |
+| Typecheck | `bun run typecheck` | exit 0 |
+| Live check | `cd apps/marketing && bun run dev` → `/` | Posts column renders; filter "> 5" narrows; sort orders |
+
+## Scope
+
+**In scope**:
+- `plans/design/derived-columns.md` (create — Step 1)
+- `packages/core/src/types/` (DerivedColumnSpec; `derived?` on
+  `ColumnDefinition`; `derived?` on `FetchDataParams`; `aggregates?` on
+  `AdapterMeta`)
+- `packages/core/src/builders/` (honest defaults for `'custom'`-typed
+  builders; `t.count` / `t.aggregate` factories in `path-builders.ts`)
+- `packages/core/src/factory.ts` (attach specs from the table definition on
+  the instance fetch path)
+- `packages/core/src/adapters/memory-adapter.ts` (nested-array aggregate
+  evaluation)
+- `packages/adapters/drizzle/src/**` (spec validation + lowering; tree-walk
+  substitution; the `:1430` error-message fix)
+- `packages/ui/src/hooks/use-table-data.ts` (attach specs client-side, same
+  seam as filters)
+- `apps/marketing/src/lib/columns/user-columns.tsx` +
+  `apps/marketing/src/lib/demo/fetch-users.ts` (dogfood `postsCount`)
+- Tests across core/drizzle/ui/marketing; docs
+  (`columns/index.mdx`, `filtering.mdx`, `adapters/custom.mdx`,
+  `adapters/drizzle.mdx`, `better-table.mdx`); `.changeset/*`;
+  `plans/README.md`
+
+**Out of scope** (do NOT touch):
+- Editing/writes on derived columns — never editable; the editing gate
+  already requires a write target, keep it that way.
+- Faceting on derived columns (`getMinMaxValues` for a count range slider)
+  — stretch goal; record as follow-up, do not build.
+- `GROUP BY`/`HAVING`-based implementations — see STOP conditions; the
+  prescribed shape is correlated subqueries precisely so pagination and
+  `total` counting are untouched.
+- The HTTP adapter — specs are serializable data on `FetchDataParams`; the
+  wire carries them with zero protocol changes (verify, don't modify).
+- Plan 048's group-builder UI.
+
+## Git workflow
+
+- Branch: current working branch unless the operator says otherwise;
+  commits `Plan 060 Step N: …`.
+
+## Steps
+
+### Step 1: Design record
+
+Write `plans/design/derived-columns.md` capturing (with the trade-offs, so
+future maintainers know why):
+
+1. **Spec shape** (serializable, declarative — NEVER functions or SQL
+   strings, because it crosses the HTTP wire and must be validated
+   server-side against the schema):
+
+   ```ts
+   interface DerivedColumnSpec {
+     kind: 'aggregate';
+     /** Relation name on the primary table (e.g. 'posts'). */
+     relation: string;
+     fn: 'count' | 'sum' | 'avg' | 'min' | 'max';
+     /** Required for sum/avg/min/max; ignored for count. */
+     field?: string;
+   }
+   ```
+
+   Result type mapping: `count` → `number`; others follow the target
+   field. (`distinct` from the toolkit union is deferred — record that.)
+
+2. **Transport decision**: specs ride `FetchDataParams.derived?:
+   Array<{ columnId: string } & DerivedColumnSpec>`, attached by the two
+   layers that own column definitions (core instance fetch; UI
+   `use-table-data`) — NOT adapter-constructor config. Rationale to
+   record: stateless per-request, works over HTTP unchanged, multi-table
+   safe, and keeps `defineTable` the single source of truth. The adapter
+   validates every spec against its schema/relationships and throws
+   `SchemaError` on unknown relation/field or non-many cardinality.
+3. **Security note**: declarative-only is the injection boundary — the
+   server builds SQL from an enum + schema-validated identifiers; a
+   malicious client can at worst request an aggregate over data the
+   endpoint already serves. HTTP allow-lists (docs `adapters/http.mdx`
+   pattern) apply to derived columnIds like any other id.
+4. **Honest defaults**: `'custom'`-typed builders (this covers
+   `t.computed` and `t.custom`) flip to `filterable: false, sortable:
+   false` at construction; aggregate builders set `derived` AND leave
+   filterable/sortable available (default ON — they're server-backed).
+5. **Capability declaration**: `AdapterMeta.capabilities?: { aggregates?:
+   DerivedColumnSpec['fn'][] }` (the design-doc vocabulary). Core's
+   instance fetch throws early with a clear error when specs are present
+   and the adapter doesn't declare the capability.
+   **Weigh per-operation granularity here** (plan 061's finding): Prisma
+   can SELECT and ORDER BY a relation count but cannot WHERE-by-count, so
+   a flat fn-list can't describe it — consider
+   `{ aggregates?: { fns: [...], render: boolean, sort: boolean, filter: boolean } }`
+   (or per-fn flags). Decide now and record it — 061 Phase 7 and 062
+   Step 6 declare against whatever shape this step picks.
+
+**Verify**: the record exists and states all five decisions.
+
+### Step 2: Core types + builders + honest defaults
+
+1. Types per the design record (`DerivedColumnSpec`, `ColumnDefinition.derived?`,
+   `FetchDataParams.derived?`, `AdapterMeta.capabilities?`), exported from
+   the barrel.
+2. `path-builders.ts`: `t.count(relation)` (id defaults to
+   `${relation}Count`, type `'number'`, `derived: { kind: 'aggregate',
+   relation, fn: 'count' }`) and `t.aggregate(id, spec)` for the general
+   form. Both return a NumberColumnBuilder-shaped builder so `.range()` /
+   number operators work. Runtime validation of `field` presence for
+   non-count fns.
+3. Flip the `'custom'` default: in `column-builder.ts`, when the
+   constructor type is `'custom'`, initialize `filterable: false, sortable:
+   false` (explicit `.filterable()` still re-enables). Update
+   `user-columns.tsx`'s `hasBio`/`roleTags` comment to say the default now
+   handles this (keep or drop the explicit flags — keep the test in
+   `apps/marketing/src/lib/columns/user-columns.test.ts` green either way).
+4. `factory.ts` instance fetch: collect `derived` specs from
+   `table.columns`, attach to params, and enforce the capability check
+   (clear error naming the adapter and the missing capability).
+
+**Verify**: `cd packages/core && bun test` — new tests: builder produces
+the spec; custom/computed default to non-filterable/sortable
+(`@ts-expect-error`-free runtime asserts); instance fetch attaches specs;
+capability check throws against a `memoryAdapter` **before** Step 4 adds
+its support (temporarily assert the error, then flip the test in Step 4 —
+or write the capability test against a stub adapter with no capabilities).
+
+### Step 3: Drizzle lowering (SELECT + WHERE + ORDER BY, tree-aware)
+
+1. Validate incoming specs against the relationship map (relation exists on
+   the primary table, cardinality `'many'`; `field` exists and is numeric
+   for sum/avg). Unknown → `SchemaError` with the resolver suggestion
+   pattern the adapter already uses.
+2. SELECT: for each requested derived column, emit a correlated subquery
+   (`(SELECT count(*) FROM posts WHERE posts.user_id = users.id) AS "postsCount"`)
+   — build identifiers from the relationship metadata, never from raw
+   client strings. Internally, lower each spec into the EXISTING
+   computed-fields pipeline (register an internal `ComputedFieldConfig`
+   with `filterSql`/`sortSql` generated from the spec) so filtering and
+   sorting reuse the machinery at `:625-637` and the substitution path —
+   do not build a parallel pipeline.
+3. Filters: derived-column filters lower to the same subquery expression in
+   WHERE (`(SELECT …) > ?`). **Extend the substitution to walk
+   `FilterGroupNode` trees** (the `:1414` TODO): a derived/computed filter
+   at any depth substitutes in place, preserving group logic. Delete the
+   `:1430` flat-only throw for specs-backed columns; for legacy
+   config-`computedFields` using the callback `filter` form, keep the
+   throw but FIX its advice text (flattening is only valid for
+   AND-equivalent trees — say "restructure so computed-field filters are
+   top-level AND'd, or use filterSql").
+4. Sorting: derived ids resolve through the same registered `sortSql`.
+
+**Verify**: `cd packages/adapters/drizzle && bun test` — new sqlite
+integration tests: count renders per row; `greaterThan` filter on count
+narrows (top-level AND); the SAME filter nested inside an OR group works
+(tree walk); sort by count orders; unknown relation → `SchemaError`;
+`sum` over a numeric field. Pattern: existing sqlite relationship suites.
+
+### Step 4: memoryAdapter aggregates over nested arrays
+
+When a derived spec arrives: `count` → `Array.isArray(row[relation]) ?
+row[relation].length : 0`; sum/avg/min/max over `row[relation][].field`
+numeric values. Declare `capabilities.aggregates` in its meta. Non-array
+relation value → treat as empty (0/undefined), matching the "no rows"
+semantics. Filters/sort on the derived id then flow through the existing
+evaluation (inject the computed value before `matchesNode`/sort compare —
+follow how accessors feed filtering today).
+
+**Verify**: core tests — memory rows with nested `posts` arrays: count
+renders, filters (including inside an OR tree), sorts; capability check
+from Step 2 now passes for memory.
+
+### Step 5: UI pass-through + dogfood
+
+1. `use-table-data.ts`: attach specs from its columns to fetch params (same
+   spot filters are built). No new UI components — a count column is a
+   number column: existing number filter input and sort header just work.
+2. Dogfood: `user-columns.tsx` adds
+   `t.count('posts').displayName('Posts')` (visible by default —
+   add to `defaultVisibleColumns`); `fetch-users.ts` includes it in the
+   fetched columns list.
+
+**Verify**: `cd apps/marketing && bun test` (extend
+`user-columns.test.ts`: the derived column exists, is
+filterable+sortable, has `derived.kind === 'aggregate'`); manual: dev
+server on `/` — Posts column shows counts; number filter "> 5" narrows;
+header sort orders by count; combining with an existing filter (e.g.
+status) still paginates correctly with a correct `total`.
+
+### Step 6: Docs + changesets + ledger
+
+- `columns/index.mdx`: "Derived columns" section — `t.count` /
+  `t.aggregate`, the one-liner acceptance example, and the honest-defaults
+  note for `t.computed` (client-only, no filter/sort by default).
+- `filtering.mdx`: derived columns filter with number operators,
+  tree-supported.
+- `adapters/custom.mdx`: `FetchDataParams.derived`, `SchemaError`
+  expectations, `capabilities.aggregates`, and the security note (specs
+  are declarative; validate identifiers against your schema).
+- `adapters/drizzle.mdx`: subquery strategy + an indexing tip (index the
+  FK column, e.g. `posts.user_id`).
+- `better-table.mdx`: nothing new needed beyond the columns link — verify.
+- Changesets: `@better-tables/core` minor (spec types, builders,
+  honest `'custom'` defaults — note the default FLIP as breaking-in-window),
+  `@better-tables/adapters-drizzle` minor (lowering + tree walk + error-text
+  fix).
+- Update this plan's row; move plan 051 item 5's "computed-TREE deferred"
+  note to resolved-for-specs (README reconcile note).
+
+**Verify**: docs greps for `t.count(` ≥ 2 pages; `bunx biome check .changeset/` clean.
+
+## Test plan
+
+- Core: builder/spec unit tests; honest-default tests; instance
+  attach + capability-check tests; memory aggregate tests (count/sum, tree
+  filter, sort). Patterns: `packages/core/tests/builders/`,
+  `packages/core/tests/adapters/memory-adapter.test.ts`.
+- Drizzle: the Step 3 integration matrix (render/filter/tree-filter/sort/
+  SchemaError/sum) on sqlite. Pattern: existing relationship suites in
+  `packages/adapters/drizzle/tests/`.
+- Marketing: extended column-contract test + manual browser scenario
+  (record in the PR).
+
+## Done criteria
+
+Machine-checkable. ALL must hold:
+
+- [ ] `t.count('posts')` on the homepage users table renders counts, filters (`greaterThan`), and sorts via real SQL (drizzle sqlite integration tests pass)
+- [ ] A derived-column filter nested inside an OR `FilterGroupNode` returns union semantics (test passes)
+- [ ] `t.computed` columns default to `filterable: false, sortable: false` (core test)
+- [ ] `memoryAdapter` evaluates count/sum over nested arrays (core tests)
+- [ ] The `:1430` error text no longer recommends unconditional flattening (`grep -n "flatten the tree" packages/adapters/drizzle/src` → no match)
+- [ ] `bun run typecheck` exit 0; core/drizzle/ui/marketing suites pass
+- [ ] Both changesets exist; docs sections exist; `plans/README.md` updated
+
+## STOP conditions
+
+Stop and report back (do not improvise) if:
+
+- The relationship metadata cannot answer "which FK links `posts` back to
+  `users`" for the demo schema (i.e. reverse/one-to-many resolution is
+  missing from the relationship map) — report what's available instead of
+  guessing join keys.
+- Correlated-subquery filtering breaks pagination `total` correctness or
+  requires switching to GROUP BY/HAVING — that changes row-multiplicity
+  semantics the adapter has hardening around (plan 003's count-inflation
+  work); report with the failing query.
+- The tree-walk substitution requires restructuring the group-translation
+  code beyond substitution (i.e. you're rewriting plan 017's translator) —
+  report.
+- Dialect divergence: a subquery form that works on sqlite fails on
+  pg/mysql paths in code review — flag it; do not fork per-dialect SQL
+  without review.
+- Performance: if the demo page visibly degrades (subquery per derived
+  column per row is the accepted v1 cost — but if sqlite shows >2×
+  fetch-time regression on the 100-row demo, report numbers).
+
+## Maintenance notes
+
+- Facet support (`getMinMaxValues` on a derived column → count range
+  slider) is the natural fast-follow; the spec transport already carries
+  what it needs.
+- `distinct` and nested-relation aggregates (`t.count('posts.comments')`)
+  are deferred — the spec's `relation` field is a single hop by design;
+  extending to paths reuses `RelationshipPath[]` (toolkit
+  `AggregateColumn` already models that shape).
+- Type-level relation-name inference for `t.count` (autocomplete from
+  `$types`) is a stretch the executor may attempt ONLY if it falls out of
+  the existing path-builder typing; otherwise runtime validation is the
+  contract — note which one shipped.
+- Reviewer scrutiny: identifier construction in the subquery builder (must
+  come from schema metadata, never client strings), the tree-walk's
+  in-place substitution correctness, and the capability check's error
+  message quality.

--- a/plans/061-prisma-adapter-full-parity.md
+++ b/plans/061-prisma-adapter-full-parity.md
@@ -1,0 +1,356 @@
+# Plan 061: Prisma adapter at full Drizzle parity (supersedes 008)
+
+> **Executor instructions**: Phased BUILD plan — each phase is a mergeable
+> unit with its own verification; do not start a phase until the previous
+> one's criteria pass. Run every verification command and confirm the
+> expected result before moving on. If anything in the "STOP conditions"
+> section occurs, stop and report — do not improvise. When done (or when a
+> phase lands), update the status row in `plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat 27c59b9..HEAD -- packages/adapters packages/core/src/types/adapter.ts .github/workflows/test.yml tsconfig.json`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P2
+- **Effort**: L (phased; expect multiple PRs)
+- **Risk**: MED (new package — nothing existing breaks; risk is semantic drift between adapters, mitigated by the conformance suite in Phase 1)
+- **Depends on**: none hard. 057/058 (contract cleanup/search) land first if scheduled — they SHRINK what this plan must implement. The aggregates phase (Phase 7) requires plan 060's spec types; skip it cleanly if 060 hasn't landed.
+- **Category**: direction
+- **Planned at**: commit `27c59b9`, 2026-07-20
+- **Supersedes**: plan 008 (read-path spike, ON HOLD since 2026-07-13, never executed). Its still-valid research is inlined below; 008 is retired in the ledger.
+- **Maintainer decision (2026-07-20)**: the Prisma plan must be the COMPLETE
+  adapter replacement for Drizzle — full contract parity, not a spike. This
+  replaces the 2026-07-13 PRISMA HOLD as the standing directive; execution
+  order still belongs to the maintainer via the ledger.
+
+## Why this matters
+
+Prisma is the largest-audience ORM in the TypeScript ecosystem and the
+named first expansion target. Today `@better-tables/adapters-drizzle` is
+the only database adapter, so "bring your own ORM" is marketing, not fact.
+A full-parity Prisma adapter (a) opens the biggest user funnel, (b) is the
+honest test of the toolkit extracted in plan 007 — its ports were shaped
+against one consumer — and (c) forces a reusable **adapter conformance
+suite** into existence, which every future adapter (Kysely — plan 062,
+memory, Prisma) then shares. "Parity" means: everything the Drizzle
+adapter actually implements, with identical observable semantics, or an
+honestly-declared capability gap in `AdapterMeta`.
+
+## Current state
+
+Verified at `27c59b9`:
+
+- **The parity bar** — what the Drizzle adapter really implements today:
+  - `fetchData`: flat + `FilterGroupNode` tree filters, multi-sort,
+    1-based pagination, dotted relation paths with JOINs, `columns`
+    selection, `primaryTable`/`options.defaultPrimaryTable` resolution,
+    computed-fields pipeline (`drizzle-adapter.ts:165,238-241,451-460`),
+    LRU caching (`adapter-cache.ts`).
+  - Facets: `getFilterOptions`, `getFacetedValues` (filter-aware with
+    self-exclusion — plan 021; top-100 LIMIT — plan 040),
+    `getMinMaxValues`.
+  - Schema: `describeColumns` (plan 054) — name/type/nullability/enum
+    options/writability (`InferredColumnSpec[]`).
+  - Writes: `createRecord`/`updateRecord`/`deleteRecord` (plan 047),
+    `bulkUpdate`/`bulkDelete`, `resolveCellWriteTarget` for dotted-path
+    cell edits incl. related-row writes (plan 055).
+  - Events: `subscribe` with insert/update/delete emission on mutations
+    (`drizzle-adapter.ts:1337`, emits at `:1161/:1196/:1227/:1259/:1290`).
+  - Export: `exportData` (`drizzle-adapter.ts:1304`) with CSV
+    formula-escaping via `packages/adapters/drizzle/src/export-format.ts`
+    (small: 3 exports — liftable).
+  - `meta`: `features` flags, `supportedColumnTypes`,
+    `supportedOperators`, `supportsFilterGroups: true`.
+- **The contract**: `TableAdapter` in `packages/core/src/types/adapter.ts`
+  (required: `fetchData:227`, `getFilterOptions:241`,
+  `getFacetedValues:255`, `getMinMaxValues:269`, `meta:380`; optional:
+  `describeColumns:445`, `exportData:537`, `subscribe:555`, mutations,
+  `resolveCellWriteTarget`). Note plan 057 may remove dead fields and plan
+  058 removes `FetchDataParams.search` — implement against whatever the
+  contract is at execution time (drift check will tell you).
+- **Toolkit** (`packages/adapters/toolkit/src/index.ts`): `FilterRouter` +
+  `PredicateEmitter` (+ `computeDatePeriodRange`, `FilterRouterError`),
+  `DataTransformer`, `PrimaryTableResolver`, `SchemaIntrospectionPort` /
+  `RelationshipManagerPort`, alias + PK + SQL-identifier utils,
+  `calculateLevenshteinDistance`, `SchemaError`. The Drizzle adapter is
+  the reference composition; `memoryAdapter`
+  (`packages/core/src/adapters/memory-adapter.ts`) is a second, simpler
+  contract consumer.
+- **Structural difference to design around** (from 008's research, still
+  valid): Drizzle builds SQL (joins + aliases, flat rows re-nested by
+  `DataTransformer`); Prisma builds a **query object**
+  (`where`/`orderBy`/`skip`/`take`/`include`/`select`) and returns
+  already-nested objects. Expect: a `PrismaPredicateEmitter` emitting
+  Prisma `where` fragments (text ops with `mode: 'insensitive'` where the
+  provider supports it — SQLite's `contains` is already case-insensitive
+  and REJECTS `mode`; normalize in the emitter); dotted paths become
+  nested objects (`'profile.location'` → `where: { profile: { location: … } }`,
+  `include: { profile: true }`, `orderBy: { profile: { location: 'asc' } }`);
+  NO alias-generator / NO `DataTransformer` on the read path. `total` via
+  `count({ where })` — Prisma counts parents naturally, so the plan-003
+  join-inflation bug class doesn't apply (assert it anyway in tests).
+  Case-insensitivity parity with Drizzle's text ops must be ASSERTED, not
+  assumed. Use Context7/Prisma docs for current API syntax — do not rely
+  on memorized shapes.
+- **Schema introspection**: Prisma exposes runtime DMMF
+  (`Prisma.dmmf.datamodel` — models, fields, types, relations, enums) —
+  the raw material for `describeColumns`, relation resolution, and
+  `resolveCellWriteTarget`, replacing Drizzle's schema-object walking.
+- **Repo mechanics**:
+  - Package scaffold: mirror `packages/adapters/drizzle/package.json`
+    (name `@better-tables/adapters-prisma`, tsdown, exports map,
+    `publishConfig.access: public`; peers: `@better-tables/core:
+    workspace:*` + `@prisma/client` with a tested version range; devDeps:
+    `prisma` CLI + `@prisma/client`).
+  - Root `tsconfig.json:24-27` paths — add
+    `"@better-tables/adapters-prisma": ["./packages/adapters/prisma/src"]`
+    (note the existing drizzle mapping uses the OLD name
+    `@better-tables/drizzle` — leave it; add the new one under the real
+    package name).
+  - CI: `.github/workflows/test.yml:321-322` — `test-adapters` job (“Test
+    Adapter Packages”); it needs a `bunx prisma generate` (and test-schema
+    push) step before running prisma tests.
+  - Tests: SQLite via `tests/schema.prisma` (`provider = "sqlite"`), temp
+    file DB, `bunx prisma generate` + `bunx prisma db push` in setup — no
+    external services. If client generation fails under Bun, see STOP.
+  - Changesets: new-package `minor` entries; Prisma package README
+    required (npm-facing — model on
+    `packages/adapters/drizzle/README.md`).
+- **Known Prisma capability gap to handle honestly** (matters for Phase
+  7): Prisma supports ORDER BY relation count
+  (`orderBy: { posts: { _count: 'desc' } }`) and SELECTing counts
+  (`_count`), but has NO native WHERE-by-relation-count. So derived
+  aggregates on Prisma can render + sort but not filter without raw SQL.
+  Plan 060's `AdapterMeta.capabilities.aggregates` may need per-operation
+  granularity (`{ render, sort, filter }`) — 060's design step has a note
+  to consider this; coordinate.
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---|---|---|
+| Install | `bun install` (root) | exit 0 |
+| Generate client | `cd packages/adapters/prisma && bunx prisma generate --schema tests/schema.prisma` | exit 0 |
+| Push test DB | `bunx prisma db push --schema tests/schema.prisma` | exit 0 |
+| Package tests | `cd packages/adapters/prisma && bun test` | all pass |
+| Conformance (all adapters) | `cd packages/adapters/conformance && bun test` | all pass |
+| Typecheck | `bun run typecheck` | exit 0 |
+| Build | `bun run build` | exit 0 |
+
+## Scope
+
+**In scope**:
+- `packages/adapters/prisma/**` (create everything)
+- `packages/adapters/conformance/**` (create — Phase 1's shared suite; private package)
+- `packages/adapters/toolkit/src/**` — ONLY the export-format lift (Phase 6) and any port-interface adjustment that Phase 2 proves necessary (each such change needs its own changeset + drizzle re-verification)
+- `packages/adapters/drizzle/**` — ONLY re-pointing to lifted toolkit modules + wiring the conformance suite (no behavior changes)
+- Root `tsconfig.json` (path mapping), `.github/workflows/test.yml`
+  (prisma generate step in `test-adapters`)
+- Docs: `apps/marketing/content/docs/adapters/prisma.mdx` (create) +
+  `adapters/meta.json` + `adapters/index.mdx` card +
+  `packages/adapters-prisma.mdx` + `packages/index.mdx` + `packages/meta.json` + `wiki.md`
+- `.changeset/*.md`; `plans/README.md`; `CLAUDE.md` package map
+
+**Out of scope** (do NOT touch):
+- Core contract changes — if a port doesn't fit, adjust the TOOLKIT seam
+  (with drizzle re-verified), never `packages/core/src/types/adapter.ts`.
+- Prisma-side migrations tooling, multi-schema, driver adapters preview
+  features — plain `PrismaClient` only.
+- `subscribe` beyond local mutation emission (parity, not realtime infra).
+- UI changes of any kind.
+
+## Git workflow
+
+- Branch per phase off the current mainline (`prisma-adapter-phase-N`) or
+  one branch with phase commits — operator's choice; commits
+  `Plan 061 Phase N: …`.
+
+## Steps
+
+### Phase 1: Adapter conformance suite (the parity instrument)
+
+Create private package `packages/adapters/conformance` exporting
+`runAdapterConformanceSuite(name, makeAdapter, options)` for bun:test:
+a factory returning `{ adapter, seed }` over the canonical two-table+
+relations shape this repo tests everywhere (users 1-1 profile, users 1-N
+posts — mirror the drizzle sqlite suites and `tests/schema.prisma` below).
+The suite encodes OBSERVED Drizzle behavior as the spec, parameterized by
+declared capabilities (skip blocks the adapter's `meta` doesn't declare):
+
+- fetch: pagination math (`total`/`totalPages`/`hasNext`), every operator
+  family per column type, flat AND + OR/nested trees, dotted-path filter/
+  sort, `columns` selection, cross-1-N `total` correctness (plan-003
+  class), case-insensitive text `contains`.
+- facets: `getFilterOptions` distinct+labels, `getFacetedValues`
+  self-exclusion + top-100 cap, `getMinMaxValues`.
+- schema: `describeColumns` field/type/nullability/enum-options/writability.
+- writes (when declared): create/update/delete round-trips, bulk variants,
+  `resolveCellWriteTarget` own-table + related-row, mutation events via
+  `subscribe`.
+- export (when declared): CSV shape + formula-escaping.
+
+Wire it to **memoryAdapter and Drizzle first** — both must pass before any
+Prisma code exists (that proves the suite, and any drizzle failure is a
+pre-existing bug to report, not to fix here).
+
+**Verify**: `cd packages/adapters/conformance && bun test` → memory +
+drizzle green. Record skipped-capability counts per adapter in the test
+output.
+
+### Phase 2: Scaffold + `PrismaPredicateEmitter`
+
+Package scaffold per Current state; `tests/schema.prisma` (SQLite) with
+the canonical schema + deterministic seed helpers. Implement the emitter
+against the toolkit `PredicateEmitter` seam, covering the FULL operator
+registry (`packages/core/src/types/filter-operators.ts`): text family
+(insensitivity normalization per provider), number, date (absolute +
+relative via `computeDatePeriodRange`), option (`is/isNot/isAnyOf/isNoneOf`
+→ equals/not/in/notIn), multiOption (Prisma list/array ops where the
+provider supports them — SQLite lacks scalar lists: declare per-provider
+in `supportedOperators` instead of faking), boolean, `isNull/isNotNull`,
+json (`contains/equals/isEmpty/isNotEmpty` best-effort per provider —
+declare honestly).
+
+**Verify**: emitter unit tests per family (`tests/predicate-emitter.test.ts`)
+→ pass; `bun run typecheck` exit 0.
+
+### Phase 3: Read path — `fetchData` + tree translation
+
+Compose: `PrimaryTableResolver` over the DMMF model map (record fit/
+friction); dotted ids → nested `where`/`include`/`orderBy`; `FilterRouter`
++ emitter for leaves; recursive `FilterGroupNode` → `AND:[…]/OR:[…]`
+(`NOT` where trees produce it); `skip`/`take` pagination; `total` via
+`count({ where })`; assemble `FetchDataResult`. No DataTransformer (rows
+arrive nested) — assert relation objects land under the same keys the
+Drizzle+transformer path produces (`row.profile.location`).
+
+**Verify**: hook Prisma into the Phase 1 conformance suite with
+capabilities `{ read: true }` — fetch + tree + dotted-path + total blocks
+green.
+
+### Phase 4: Facets trio
+
+`getFilterOptions` (distinct values), `getFacetedValues` (`groupBy` +
+`_count`, WITH self-exclusion of the target column's own filter and the
+top-100 cap — match plans 021/040 semantics exactly), `getMinMaxValues`
+(`aggregate` `_min/_max`).
+
+**Verify**: conformance facet blocks green for Prisma.
+
+### Phase 5: Schema + typed factory
+
+`describeColumns` from DMMF (fields → `InferredColumnSpec`: type mapping
+table, nullability, enum values as options, `writable` from
+id/updatedAt/relation rules); `prismaAdapter(client, options?)` typed
+factory — model map from the client type (`keyof` minus `$`-members), zero
+manual generics at the call site, `options.defaultPrimaryTable` parity,
+unknown-table `SchemaError` with levenshtein suggestions. Attempt the
+`$types` schema-catalog protocol (per-model relation-aware row types via
+`Prisma.<Model>GetPayload` depth-1) so `defineTable<Tables>()` path
+builders autocomplete — if the generated types can't satisfy it without
+codegen, deliver the runtime factory and record the exact type-level
+blocker in the findings section of the PR (this was 008's riskiest
+question; answer it with evidence).
+
+**Verify**: conformance schema block green; a compile-only test proves
+`betterTables({ database: prismaAdapter(new PrismaClient()) })` +
+`defineTable<typeof tables>()('user', t => [t.text('name'),
+t.text('profile.location')])` typechecks (or the recorded blocker).
+
+### Phase 6: Writes, events, export
+
+Mutations + bulk + `resolveCellWriteTarget` (DMMF relation metadata:
+dotted id → `{ table, field, relatedIdPath, single, writable }`; 1-N paths
+never single); local `subscribe` emission on all five mutation sites
+(drizzle parity). Export: FIRST lift `export-format.ts` out of drizzle
+into the toolkit (3 exports; drizzle re-imports; its tests stay green —
+separate commit + changesets for toolkit/drizzle), THEN implement
+`exportData` on Prisma reusing it, including the plan-050 row-cap decision
+if 050 has landed (drift check).
+
+**Verify**: conformance write/export blocks green for Prisma; drizzle
+suite still green after the lift (`cd packages/adapters/drizzle && bun test`).
+
+### Phase 7 (gated on plan 060): Derived aggregates
+
+Lower `DerivedColumnSpec` per Prisma's real abilities: render via
+`_count`/aggregate selection; sort via `orderBy: { relation: { _count } }`;
+FILTER is not natively expressible — declare the capability honestly
+(coordinate with 060's capability shape; if 060 adopted per-op granularity,
+declare `{ render: true, sort: true, filter: false }`; if not, declare no
+aggregate capability and file the gap in the ledger). Do NOT reach for
+`$queryRaw` composition in v1.
+
+**Verify**: conformance aggregate blocks (from 060) green or cleanly
+skipped per declared capabilities; a test asserts the filter-capability
+error path gives an actionable message.
+
+### Phase 8: Docs, CI, publish surface, ledger
+
+Docs pages listed in Scope (model `adapters/prisma.mdx` on
+`adapters/drizzle.mdx`: factory options, provider notes, capability table
+incl. the aggregate-filter gap and multiOption-per-provider notes); CI
+generate step in `test-adapters`; package README; changesets
+(`@better-tables/adapters-prisma` minor — first release; toolkit/drizzle
+patches from Phase 6); `CLAUDE.md` package map row; `wiki.md`;
+`plans/README.md` rows (this plan + retire 008).
+
+**Verify**: `bun run build` + root typecheck green; CI config change
+exercised by pushing the branch (adapter job runs prisma generate); docs
+links resolve (`grep -rn "adapters/prisma" apps/marketing/content/docs/ | wc -l` ≥ 3).
+
+## Test plan
+
+- The conformance suite IS the test plan's spine (Phase 1) — memory,
+  drizzle, prisma all run it; capability-skips are printed, not silent.
+- Prisma-only additions: emitter unit tests; provider-quirk tests
+  (SQLite insensitive-`contains` normalization, multiOption declared-out);
+  DMMF describeColumns snapshots; `$types` compile test; capability-error
+  test (Phase 7).
+- Patterns: `packages/adapters/drizzle/tests/` sqlite suites;
+  `packages/core/tests/adapters/memory-adapter.test.ts`.
+
+## Done criteria
+
+Machine-checkable. ALL must hold:
+
+- [ ] `packages/adapters/conformance` exists; memory + drizzle + prisma all run it green (prisma's skips limited to honestly-declared gaps)
+- [ ] Prisma passes: tree filters, dotted-path filter/sort, self-excluding facets, describeColumns, all writes + `resolveCellWriteTarget`, mutation events, exportData
+- [ ] `meta.supportedOperators`/`features`/capabilities match implemented reality (a conformance meta-honesty check asserts this)
+- [ ] `bun run build` + `bun run typecheck` + all package suites green; CI adapter job generates the client and passes
+- [ ] Docs pages exist and are linked (adapters nav + packages matrix + wiki.md + CLAUDE.md)
+- [ ] Changesets exist; `plans/README.md` updated (this row DONE-or-phase-status; 008 marked SUPERSEDED)
+
+## STOP conditions
+
+Stop and report back (do not improvise) if:
+
+- Drizzle or memory FAIL the Phase 1 conformance suite — that's a
+  pre-existing semantic bug or a wrong spec encoding; report before
+  building Prisma against it.
+- A toolkit port cannot express a Prisma need without modification —
+  propose the minimal seam change, get it reviewed, land it with drizzle
+  re-verified BEFORE continuing (do not fork a private copy of the port).
+- `@prisma/client` generation is unworkable under Bun in this repo — try
+  the documented workaround once, then report (decides the test rig).
+- The zero-generics factory requires hidden `any` — ship the explicit-
+  generic escape hatch and flag it; never hidden `any`.
+- Case-insensitivity or null-ordering semantics cannot be made to match
+  Drizzle on some provider — report the matrix; silent semantic drift
+  between adapters is the worst failure mode.
+
+## Maintenance notes
+
+- The conformance suite is now the contract's executable spec: every
+  future adapter (Kysely — plan 062 — depends on Phases 1+6 here) starts
+  by running it; contract changes must update it first.
+- The Prisma aggregate-filter gap should be revisited whenever Prisma
+  ships relation-count filtering; the capability declaration makes that a
+  one-line flip plus tests.
+- Reviewer scrutiny per phase: emitter semantics vs drizzle (Phase 2),
+  nested-vs-flat row shape parity (Phase 3), self-exclusion correctness
+  (Phase 4), DMMF writability rules (Phase 5/6), and that no phase touched
+  core types.

--- a/plans/062-kysely-adapter.md
+++ b/plans/062-kysely-adapter.md
@@ -1,0 +1,272 @@
+# Plan 062: Kysely adapter — the SQL-native second adapter on the conformance suite
+
+> **Executor instructions**: BUILD plan. Requires plan 061's Phase 1
+> (conformance suite) and Phase 6 (toolkit export-format lift) to have
+> landed — verify via the drift check before starting. Run every
+> verification command and confirm the expected result before moving on.
+> If anything in the "STOP conditions" section occurs, stop and report —
+> do not improvise. When done, update the status row in `plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat 27c59b9..HEAD -- packages/adapters plans/061-prisma-adapter-full-parity.md`
+> Confirm `packages/adapters/conformance/` exists and the toolkit exports
+> the lifted export-format util. If either is missing, STOP — execute 061
+> Phases 1+6 first (or report to the maintainer to reorder).
+
+## Status
+
+- **Priority**: P3
+- **Effort**: L
+- **Risk**: MED (new package; the novel surface is runtime schema introspection and a required relationships config)
+- **Depends on**: 061 Phases 1 + 6 (conformance suite; shared export-format). Aggregates phase gated on plan 060 like 061's Phase 7 — but note Kysely reaches FULL aggregate parity (render+sort+filter), unlike Prisma.
+- **Category**: direction
+- **Planned at**: commit `27c59b9`, 2026-07-20
+- **Maintainer decision (2026-07-20)**: build a Kysely adapter as the next
+  adapter after Prisma.
+
+## Why this matters
+
+Kysely is the type-safe SQL builder the "I don't want an ORM" segment
+standardized on, and it is the most toolkit-native adapter possible: it
+speaks SQL expressions directly, so `FilterRouter`/`PredicateEmitter`,
+alias generation, and `DataTransformer` (flat JOINed rows → nested
+objects) are exercised exactly as the Drizzle adapter exercises them —
+where Prisma (plan 061) bypasses the transformer/alias machinery entirely.
+Between the three, the toolkit's claim of ORM-agnosticism is finally
+tested from both directions: object-query ORMs (Prisma) and SQL builders
+(Kysely). Kysely also has no schema/relations runtime metadata of its own,
+which forces this plan to prove the adapter story for "bring your own
+relationship map" — the same shape future raw-SQL adapters need.
+
+## Current state
+
+Verified at `27c59b9` (plus the 061 prerequisites the drift check
+confirms):
+
+- **What Kysely gives you** (verify against current docs via Context7 —
+  do not trust memorized API):
+  - Query building: `db.selectFrom('users').leftJoin(…).where(eb => …)`
+    with an expression builder — a direct fit for a `PredicateEmitter`
+    that returns Kysely expression fragments.
+  - Runtime introspection: `db.introspection.getTables()`
+    (`DatabaseIntrospector`) → per-table `TableMetadata` with columns
+    (name, dataType, isNullable, hasDefaultValue) — the raw material for
+    `describeColumns`. Data-type strings are DIALECT-SPECIFIC → a mapping
+    table per dialect (start: sqlite + postgres + mysql keyword maps).
+  - NO relations concept — relationship paths (`profile.location`) require
+    a user-supplied relationship map.
+- **The toolkit pieces this adapter composes** (all landed;
+  `packages/adapters/toolkit/src/index.ts`): `FilterRouter` +
+  `PredicateEmitter` + `computeDatePeriodRange`; `DataTransformer` (flat →
+  nested; the Kysely read path USES it, selecting joined columns under
+  path aliases exactly like Drizzle); `PrimaryTableResolver` +
+  `RelationshipMapLike`; `generateAlias`/`generatePathAlias`/
+  `generatePathKey`; `getPrimaryKeyInfo`/`getPrimaryKeyMap`;
+  `escapeSqlIdentifier`/`quoteIdentifier`; `SchemaError` +
+  `calculateLevenshteinDistance`.
+- **The relationships config precedent**: the Drizzle factory already
+  accepts a manual `relationships` map keyed by dotted path with
+  `{ from, to, foreignKey, localKey, cardinality, isArray?, nullable?, joinType? }`
+  (`packages/adapters/drizzle/src/factory.ts:48,165-167`; field semantics
+  per `RelationshipPath` in `packages/adapters/toolkit/src/types.ts:16-40`;
+  worked examples in
+  `packages/adapters/drizzle/docs/ADVANCED_USAGE.md` MySQL/SQLite
+  sections). The Kysely factory REQUIRES this map for any relationship
+  feature (there is nothing to auto-detect from); own-table usage works
+  with zero config.
+- **The parity instrument**: `packages/adapters/conformance` (created by
+  061 Phase 1) — memory, drizzle, prisma run it; Kysely joins them. The
+  suite is capability-parameterized; Kysely should declare near-full
+  capabilities (see phases).
+- **Conventions**: package scaffold mirrors
+  `packages/adapters/drizzle/package.json` (name
+  `@better-tables/adapters-kysely`, tsdown, exports map, publishConfig
+  public; peers: `@better-tables/core: workspace:*` + `kysely` with a
+  tested range; test devDep `better-sqlite3` — already in the workspace
+  catalog). Root `tsconfig.json:24-27` gains
+  `"@better-tables/adapters-kysely": ["./packages/adapters/kysely/src"]`.
+  CI: the `test-adapters` job (`.github/workflows/test.yml:321-322`) picks
+  the package up by path — no generate step needed (unlike Prisma).
+  Docs live under `apps/marketing/content/docs/adapters/` +
+  `packages/` matrix; changesets per package.
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---|---|---|
+| Install | `bun install` (root) | exit 0 |
+| Package tests | `cd packages/adapters/kysely && bun test` | all pass (SQLite in-memory via better-sqlite3 dialect) |
+| Conformance | `cd packages/adapters/conformance && bun test` | all adapters green |
+| Typecheck | `bun run typecheck` | exit 0 |
+| Build | `bun run build` | exit 0 |
+
+## Scope
+
+**In scope**:
+- `packages/adapters/kysely/**` (create everything: src, tests, README)
+- `packages/adapters/conformance/**` — ONLY wiring the Kysely factory into
+  the existing suite
+- Root `tsconfig.json` (path mapping)
+- Docs: `apps/marketing/content/docs/adapters/kysely.mdx` (create) +
+  `adapters/meta.json` + `adapters/index.mdx` card +
+  `packages/adapters-kysely.mdx` + `packages/index.mdx` +
+  `packages/meta.json` + `wiki.md` + `CLAUDE.md` package map
+- `.changeset/*.md`; `plans/README.md`
+
+**Out of scope** (do NOT touch):
+- `packages/core/**`, `packages/adapters/toolkit/**` (if a port doesn't
+  fit, STOP — after Prisma, a third misfit means the seam needs a
+  deliberate redesign, not another local workaround)
+- `packages/adapters/drizzle/**`, `packages/adapters/prisma/**`
+- FK auto-detection from `information_schema` — v1 is explicit
+  relationships config only; record auto-detection as a follow-up
+- Dialect-specific drivers beyond the sqlite test rig (pg/mysql type maps
+  ship as code, but integration tests against live pg/mysql follow the
+  drizzle pattern: env-gated suites, added only if cheap)
+
+## Git workflow
+
+- Branch: `kysely-adapter`; commits `Plan 062 Step N: …`.
+
+## Steps
+
+### Step 1: Scaffold + `KyselyPredicateEmitter`
+
+Package scaffold per Current state. Test rig: `kysely` +
+`better-sqlite3` dialect over an in-memory DB, canonical
+users/profile/posts schema + deterministic seed (mirror the conformance
+fixtures). Implement the emitter returning Kysely expression fragments for
+the FULL operator registry (`packages/core/src/types/filter-operators.ts`),
+including relative date operators via `computeDatePeriodRange` and
+LOWER()-based case-insensitive text ops (assert parity with Drizzle's
+semantics — the conformance suite checks it).
+
+**Verify**: emitter unit tests per operator family pass;
+`bun run typecheck` exit 0.
+
+### Step 2: Read path — `fetchData` with JOINs and the transformer
+
+Compose exactly like the Drizzle reference: resolve primary table
+(`PrimaryTableResolver` + `options.defaultPrimaryTable` parity); for
+dotted paths, LEFT JOIN via the relationships config using
+`generatePathAlias` aliases; select joined columns under path keys; route
+filters (`FilterRouter`, flat + `FilterGroupNode` recursion into
+`eb.and/eb.or`); multi-sort incl. joined columns; paginate
+(`limit/offset`, 1-based math); `total` via a parallel count query that
+counts DISTINCT primary rows (the plan-003 join-inflation class — the
+conformance suite asserts it); re-nest rows with `DataTransformer`.
+
+**Verify**: Kysely wired into the conformance suite with
+`{ read: true }` — fetch/tree/dotted-path/total blocks green.
+
+### Step 3: Facets trio
+
+`getFilterOptions` (SELECT DISTINCT), `getFacetedValues`
+(GROUP BY + count, self-exclusion of the target column's own filter,
+top-100 cap), `getMinMaxValues` (MIN/MAX) — plans 021/040 semantics.
+
+**Verify**: conformance facet blocks green.
+
+### Step 4: `describeColumns` via runtime introspection
+
+`db.introspection.getTables()` on first call, cached; map dialect
+`dataType` strings → `ColumnType` via per-dialect keyword tables (sqlite,
+postgres, mysql; unknown types → `custom` with a dev note); nullability
+from metadata; `writable` = not-PK (PK detection via `getPrimaryKeyInfo`
+against the relationships/PK config, falling back to `id` convention);
+enum options: postgres enums surface through introspection metadata where
+available — map when present, otherwise omit (facet fallback covers
+dropdowns). Declare the capability honestly.
+
+**Verify**: conformance schema block green on sqlite; unit tests for the
+pg/mysql type maps (pure functions, no live DB).
+
+### Step 5: Typed factory + writes + events + export
+
+- `kyselyAdapter(db, options)` — `TDatabase` inference from
+  `Kysely<TDatabase>` gives typed table/column names; `options` requires
+  `relationships` for any dotted-path use (clear `SchemaError` naming the
+  missing path otherwise) and accepts `defaultPrimaryTable`.
+  Attempt the `$types` catalog so `defineTable<typeof tables>()` path
+  builders autocomplete own-table columns from `TDatabase` (relation paths
+  type against the relationships config keys); record blocker if the
+  type-level story falls short — same evidence rule as 061 Phase 5.
+- Writes: insert/update/delete + bulk via Kysely builders; PK targeting via
+  `getPrimaryKeyMap`; `resolveCellWriteTarget` from the relationships
+  config (single-cardinality only); local `subscribe` emission on all
+  mutation sites (drizzle parity).
+- `exportData` reusing the toolkit-lifted export-format.
+
+**Verify**: conformance write/export/event blocks green; compile-only
+factory test (zero manual generics beyond `Kysely<DB>`'s own).
+
+### Step 6 (gated on plan 060): Derived aggregates — full parity
+
+Lower `DerivedColumnSpec` to correlated subqueries with the expression
+builder (`(SELECT count(*) FROM posts WHERE posts.user_id = users.id)`)
+for SELECT, WHERE (filter!), and ORDER BY — Kysely supports all three, so
+declare FULL aggregate capability (contrast with Prisma's sort-only; if
+060 adopted per-op capability granularity, declare all true).
+
+**Verify**: conformance aggregate blocks fully green (no skips).
+
+### Step 7: Docs + CI sanity + changesets + ledger
+
+Docs pages per Scope — `adapters/kysely.mdx` modeled on
+`adapters/drizzle.mdx`, with a prominent "Relationships are explicit
+config" section reusing the `RelationshipPath` field semantics and one
+worked map example; packages matrix + wiki + CLAUDE.md rows; changeset
+(`@better-tables/adapters-kysely` minor — first release); push branch and
+confirm the `test-adapters` CI job runs the new package; update
+`plans/README.md`.
+
+**Verify**: `bun run build` + root typecheck green; docs link greps
+resolve (`grep -rn "adapters/kysely" apps/marketing/content/docs/ | wc -l` ≥ 3).
+
+## Test plan
+
+- The conformance suite is the spine (identical spec across memory /
+  drizzle / prisma / kysely).
+- Kysely-only: emitter units; dialect type-map units; relationships-config
+  error paths (missing path → SchemaError with suggestion); introspection
+  caching; aggregate subquery SQL snapshots.
+- Patterns: `packages/adapters/drizzle/tests/` sqlite suites and the
+  conformance fixtures from 061.
+
+## Done criteria
+
+Machine-checkable. ALL must hold:
+
+- [ ] Kysely runs the conformance suite green with near-full declared capabilities (any skip is an honestly-declared, ledger-recorded gap)
+- [ ] Dotted-path filter/sort/facets work through the explicit relationships config; missing-config errors are actionable
+- [ ] `describeColumns` works from runtime introspection on sqlite; pg/mysql type maps unit-tested
+- [ ] Writes + `resolveCellWriteTarget` + events + export green
+- [ ] (If 060 landed) aggregates render/filter/sort all green — no capability skips
+- [ ] `bun run build` + `bun run typecheck` + all suites green; CI adapter job includes the package
+- [ ] Docs pages exist and are linked; changeset exists; `plans/README.md` updated
+
+## STOP conditions
+
+Stop and report back (do not improvise) if:
+
+- A toolkit port cannot express a Kysely need — after Drizzle and Prisma,
+  a third-consumer misfit means the seam needs deliberate redesign; report
+  the exact mismatch, do not fork or locally reimplement.
+- `db.introspection` cannot provide enough for `describeColumns` on
+  sqlite (the test dialect) — report what's available; do not silently
+  drop the capability.
+- The typed factory needs hidden `any` — explicit-generic escape hatch +
+  flag, never hidden `any`.
+- Conformance reveals a semantic mismatch you'd need to change the SUITE
+  to pass — the suite is the spec; report instead of loosening it.
+
+## Maintenance notes
+
+- FK auto-detection (postgres `information_schema` → relationships map
+  seeding) is the natural DX follow-up; the explicit-config contract stays
+  the source of truth either way.
+- A future raw-`sql`/`postgres.js` adapter should start from this package,
+  not from Drizzle — Kysely is the closest structural template for
+  SQL-native adapters.
+- Reviewer scrutiny: identifier handling in JOIN/alias construction (must
+  flow through the toolkit quoting utils), count-query distinctness, and
+  that `supportedOperators`/capabilities match implementation exactly.

--- a/plans/README.md
+++ b/plans/README.md
@@ -116,7 +116,7 @@ the breaking window.
 | [055](055-direct-save-path.md) | **Zero-boilerplate saves** — `tables.cellEditAction(def)` (serializable, `'use server'`-ready; the PRIMARY monolith path), `saveAction` prop, opt-in double-sided cell-oriented HTTP write proxy, **joined-table editing** (`resolveCellWriteTarget`; related-row writes proven in browser + integration test), dogfood on the direct path (custom route deleted) | 053, 054 | DONE — executor-run, advisor-reviewed (APPROVED), merged into `editable-cells` at `ec60f80` |
 | [048](048-filter-group-builder-ui.md) | Visual filter group-builder UI (nested AND/OR) — fast-follow, contract already shipped | 015/016/017 (done) | TODO (reconciled 2026-07-18 — finding valid; see plan's reconcile note) |
 | [049](049-plugin-hook-execution.md) | Execute the plugin hook seam (`beforeFetch`/`afterFetch`), validated by one real plugin | 018 (done) | TODO (reconciled 2026-07-18 — seam still stored-only; line refs refreshed) |
-| [050](050-export-ui.md) | Export UI: `ExportButton`/`useTableExport` + `csvExport()` plugin + row-cap decision | 049, **059** | TODO (reconciled 2026-07-18; **2026-07-20: refresh against `plans/design/ui-modules.md` before executing — `ExportButton` rides 059's `toolbarExtra` slot and ships as an `export` module; `TableConfig.exportOptions` is removed by 057, reintroduce only what the module needs as module-local props**) |
+| [050](050-export-ui.md) | Export UI: `ExportButton`/`useTableExport` + `csvExport()` plugin + row-cap decision | 049, **059** | TODO (reconciled 2026-07-18; **2026-07-20: refresh against `plans/design/ui-modules.md` (created by 059 Step 1) before executing — `ExportButton` rides 059's `toolbarExtra` slot and ships as an `export` module; `TableConfig.exportOptions` is removed by 057, reintroduce only what the module needs as module-local props**) |
 | 008 | Prisma adapter spike (read path) | — | **SUPERSEDED** by [061](061-prisma-adapter-full-parity.md) (2026-07-20 maintainer directive: full parity, not a spike; 008's research is inlined there) |
 
 ### Wave D — maintainer-requested (planned 2026-07-20 at `27c59b9`)
@@ -195,7 +195,8 @@ Notes for the record (all acceptable, none require action):
   060 both extend the instance fetch path in `packages/core/src/factory.ts`
   — land in either order, rebase the second. **050 executes only after 059**
   (slot seam + module packaging) and after refreshing its plan text against
-  `plans/design/ui-modules.md`. 049 remains independent (core-tier hooks);
+  `plans/design/ui-modules.md` (created by 059 Step 1 — a forward deliverable,
+  not an existing prerequisite). 049 remains independent (core-tier hooks);
   its vocabulary rule — core tier = "plugins", copied-UI tier = "modules" —
   is defined in 059.
 - **Wave E ordering**: 061 is phased and mergeable per phase; its Phase 1

--- a/plans/README.md
+++ b/plans/README.md
@@ -7,7 +7,7 @@ starting, honor its STOP conditions, and update your status row when done
 line — detailed execution history lives in each plan file and in git history.
 
 Layout: **maintainer policies** → **current status** → **outstanding work**
-(the full 033–052 plan roster, execution order, runbook, maintainer
+(the 033–060 plan roster, execution order, runbook, maintainer
 decisions) → **operational notes** → **done archive** → **considered and
 rejected / deferred**.
 
@@ -28,8 +28,13 @@ wave are in "Deferred by decision" at the bottom.
   exception: URL wire-format READ compatibility (old `c:` payloads still
   parse) is kept — bookmarked URLs aren't API consumers. If any plan text
   still contains softer compat language, this policy wins.
-- **PRISMA HOLD (2026-07-13)**: no Prisma implementation until everything
-  else is done; Drizzle abstraction/provider-readiness proceeds.
+- **PRISMA DIRECTION (2026-07-20, replaces the 2026-07-13 PRISMA HOLD)**:
+  the Prisma plan is now the COMPLETE Drizzle-parity adapter —
+  plan [061](061-prisma-adapter-full-parity.md) (supersedes the 008 spike).
+  Kysely follows on the same conformance suite
+  ([062](062-kysely-adapter.md)). Execution scheduling stays with the
+  maintainer via this ledger; the old "nothing until everything else is
+  done" gate no longer applies.
 
 ---
 
@@ -54,6 +59,16 @@ wave are in "Deferred by decision" at the bottom.
   decisions collected and folded in. It heads Wave C.
 - **0.6 remains SHIPPABLE**; Wave A landed the pre-publish obligations
   (033 infra truth, 035 HTTP wire hardening, 040 facet top-100, 047 writes).
+- **2026-07-20 (at `27c59b9`, branch `docs-overhaul-and-cli-init-fix`,
+  [PR #88](https://github.com/Better-Tables/better-tables/pull/88))**: docs
+  handbook overhaul shipped; legacy column-factory entry points REMOVED
+  (release-policy removal — `defineColumns` kept as the standalone-columns
+  utility); **`memoryAdapter` landed in core** (closes the deferred DIR-05
+  in spirit — core-hosted rather than toolkit-native); homepage demo ported
+  to flagship `defineTable` path builders. **Wave D planned (056–060)**:
+  maintainer-requested plans for the typecheck race, dead reserved contract
+  surface, global search, UI modules (actions extracted, opt-in), and
+  filterable/sortable derived aggregate columns.
 
 ---
 
@@ -101,8 +116,33 @@ the breaking window.
 | [055](055-direct-save-path.md) | **Zero-boilerplate saves** — `tables.cellEditAction(def)` (serializable, `'use server'`-ready; the PRIMARY monolith path), `saveAction` prop, opt-in double-sided cell-oriented HTTP write proxy, **joined-table editing** (`resolveCellWriteTarget`; related-row writes proven in browser + integration test), dogfood on the direct path (custom route deleted) | 053, 054 | DONE — executor-run, advisor-reviewed (APPROVED), merged into `editable-cells` at `ec60f80` |
 | [048](048-filter-group-builder-ui.md) | Visual filter group-builder UI (nested AND/OR) — fast-follow, contract already shipped | 015/016/017 (done) | TODO (reconciled 2026-07-18 — finding valid; see plan's reconcile note) |
 | [049](049-plugin-hook-execution.md) | Execute the plugin hook seam (`beforeFetch`/`afterFetch`), validated by one real plugin | 018 (done) | TODO (reconciled 2026-07-18 — seam still stored-only; line refs refreshed) |
-| [050](050-export-ui.md) | Export UI: `ExportButton`/`useTableExport` + `csvExport()` plugin + row-cap decision | 049 | TODO (reconciled 2026-07-18 — export seams moved by 044; line refs refreshed) |
-| 008 | Prisma adapter spike (read path) | 007 (done) + lift of the PRISMA HOLD | **ON HOLD** (maintainer) |
+| [050](050-export-ui.md) | Export UI: `ExportButton`/`useTableExport` + `csvExport()` plugin + row-cap decision | 049, **059** | TODO (reconciled 2026-07-18; **2026-07-20: refresh against `plans/design/ui-modules.md` before executing — `ExportButton` rides 059's `toolbarExtra` slot and ships as an `export` module; `TableConfig.exportOptions` is removed by 057, reintroduce only what the module needs as module-local props**) |
+| 008 | Prisma adapter spike (read path) | — | **SUPERSEDED** by [061](061-prisma-adapter-full-parity.md) (2026-07-20 maintainer directive: full parity, not a spike; 008's research is inlined there) |
+
+### Wave D — maintainer-requested (planned 2026-07-20 at `27c59b9`)
+
+Written on maintainer request ("plans for each unimplemented contract, the
+typecheck race, filterable computed/aggregate columns, and the plugin
+rethink — action builder should be a plugin, not default-included").
+
+| Plan | What | Depends on | Status |
+|------|------|------------|--------|
+| [056](056-toolkit-typecheck-ordering.md) | Deterministic root typecheck: `typecheck` gains `dependsOn: ["build", "^build"]` (same-package build/typecheck race — tsdown cleans `dist/` mid-`tsc`) | none | TODO |
+| [057](057-contract-surface-truth.md) | Remove dead reserved surface: `TableConfig.defaultFilters/actionsConfig/exportOptions/theme/loadingState` + `TableFeatures.bulkActions/export/columnResizing/virtualScrolling/realTimeUpdates/rowExpansion` (0.6 removal policy; adapter contract untouched — `exportData`/`subscribe` are real) | none (coordinates with 050/058/059) | TODO |
+| [058](058-global-search.md) | Global search as filter sugar: `buildSearchFilterGroup` OR-group over `.searchable()` columns, table-scoped `search` param (adapter-level field removed), `SearchInput` + URL sync — zero adapter changes | none | TODO |
+| [059](059-ui-modules-and-actions-extraction.md) | **UI modules tier** (`better-tables add <module>`, module-shaped CLI manifest, `slots` seam in `table.tsx`) + actions toolbar extracted as the first opt-in module (maintainer decision: not default-included) | none; validates slot vs 050's ExportButton | TODO |
+| [060](060-derived-aggregate-columns.md) | Server-derived aggregate columns: `t.count('posts')` renders/filters/sorts via correlated subqueries lowered into the drizzle computed-fields engine (tree-walk substitution closes 051 item 5 for specs); memoryAdapter nested-array aggregates; honest `filterable/sortable: false` defaults for `t.computed` | none (rebase order with 058 in `factory.ts`) | TODO |
+
+### Wave E — adapter expansion (planned 2026-07-20 at `27c59b9`)
+
+Maintainer directive: Prisma at full Drizzle parity (not the 008 spike),
+then Kysely. Both ride a shared adapter conformance suite so "parity" is
+executable, not aspirational.
+
+| Plan | What | Depends on | Status |
+|------|------|------------|--------|
+| [061](061-prisma-adapter-full-parity.md) | **Prisma adapter, full parity** (supersedes 008): Phase 1 extracts an adapter conformance suite (memory+drizzle prove it), then emitter → reads/trees → filter-aware facets → DMMF `describeColumns` + typed factory → writes/`resolveCellWriteTarget`/events/export (lifts `export-format` to toolkit) → aggregates (sort-only; Prisma can't WHERE-by-count — capability-declared) → docs/CI/publish | none hard; Phase 7 gated on 060 | TODO |
+| [062](062-kysely-adapter.md) | **Kysely adapter**: SQL-native composition (emitter + JOINs + `DataTransformer` + alias utils — the toolkit's other stress direction), runtime `db.introspection` for `describeColumns`, explicit `relationships` config for dot-paths, full writes/events/export, FULL aggregate parity (render+filter+sort) | 061 Phases 1+6; aggregates gated on 060 | TODO |
 
 ### Reconcile audit (2026-07-18, at `7b58ed8`)
 
@@ -148,6 +188,26 @@ Notes for the record (all acceptable, none require action):
   future `beforeSave`/`afterSave` hooks without rework.
 - Within Wave A, 034/035/036/040/046/047 touch largely disjoint files and can
   run in parallel worktrees; 033 first is safest (test-cache correctness).
+- **Wave D ordering**: 056 any time (one-line turbo change — do it first for
+  a stable gate). 057 before or parallel with 058/059 (disjoint fields;
+  057 deliberately does NOT touch `FetchDataParams.search` — 058 owns it —
+  and does not touch `actions`/`TableAction` — 059 owns packaging). 058 and
+  060 both extend the instance fetch path in `packages/core/src/factory.ts`
+  — land in either order, rebase the second. **050 executes only after 059**
+  (slot seam + module packaging) and after refreshing its plan text against
+  `plans/design/ui-modules.md`. 049 remains independent (core-tier hooks);
+  its vocabulary rule — core tier = "plugins", copied-UI tier = "modules" —
+  is defined in 059.
+- **Wave E ordering**: 061 is phased and mergeable per phase; its Phase 1
+  (conformance suite over memory+drizzle) is valuable standalone and is a
+  prerequisite for 062 (along with Phase 6's export-format lift). 057/058
+  first SHRINK the contract 061 must implement — schedule them ahead when
+  possible. 060 gates 061 Phase 7 / 062 Step 6 (aggregates); both plans
+  skip that phase cleanly if 060 hasn't landed. Note the capability
+  asymmetry 061 surfaces: Prisma can sort-by-relation-count but not
+  filter-by-count, while Kysely (and Drizzle) do all three — 060's design
+  step weighs per-operation capability granularity for exactly this
+  reason.
 
 ### Maintainer decisions folded into the wave (collected 2026-07-17)
 
@@ -332,11 +392,41 @@ hygiene · bun isolated-linker flaky typecheck (bunfig hoisted pin).
 
 ## Deferred by decision (maintainer chose not to plan this wave — revisit on request)
 
-- **DIR-05 in-memory adapter** (toolkit-native second adapter): grounded and
-  valuable (backs UI tests/demos, de-risks Prisma), but not selected for this
-  wave. Plan 043 uses `bun:sqlite` + Drizzle for its integration test instead;
-  if that proves the toolkit ports are ORM-neutral, the in-memory adapter is
-  the natural next spike.
+- **DIR-05 in-memory adapter** — **LANDED 2026-07-20** (not as originally
+  scoped): `memoryAdapter(rows)` ships from `@better-tables/core`
+  (`packages/core/src/adapters/memory-adapter.ts`) rather than as a
+  toolkit-native adapter — full filter/sort/pagination/facets/describeColumns
+  over arrays. The toolkit-port-validation goal transfers to the (still held)
+  Prisma spike. Plan 060 extends it with nested-array aggregates.
+- **Column resizing** (`features.columnResizing`): flag removed by 057 (was
+  contract-only, no implementation). Reintroduce flag + feature together via
+  a future plan when prioritized.
+- **Row expansion** (`features.rowExpansion`): same disposition as resizing —
+  removed by 057; feature plan on request.
+- **Realtime UI** (`features.realTimeUpdates`): the UI flag is removed by 057,
+  but the ADAPTER half is real — drizzle implements `subscribe` and emits
+  insert/update/delete on mutations (`drizzle-adapter.ts:1337`, emits at
+  `:1161/:1196/:1227/:1259/:1290`). A future realtime capability ships as a
+  059-style module (+ possibly a 049 plugin) riding `subscribe`.
+- **Facets on derived columns** (count range slider via `getMinMaxValues`):
+  explicitly deferred out of plan 060 — natural fast-follow once 060 lands.
+- **Other ORM/data-client adapters** (2026-07-20 survey, on the "any other
+  ORM?" question — revisit on demand; each would ride 061's conformance
+  suite):
+  - **TypeORM / Sequelize**: DECLINED for now — large but legacy/declining
+    installed bases, decorator/legacy APIs make introspection awkward, and
+    their users are Prisma/Drizzle migration candidates anyway.
+  - **MikroORM**: DECLINED — capable but small audience relative to build
+    cost; its users can follow the Kysely template if demand appears.
+  - **Supabase** (`supabase-js`/PostgREST): the strongest NEXT candidate —
+    huge app-dev audience, filter language maps well
+    (`ilike`/`in`/`gte`), auth/RLS story composes with the HTTP adapter's
+    allow-list model. Needs its own design pass (no JOIN aliasing;
+    embedded-resource selects instead) — plan on request after 062.
+  - **MongoDB (mongoose)**: DEFERRED — document model changes relation
+    semantics (embedded arrays vs FK paths); memoryAdapter's nested-array
+    aggregate semantics (060) are the closest precedent. Post-1.0
+    question.
 - **DIR-03 saved/named views** (`savedFilters()` plugin over the existing
   FilterState serialization): deferred until the plugin seam (049) and a
   second real plugin exist to validate the storage-port shape. The design is


### PR DESCRIPTION
Three adapter defects surfaced while debugging the homepage users demo against Neon Postgres. Each was reproduced against a live 1,000,000-row database and is pinned by a test I confirmed **fails without its fix**.

The first was the reported bug; the other two were found while verifying it. All three are independent of the demo — they affect any consumer.

## 1. Cross-table predicates on the Postgres relational path

Drizzle's relational `findMany({ where })` scopes predicates to the primary table, so a condition built on a related column is emitted against the wrong table. The reported failure:

```sql
select … from "users" "users"
  left join lateral (… from "profiles" "users_profile" …) on true
where "users"."github" is not null   -- github lives on profiles, not users
```

Filters and sorts naming a related column now decline the relational path and fall back to manual joins. So does any `additionalConditions` entry — those carry a computed field's `filterSql` as raw SQL, never pass through `buildQueryContext`, and are opaque, so there's no way to tell whether they reference a joined table. Joins are no-ops on that path anyway, so such a predicate would have nothing to bind to even if the rewrite were correct.

The guard also moved **below** the `db.query` capability check. A database built without relations has no relational path to decline, and resolving an unvalidated context there would convert a previously-silent fallback into a throw for external callers of the exported `PostgresQueryBuilder`.

PostgreSQL-only — MySQL and SQLite always use manual joins, which is why no existing test caught this.

Verified live:

| Case | Before | After |
|---|---|---|
| Filter `profile.github` | `where "users"."github"` → error | `where ("profiles"."github" is not null and …)` ✅ |
| Sort `profile.location` | broken | manual-join fallback ✅ |
| Related leaf inside `OR` group | — | `where ("profiles"."location" ilike $1 or "users"."role" = $2)` ✅ |
| Primary-column filter only | — | stays on the relational path ✅ |

## 2. Related objects discarded on a nullable sentinel column

`DataTransformer` decided whether a one-to-one related row existed by testing **one** column — whichever the caller happened to request first. A `NULL` there discarded the entire related object, so every other related column rendered blank even though the join had returned data.

Same query, same 8 rows, only the column **order** changed:

```
profile.id     requested first → rows with profile === null: 0
profile.github requested first → rows with profile === null: 4   ← half the page
```

Callers were safe only by accident. Presence now derives from the related table's primary key — the signal `processOneToManyColumn` already used — falling back to "any requested related column carries a value" when the PK was not selected. One-to-many was never affected.

This is in the **toolkit**, so it applies to every adapter built on it.

## 3. Invalid filters dropped silently

A filter whose operator isn't valid for its type is skipped so partial URL/UI state still fetches (deliberate — plan 038, asserted by the SQLite suite). But dropping a leaf under implicit-AND *widens* the result set, so a malformed filter returned the whole table with no error and no warning:

```
VALID    option/is admin           → WHERE emitted | total =    49,937
MISMATCH text/is on option column  → NO WHERE      | total = 1,000,000
BOGUS    operator name             → NO WHERE      | total = 1,000,000
UNKNOWN  column id                 → throws (already correct)
```

I did **not** flip this to throw — fail-soft is a documented decision with a passing test behind it. Instead the two cases the old code conflated are now split: an operator invalid for its type warns (value-free, matching `normalizeFilterNode`), while genuinely incomplete values on a supported operator stay silent, since warning there would fire on every keystroke.

> If you'd prefer this to fail closed, the natural shape is an adapter option (`onInvalidFilter: 'skip' | 'throw'`, default `'skip'`) so server-side scoping filters can opt into strict mode without breaking the UI contract. Happy to add it — it's a design call worth making explicitly.

## Also

- Corrects a dormant test asserting the **opposite** of documented fail-soft behavior. It contradicted both its own sibling test and the SQLite mirror, and never ran (outer `skipIf` plus `describe.skip`), so it would have failed the moment anyone unskipped it.
- Plans 056–062 land in a separate commit — docs-only, safe to skip while reviewing.

## Testing

`bun run typecheck` and `bun run test` green (11/11 tasks); biome clean on every touched file. Each fix has a regression test verified to fail when the fix is reverted.

Two notes worth flagging, neither introduced here:

- **The Postgres integration suite is effectively dormant** — `describe.skipIf(!process.env.POSTGRES_TEST_URL)` skips 94 of 95 tests, and CI doesn't set it. That's why a Postgres-only bug shipped. Worth deciding whether CI should run a Postgres service container.
- **Local package-scoped test runs use stale artifacts.** `packages/adapters/drizzle/tsconfig.json` only maps `@better-tables/core`, so `@better-tables/adapters-toolkit` resolves to its built `dist/`. Running `bun test` inside the drizzle package tests a stale toolkit — my first regression test passed identically with the fix applied *and* reverted. CI is fine (`test → build → ^build`), but it's a real local-iteration trap, and it's why the transformer test lives in the toolkit's own suite where it imports `../src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cross-table predicates in Postgres and makes computed-field SQL work across related tables, with clear warnings for dropped filters and sorts. Also restores one-to-one relation presence and stops the factory from silently dropping `computedFields` and `hooks`.

- **Bug Fixes**
  - Postgres cross-table predicates: decline Drizzle’s relational `findMany({ where })` when filters/sorts target related columns or when `additionalConditions` (computed `filterSql`/`sortSql`) are present; guard moved below the `db.query` capability check. MySQL/SQLite unaffected.
  - Computed-field SQL across relations: plan JOINs for `filterSql`/`sortSql` by walking `SQL.queryChunks` (reuses existing joins, tracks FROM scope per fragment so correlated subqueries don’t suppress other joins, fails fast when no direct relationship exists). Include sort-only computed fields in join metadata; drop sorts on computed fields without `sortSql` with a `[better-tables]` warning.
  - Relation presence: `@better-tables/adapters-toolkit` now detects one-to-one existence via the related table’s primary key, falling back to “any requested related column has a value.”
  - Dropped filters visibility: keep fail-soft skip for operators invalid for their type, but emit a `[better-tables]` warning naming the column/operator/type. Incomplete values for supported operators remain silent.
  - Factory passthrough: `@better-tables/adapters-drizzle` `drizzleAdapter()`/`createDrizzleAdapter()` now accept and forward `computedFields` and `hooks` via shared `ComputedFieldsConfig`, matching the constructor.
  - Join planner tests: unit suite for `planJoinsForOpaqueSqlConditions` pins alias-keyed joins, per-fragment FROM-scope exemption, no double-join, sortSql planning, and unrelated-table errors.

<sup>Written for commit 461479bbd308a836b91e1108f70a79c0e983ec6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Better-Tables/better-tables/pull/97?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

