### PR TITLE
feat(adapters): onInvalidFilter strict mode + CI integration-suite guard

### DIFF
--- a/.changeset/drizzle-on-invalid-filter.md
+++ b/.changeset/drizzle-on-invalid-filter.md
@@ -1,0 +1,32 @@
+---
+'@better-tables/adapters-drizzle': minor
+---
+
+Add `onInvalidFilter: 'skip' | 'throw'` for strict, fail-closed filtering
+
+When a filter leaf can't be translated to SQL — an operator that isn't valid
+for the column's type, or a supported operator with missing/incomplete values —
+the adapter drops it by default so partial URL/UI filter state still fetches.
+But dropping a leaf **widens** the result set: under implicit-AND a discarded
+predicate reads as "no restriction", so a filter meant to scope rows (a tenant
+or owner guard built server-side) silently returns everything.
+
+The new `options.onInvalidFilter` makes that choice explicit:
+
+- `'skip'` (default, unchanged) — drop the leaf and continue. An invalid
+  operator still warns; incomplete values stay silent.
+- `'throw'` — raise a `QueryError` instead of dropping, so a malformed scoping
+  filter fails loudly rather than exposing rows.
+
+```ts
+const adapter = drizzleAdapter(db, {
+  options: { onInvalidFilter: 'throw' },
+});
+```
+
+The option threads through every dialect (Postgres/MySQL/SQLite) and applies to
+both flat filters and leaves nested inside a `FilterGroupNode`. The legitimate
+"match null rows only" intent (`includeNull` with empty values) is a real
+condition, not a drop, and is unaffected. As part of this change, a `QueryError`
+raised during filter translation now propagates with its type intact instead of
+being flattened into a generic `Error`.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -420,7 +420,12 @@ jobs:
         env:
           CI: 'true'
           # Set connection strings for MySQL and Postgres services
-          # Using root for MySQL since tests need to create databases
+          # Using root for MySQL since tests need to create databases.
+          # NOTE: the integration suites skip themselves when these are unset.
+          # tests/ci-integration-guard.test.ts fails this job if either is
+          # missing under GitHub Actions, so a dropped URL can't turn the
+          # integration tests into a silent (green) skip. Remove that guard in
+          # the same change if you ever intentionally drop a database here.
           MYSQL_TEST_URL: mysql://root:testpassword@localhost:3306
           POSTGRES_TEST_URL: postgresql://testuser:testpassword@localhost:5432/drizzle_test
         run: |

--- a/apps/marketing/content/docs/adapters/drizzle.mdx
+++ b/apps/marketing/content/docs/adapters/drizzle.mdx
@@ -40,6 +40,7 @@ export const ticketsTable = defineTable<typeof tables>()('tickets', (t) => ({
 |---|---|
 | `defaultPrimaryTable` | Table for reads when a call provides neither `columns` nor `primaryTable` (required for that case on multi-table schemas — the adapter throws a `SchemaError` instead of guessing) |
 | `defaultMutationTable` | Table for writes on multi-table schemas |
+| `onInvalidFilter` | `'skip'` (default) or `'throw'`. What to do when a filter can't be translated — see [Invalid filters](#invalid-filters) below |
 | `cache` | Query result caching: `{ enabled, ttl, maxSize? }` (LRU, default max 500 entries) |
 | `optimization` | **Reserved / unimplemented** — typed only; join caps and related knobs are not wired at runtime |
 | `batching` | **Reserved / unimplemented** — typed only; the emitter uses fixed batch constants (`batchSize` 50, `maxBatchesPerGroup` 200) |
@@ -77,9 +78,27 @@ Try it live: [/examples/relationship-filtering](/examples/relationship-filtering
 
 `getFacetedValues` / `getMinMaxValues` / `fetchData({ faceted })` power filter option counts and range facets, with self-exclusion handled by the adapter. See the [Facets guide](/docs/facets) and [/examples/facets](/examples/facets).
 
+## Invalid filters
+
+When a filter leaf can't be translated to SQL — an operator that isn't valid for the column's type, or a supported operator with missing/incomplete values — the adapter has to decide between dropping it and failing. Dropping **widens** the result set: under implicit-AND, a discarded predicate reads as "no restriction", so a filter meant to scope rows silently returns everything.
+
+`options.onInvalidFilter` controls this:
+
+- **`'skip'` (default)** — drop the leaf and keep going, so partial URL/UI filter state still fetches. An invalid operator logs a `[better-tables]` warning; genuinely incomplete values stay silent (normal mid-edit state).
+- **`'throw'`** — raise a `QueryError` instead of dropping. Use this when filters are built programmatically and every one *must* apply — a dropped tenant or owner guard is a data-exposure bug, not a UI convenience.
+
+```ts
+// A server-side scoping filter that must never be silently dropped:
+const adapter = drizzleAdapter(db, {
+  options: { defaultPrimaryTable: 'users', onInvalidFilter: 'throw' },
+});
+```
+
+The legitimate "match null rows only" request (`includeNull` with empty values) is a real condition, not a drop, and is unaffected by either mode.
+
 ## Databases
 
-Postgres, MySQL, and SQLite are supported. Peer dependencies are your driver's (`postgres`, `mysql2`, `better-sqlite3`) plus `drizzle-orm`. Integration tests for MySQL/Postgres live under `packages/adapters/drizzle/tests` (optional `.env.local`).
+Postgres, MySQL, and SQLite are supported. Peer dependencies are your driver's (`postgres`, `mysql2`, `better-sqlite3`) plus `drizzle-orm`. Integration tests for MySQL/Postgres live under `packages/adapters/drizzle/tests` and **run in CI against real Postgres and MySQL service containers** (they self-skip locally when no DB URL is set; a CI guard fails the build if those URLs ever go missing so the suites can't silently skip).
 
 ## Performance tuning
 

--- a/packages/adapters/drizzle/src/drizzle-adapter.ts
+++ b/packages/adapters/drizzle/src/drizzle-adapter.ts
@@ -325,7 +325,13 @@ export class DrizzleAdapter<TSchema extends Record<string, unknown>, TDriver ext
    */
   private createQueryBuilderStrategy(driver: TDriver): BaseQueryBuilder {
     const createQueryBuilder = getQueryBuilderFactory(driver);
-    return createQueryBuilder(this.db, this.schema, this.relationshipManager, this.hooks);
+    return createQueryBuilder(
+      this.db,
+      this.schema,
+      this.relationshipManager,
+      this.hooks,
+      this.options?.onInvalidFilter
+    );
   }
 
   /**

--- a/packages/adapters/drizzle/src/filter-handler.ts
+++ b/packages/adapters/drizzle/src/filter-handler.ts
@@ -58,8 +58,9 @@ import type {
   ColumnPath,
   DatabaseDriver,
   FilterHandlerHooks,
+  InvalidFilterBehavior,
 } from './types';
-import { QueryError } from './types';
+import { DrizzleAdapterError, QueryError } from './types';
 
 /**
  * Collect every {@link FilterState} leaf out of a `filters` value that may be
@@ -190,18 +191,21 @@ export class FilterHandler {
   private hooks?: FilterHandlerHooks;
   private emitter: DrizzlePredicateEmitter;
   private router: FilterRouter<ColumnOrExpression, SQL | SQLWrapper>;
+  private onInvalidFilter: InvalidFilterBehavior;
 
   constructor(
     schema: Record<string, AnyTableType>,
     relationshipManager: RelationshipManager,
     databaseType: DatabaseDriver,
-    hooks?: FilterHandlerHooks
+    hooks?: FilterHandlerHooks,
+    onInvalidFilter: InvalidFilterBehavior = 'skip'
   ) {
     this.schema = schema;
     this.relationshipManager = relationshipManager;
     if (hooks !== undefined) {
       this.hooks = hooks;
     }
+    this.onInvalidFilter = onInvalidFilter;
     this.emitter = new DrizzlePredicateEmitter(schema, databaseType, hooks);
     this.router = new FilterRouter(this.emitter);
   }
@@ -321,6 +325,44 @@ export class FilterHandler {
   }
 
   /**
+   * Resolve a filter leaf that produced no WHERE condition because it was
+   * malformed. Under `onInvalidFilter: 'throw'` this raises a {@link QueryError};
+   * under `'skip'` (the default) it returns `undefined` so the leaf is dropped,
+   * emitting a value-free `[better-tables]` warning only when the drop widens
+   * results (an invalid operator) rather than for normal mid-edit UI state
+   * (incomplete values).
+   *
+   * @param warnWhenSkipping - whether `'skip'` mode should warn. `true` for the
+   *   result-widening invalid-operator case; `false` for incomplete values,
+   *   where a warning would fire on every keystroke.
+   * @returns always `undefined` (in `'skip'` mode); never returns in `'throw'`.
+   */
+  private handleDroppedLeaf(
+    filter: FilterState,
+    reason: string,
+    warnWhenSkipping: boolean
+  ): undefined {
+    if (this.onInvalidFilter === 'throw') {
+      throw new QueryError(
+        `Filter on "${filter.columnId}" cannot be applied: ${reason} ` +
+          'It was rejected because this adapter is configured with onInvalidFilter: "throw". ' +
+          'Provide a valid operator and values, or set onInvalidFilter to "skip" to drop it instead.',
+        { columnId: filter.columnId, operator: filter.operator, type: filter.type }
+      );
+    }
+    if (warnWhenSkipping) {
+      // Value-free by convention -- never log `filter.values`, matching
+      // `normalizeFilterNode` / `deserializeFiltersFromURL`.
+      // biome-ignore lint/suspicious/noConsole: intentional warning for a dropped filter that widens results
+      console.warn(
+        `[better-tables] Dropped filter on "${filter.columnId}": ${reason} ` +
+          'The query will run WITHOUT this filter and may return more rows than intended.'
+      );
+    }
+    return undefined;
+  }
+
+  /**
    * Validate and build a single filter leaf's condition (plan 017 extracted
    * this from {@link handleCrossTableFilters}'s loop body so both the flat
    * path and {@link buildTreeCondition}'s recursive walk share one leaf
@@ -328,16 +370,12 @@ export class FilterHandler {
    * core/adapter validation rejects it or because {@link buildFilterCondition}
    * itself found no condition to build (e.g. empty values).
    *
-   * Two distinct reasons a leaf is skipped, deliberately treated differently:
+   * A malformed leaf (invalid operator, or incomplete values) is routed through
+   * {@link handleDroppedLeaf}, which either drops it (`onInvalidFilter: 'skip'`,
+   * the default) or throws a {@link QueryError} (`'throw'`) for callers whose
+   * filters must all apply — see {@link InvalidFilterBehavior}.
    *
-   * - **Incomplete values** for an operator this adapter DOES support (the user
-   *   picked a column but has not finished typing). Skipped silently — this is
-   *   normal mid-edit UI state and warning on it would fire on every keystroke.
-   * - **An operator that is not valid for the filter's type.** Also skipped
-   *   (plan 038 keeps partial URL/UI state fetchable) but WARNS, because
-   *   dropping a leaf widens the result set: under implicit-AND the query then
-   *   returns more rows than the caller asked for.
-   *
+   * @throws {QueryError} When `onInvalidFilter: 'throw'` and a leaf is malformed.
    * @throws {Error} Wraps any resolution/build error with the offending
    *   `columnId`, surfacing it instead of silently swallowing it.
    */
@@ -379,8 +417,14 @@ export class FilterHandler {
             !hasValidValues ||
             (expectedCount > 0 && filter.values.some((v) => v === undefined))
           ) {
-            // Skip invalid filters silently - this allows for partial filter states in UI
-            return undefined;
+            // Supported operator, but the values are missing/incomplete. In the
+            // UI this is normal mid-edit state, so `'skip'` drops it silently.
+            // Under `'throw'` it is a malformed programmatic filter and raises.
+            return this.handleDroppedLeaf(
+              filter,
+              `operator "${filter.operator}" requires values that are missing or incomplete.`,
+              false
+            );
           }
         } else {
           // The operator is not valid for this filter's type (unknown operator,
@@ -389,18 +433,14 @@ export class FilterHandler {
           // This is NOT a partial UI state -- it is a malformed filter, and
           // dropping it WIDENS the result set: under implicit-AND a dropped
           // leaf returns MORE rows than asked for, so a scoping filter that is
-          // silently discarded reads as "no restriction". Dropping stays the
-          // behavior (plan 038: partial URL/UI filter state must still fetch),
-          // but it must never be silent.
-          //
-          // Value-free by convention -- never log `filter.values`, matching
-          // `normalizeFilterNode` / `deserializeFiltersFromURL`.
-          // biome-ignore lint/suspicious/noConsole: intentional warning for a dropped filter that widens results
-          console.warn(
-            `[better-tables] Dropped filter on "${filter.columnId}": operator "${filter.operator}" is not valid for type "${filter.type ?? 'unknown'}". ` +
-              'The query will run WITHOUT this filter and may return more rows than intended.'
+          // silently discarded reads as "no restriction". Under `'skip'` it is
+          // dropped with a warning (plan 038: partial URL/UI state must still
+          // fetch); under `'throw'` it raises.
+          return this.handleDroppedLeaf(
+            filter,
+            `operator "${filter.operator}" is not valid for type "${filter.type ?? 'unknown'}".`,
+            true
           );
-          return undefined;
         }
       }
 
@@ -408,7 +448,13 @@ export class FilterHandler {
       // undefined means empty/invalid filter - treat the same as "skip"
       return condition !== undefined && condition !== null ? condition : undefined;
     } catch (error) {
-      // Re-throw the error to surface the issue instead of silently ignoring it
+      // Adapter errors (including a configured `onInvalidFilter: 'throw'`) are
+      // already descriptive and carry a stable `code` — surface them unchanged
+      // instead of flattening them into a generic Error and losing the type.
+      if (error instanceof DrizzleAdapterError) {
+        throw error;
+      }
+      // Re-throw anything else with the offending column for context.
       throw new Error(
         `Invalid filter configuration for column '${filter.columnId}': ${error instanceof Error ? error.message : 'Unknown error'}`
       );

--- a/packages/adapters/drizzle/src/filter-handler.ts
+++ b/packages/adapters/drizzle/src/filter-handler.ts
@@ -426,6 +426,23 @@ export class FilterHandler {
               false
             );
           }
+
+          // Reaching here means core validation FAILED yet we have enough values
+          // to build a predicate anyway — the operator is over-specified (surplus
+          // values that translation silently ignores, e.g. `isEmpty` or a
+          // single-value operator handed extra values). It still applies
+          // correctly, so `'skip'` keeps it (no widening, unchanged behavior).
+          // But `'throw'` promises to reject EVERY leaf core rejects, so surface
+          // it — a caller in strict mode wants malformed filters flagged, not
+          // quietly trimmed. `nullOnlyIntent` is a real match-null request, not a
+          // tolerated malformation, so it is exempt.
+          if (this.onInvalidFilter === 'throw' && !nullOnlyIntent) {
+            return this.handleDroppedLeaf(
+              filter,
+              `operator "${filter.operator}" received values that do not match its expected shape for type "${filter.type ?? 'unknown'}".`,
+              false
+            );
+          }
         } else {
           // The operator is not valid for this filter's type (unknown operator,
           // or one this adapter does not advertise for the type).

--- a/packages/adapters/drizzle/src/index.ts
+++ b/packages/adapters/drizzle/src/index.ts
@@ -92,6 +92,7 @@ export type {
   ExtractSchemaFromDB,
   FilterTablesFromSchema,
   InferSelectModelFromFilteredSchema,
+  InvalidFilterBehavior,
   JoinConfig,
   QueryBuilderFactory,
   QueryContext,

--- a/packages/adapters/drizzle/src/query-builders/base-query-builder.ts
+++ b/packages/adapters/drizzle/src/query-builders/base-query-builder.ts
@@ -49,6 +49,7 @@ import type {
   ComputedFieldWithResolvedSortSql,
   DatabaseDriver,
   FilterHandlerHooks,
+  InvalidFilterBehavior,
   JoinConfig,
   MySQLQueryBuilderWithJoins,
   PostgresQueryBuilderWithJoins,
@@ -229,11 +230,18 @@ export abstract class BaseQueryBuilder {
     schema: Record<string, AnyTableType>,
     relationshipManager: RelationshipManager,
     databaseType: DatabaseDriver,
-    hooks?: FilterHandlerHooks
+    hooks?: FilterHandlerHooks,
+    onInvalidFilter?: InvalidFilterBehavior
   ) {
     this.schema = schema;
     this.relationshipManager = relationshipManager;
-    this.filterHandler = new FilterHandler(schema, relationshipManager, databaseType, hooks);
+    this.filterHandler = new FilterHandler(
+      schema,
+      relationshipManager,
+      databaseType,
+      hooks,
+      onInvalidFilter
+    );
     // Primary keys are auto-detected from the schema
     this.primaryKeyMap = getPrimaryKeyMap(schema, {
       getColumnNames,

--- a/packages/adapters/drizzle/src/query-builders/mysql-query-builder.ts
+++ b/packages/adapters/drizzle/src/query-builders/mysql-query-builder.ts
@@ -18,7 +18,13 @@
 import { type SQL, sql } from 'drizzle-orm';
 import type { MySqlColumn } from 'drizzle-orm/mysql-core';
 import type { RelationshipManager } from '../relationship-manager';
-import type { AnyColumnType, AnyTableType, FilterHandlerHooks, MySqlDatabaseType } from '../types';
+import type {
+  AnyColumnType,
+  AnyTableType,
+  FilterHandlerHooks,
+  InvalidFilterBehavior,
+  MySqlDatabaseType,
+} from '../types';
 import { BaseQueryBuilder, type DialectDb } from './base-query-builder';
 
 /**
@@ -40,9 +46,10 @@ export class MySQLQueryBuilder extends BaseQueryBuilder {
     db: MySqlDatabaseType,
     schema: Record<string, AnyTableType>,
     relationshipManager: RelationshipManager,
-    hooks?: FilterHandlerHooks
+    hooks?: FilterHandlerHooks,
+    onInvalidFilter?: InvalidFilterBehavior
   ) {
-    super(schema, relationshipManager, 'mysql', hooks);
+    super(schema, relationshipManager, 'mysql', hooks, onInvalidFilter);
     this.db = db;
   }
 

--- a/packages/adapters/drizzle/src/query-builders/postgres-query-builder.ts
+++ b/packages/adapters/drizzle/src/query-builders/postgres-query-builder.ts
@@ -26,6 +26,7 @@ import type {
   AnyTableType,
   ComputedFieldWithResolvedSortSql,
   FilterHandlerHooks,
+  InvalidFilterBehavior,
   PostgresDatabaseType,
   PostgresQueryBuilderWithJoins,
   QueryContext,
@@ -172,9 +173,10 @@ export class PostgresQueryBuilder extends BaseQueryBuilder {
     db: PostgresDatabaseType,
     schema: Record<string, AnyTableType>,
     relationshipManager: RelationshipManager,
-    hooks?: FilterHandlerHooks
+    hooks?: FilterHandlerHooks,
+    onInvalidFilter?: InvalidFilterBehavior
   ) {
-    super(schema, relationshipManager, 'postgres', hooks);
+    super(schema, relationshipManager, 'postgres', hooks, onInvalidFilter);
     this.db = db;
   }
 

--- a/packages/adapters/drizzle/src/query-builders/query-builder-factory.ts
+++ b/packages/adapters/drizzle/src/query-builders/query-builder-factory.ts
@@ -42,7 +42,15 @@ import { SQLiteQueryBuilder } from './sqlite-query-builder';
  *
  * @template TDriver - The database driver type
  * @param driver - The database driver identifier ('postgres', 'mysql', or 'sqlite')
- * @returns A factory function that creates a query builder for the specific driver
+ * @returns A factory function `(db, schema, relationshipManager, hooks?, onInvalidFilter?)`
+ *   that creates a query builder for the specific driver. Its parameters:
+ *   - `db` — the Drizzle database instance for the driver
+ *   - `schema` — the table schema (relations filtered out)
+ *   - `relationshipManager` — resolves relationship/join paths
+ *   - `hooks` — optional {@link FilterHandlerHooks} for customizing filter SQL
+ *   - `onInvalidFilter` — optional {@link InvalidFilterBehavior}; `'skip'`
+ *     (default) drops an untranslatable filter leaf, `'throw'` raises a
+ *     `QueryError`. Threaded straight through to the `FilterHandler`.
  *
  * @example
  * ```typescript
@@ -51,13 +59,15 @@ import { SQLiteQueryBuilder } from './sqlite-query-builder';
  * const queryBuilder = createQueryBuilder(
  *   nodePgDb, // NodePgDatabase, PostgresJsDatabase, or NeonHttpDatabase
  *   schema,
- *   relationshipManager
+ *   relationshipManager,
+ *   undefined, // no filter hooks
+ *   'throw' // reject filters that cannot be translated instead of dropping them
  * );
  * ```
  *
  * @throws {Error} If an unsupported driver is provided
  *
- * @since 1.0.0 (expanded to support all driver variants in 1.1.0)
+ * @since 1.0.0 (expanded to support all driver variants in 1.1.0; `onInvalidFilter` added in 1.2.0)
  */
 export function getQueryBuilderFactory<TDriver extends DatabaseDriver>(
   driver: TDriver

--- a/packages/adapters/drizzle/src/query-builders/query-builder-factory.ts
+++ b/packages/adapters/drizzle/src/query-builders/query-builder-factory.ts
@@ -19,6 +19,7 @@ import type {
   DatabaseDriver,
   DrizzleDatabase,
   FilterHandlerHooks,
+  InvalidFilterBehavior,
   MySqlDatabaseType,
   PostgresDatabaseType,
   QueryBuilderFactory,
@@ -65,7 +66,8 @@ export function getQueryBuilderFactory<TDriver extends DatabaseDriver>(
     db: DrizzleDatabase<TDriver>,
     schema: Record<string, AnyTableType>,
     relationshipManager: RelationshipManager,
-    hooks?: FilterHandlerHooks
+    hooks?: FilterHandlerHooks,
+    onInvalidFilter?: InvalidFilterBehavior
   ): BaseQueryBuilder => {
     switch (driver) {
       case 'postgres':
@@ -78,15 +80,28 @@ export function getQueryBuilderFactory<TDriver extends DatabaseDriver>(
           db as PostgresDatabaseType,
           schema,
           relationshipManager,
-          hooks
+          hooks,
+          onInvalidFilter
         );
       case 'mysql':
         // Same reasoning: DrizzleDatabase<'mysql'> = MySqlDatabaseType
-        return new MySQLQueryBuilder(db as MySqlDatabaseType, schema, relationshipManager, hooks);
+        return new MySQLQueryBuilder(
+          db as MySqlDatabaseType,
+          schema,
+          relationshipManager,
+          hooks,
+          onInvalidFilter
+        );
       case 'sqlite':
         // Same reasoning: DrizzleDatabase<'sqlite'> = SQLiteDatabaseType
         // which includes BetterSQLite3Database and LibSQLDatabase
-        return new SQLiteQueryBuilder(db as SQLiteDatabaseType, schema, relationshipManager, hooks);
+        return new SQLiteQueryBuilder(
+          db as SQLiteDatabaseType,
+          schema,
+          relationshipManager,
+          hooks,
+          onInvalidFilter
+        );
       default:
         throw new Error(`Unsupported database driver: ${driver as string}`);
     }

--- a/packages/adapters/drizzle/src/query-builders/sqlite-query-builder.ts
+++ b/packages/adapters/drizzle/src/query-builders/sqlite-query-builder.ts
@@ -19,7 +19,13 @@
 import { type SQL, sql } from 'drizzle-orm';
 import type { SQLiteColumn } from 'drizzle-orm/sqlite-core';
 import type { RelationshipManager } from '../relationship-manager';
-import type { AnyColumnType, AnyTableType, FilterHandlerHooks, SQLiteDatabaseType } from '../types';
+import type {
+  AnyColumnType,
+  AnyTableType,
+  FilterHandlerHooks,
+  InvalidFilterBehavior,
+  SQLiteDatabaseType,
+} from '../types';
 import { BaseQueryBuilder, type DialectDb } from './base-query-builder';
 
 /**
@@ -42,9 +48,10 @@ export class SQLiteQueryBuilder extends BaseQueryBuilder {
     db: SQLiteDatabaseType,
     schema: Record<string, AnyTableType>,
     relationshipManager: RelationshipManager,
-    hooks?: FilterHandlerHooks
+    hooks?: FilterHandlerHooks,
+    onInvalidFilter?: InvalidFilterBehavior
   ) {
-    super(schema, relationshipManager, 'sqlite', hooks);
+    super(schema, relationshipManager, 'sqlite', hooks, onInvalidFilter);
     this.db = db;
   }
 

--- a/packages/adapters/drizzle/src/types/filter-hooks.ts
+++ b/packages/adapters/drizzle/src/types/filter-hooks.ts
@@ -6,6 +6,28 @@ import type { SQL, SQLWrapper } from 'drizzle-orm';
 import type { ColumnOrExpression } from './core';
 
 /**
+ * What the adapter does when a filter leaf is malformed and therefore cannot
+ * be translated to a WHERE condition — an operator that is not valid for the
+ * filter's type, or a supported operator whose values are missing/incomplete.
+ *
+ * Dropping such a leaf WIDENS the result set: under implicit-AND, a discarded
+ * predicate reads as "no restriction", so a filter meant to scope rows (e.g. a
+ * tenant/owner guard built server-side) silently returns everything.
+ *
+ * - `'skip'` (default): drop the leaf and keep going, preserving partial
+ *   URL/UI filter state (plan 038). An invalid operator still logs a
+ *   `[better-tables]` warning; genuinely incomplete values stay silent (they
+ *   are normal mid-edit state). This is the historical behavior.
+ * - `'throw'`: raise a `QueryError` instead of dropping. Use this when filters
+ *   are constructed programmatically and every one MUST apply — a dropped
+ *   scoping filter is a data-exposure bug, not a UI convenience.
+ *
+ * The legitimate "match null rows only" intent (`includeNull` with empty
+ * values) is a real condition, not a drop, and is unaffected by either mode.
+ */
+export type InvalidFilterBehavior = 'skip' | 'throw';
+
+/**
  * Hooks for customizing filter handler behavior
  *
  * @description

--- a/packages/adapters/drizzle/src/types/filter-hooks.ts
+++ b/packages/adapters/drizzle/src/types/filter-hooks.ts
@@ -18,9 +18,11 @@ import type { ColumnOrExpression } from './core';
  *   URL/UI filter state (plan 038). An invalid operator still logs a
  *   `[better-tables]` warning; genuinely incomplete values stay silent (they
  *   are normal mid-edit state). This is the historical behavior.
- * - `'throw'`: raise a `QueryError` instead of dropping. Use this when filters
- *   are constructed programmatically and every one MUST apply — a dropped
- *   scoping filter is a data-exposure bug, not a UI convenience.
+ * - `'throw'`: raise a `QueryError` for any leaf that fails validation —
+ *   whether it would be dropped (invalid operator, missing values) or leniently
+ *   accepted with surplus values core rejects. Use this when filters are
+ *   constructed programmatically and every one MUST apply as written — a
+ *   dropped scoping filter is a data-exposure bug, not a UI convenience.
  *
  * The legitimate "match null rows only" intent (`includeNull` with empty
  * values) is a real condition, not a drop, and is unaffected by either mode.

--- a/packages/adapters/drizzle/src/types/operations.ts
+++ b/packages/adapters/drizzle/src/types/operations.ts
@@ -14,7 +14,7 @@ import type {
   TableWithId,
 } from './core';
 import type { DatabaseDriver } from './drivers';
-import type { FilterHandlerHooks } from './filter-hooks';
+import type { FilterHandlerHooks, InvalidFilterBehavior } from './filter-hooks';
 import type { RelationshipMap } from './relationships';
 
 export interface DatabaseOperations<TRecord> {
@@ -95,7 +95,8 @@ export type QueryBuilderFactory<TDriver extends DatabaseDriver> = (
   db: DrizzleDatabase<TDriver>,
   schema: Record<string, AnyTableType>,
   relationshipManager: RelationshipManager,
-  hooks?: FilterHandlerHooks
+  hooks?: FilterHandlerHooks,
+  onInvalidFilter?: InvalidFilterBehavior
 ) => BaseQueryBuilder;
 
 /**
@@ -309,6 +310,24 @@ export interface DrizzleAdapterOptions {
     /** Enable nested OR/AND grouping for very large arrays (default: true) */
     enableNestedGrouping?: boolean;
   };
+
+  /**
+   * How to handle a filter leaf that cannot be translated to a WHERE
+   * condition — an operator invalid for the filter's type, or a supported
+   * operator with missing/incomplete values. Defaults to `'skip'` (drop and
+   * continue, preserving partial UI state). Set to `'throw'` for
+   * server-side scoping filters that must never be silently dropped, since a
+   * dropped predicate widens results (see {@link InvalidFilterBehavior}).
+   *
+   * @default 'skip'
+   * @example
+   * ```typescript
+   * const adapter = drizzleAdapter(db, {
+   *   options: { onInvalidFilter: 'throw' }
+   * });
+   * ```
+   */
+  onInvalidFilter?: InvalidFilterBehavior;
 }
 
 /**

--- a/packages/adapters/drizzle/tests/ci-integration-guard.test.ts
+++ b/packages/adapters/drizzle/tests/ci-integration-guard.test.ts
@@ -1,0 +1,42 @@
+/**
+ * @fileoverview CI guard — the Postgres/MySQL integration suites must actually run.
+ *
+ * The MySQL and Postgres integration suites gate themselves on
+ * `MYSQL_TEST_URL` / `POSTGRES_TEST_URL` via `describe.skipIf(!process.env.…)`.
+ * That is correct for local development (SQLite needs no server), but it means
+ * that if those env vars are ever unset IN CI — a refactor of the workflow, a
+ * removed service container, a renamed secret — the suites skip SILENTLY and
+ * the adapter job still reports green. A Postgres- or MySQL-only regression
+ * (exactly the class of bug that shipped in #97's history) would then reach
+ * main with no failing check.
+ *
+ * This guard fails the adapter test job when the integration databases are not
+ * configured, so "the integration tests didn't run" can never masquerade as
+ * "the integration tests passed".
+ *
+ * Scope:
+ * - Runs ONLY inside GitHub Actions (`GITHUB_ACTIONS === 'true'`). Gating on
+ *   that specific signal rather than the generic `CI` avoids a false failure
+ *   if some local tool sets `CI=1`; developers running the SQLite-only subset
+ *   never see it.
+ * - Lives in the drizzle package's tests, so it executes only in the
+ *   `test-adapters` job — the only CI job whose `bun test` runs this package.
+ *   The core / cli / ui / marketing jobs never load it.
+ *
+ * If the workflow intentionally stops providing a database, delete this file in
+ * the same change — do not let it rot into a skipped test.
+ */
+
+import { describe, expect, it } from 'bun:test';
+
+const inGitHubActions = process.env.GITHUB_ACTIONS === 'true';
+
+describe.skipIf(!inGitHubActions)('CI integration-database guard', () => {
+  it('POSTGRES_TEST_URL is set so the Postgres integration suite runs (not silently skipped)', () => {
+    expect(process.env.POSTGRES_TEST_URL?.trim()).toBeTruthy();
+  });
+
+  it('MYSQL_TEST_URL is set so the MySQL integration suite runs (not silently skipped)', () => {
+    expect(process.env.MYSQL_TEST_URL?.trim()).toBeTruthy();
+  });
+});

--- a/packages/adapters/drizzle/tests/on-invalid-filter.test.ts
+++ b/packages/adapters/drizzle/tests/on-invalid-filter.test.ts
@@ -1,0 +1,233 @@
+/**
+ * @fileoverview `onInvalidFilter: 'skip' | 'throw'` behavior.
+ *
+ * A filter leaf that cannot be translated to a WHERE condition (an operator
+ * invalid for the type, or a supported operator with missing/incomplete values)
+ * is DROPPED by default, which widens the result set under implicit-AND — a
+ * scoping filter that silently disappears reads as "no restriction". The
+ * `onInvalidFilter: 'throw'` option makes such a leaf raise a `QueryError`
+ * instead, for callers whose filters are built programmatically and must all
+ * apply.
+ *
+ * Two layers are covered:
+ * - FilterHandler unit tests (skip vs throw, both malformed branches)
+ * - end-to-end through `adapter.fetchData` (flat filters and a group tree),
+ *   proving the throw propagates the whole way up.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+import type { FilterGroupNode, FilterOperator, FilterState } from '@better-tables/core';
+import { pgTable, text, uuid } from 'drizzle-orm/pg-core';
+import { DrizzleAdapter as DrizzleAdapterClass } from '../src/drizzle-adapter';
+import { FilterHandler } from '../src/filter-handler';
+import { RelationshipManager } from '../src/relationship-manager';
+import type { DrizzleAdapterConfig, DrizzleDatabase, InvalidFilterBehavior } from '../src/types';
+import { QueryError } from '../src/types';
+import {
+  type BunSQLiteDatabase,
+  closeSQLiteDatabase,
+  createTestDatabase,
+  setupTestDatabase,
+} from './helpers/test-fixtures';
+import { relationsSchema, schema as testSchema } from './helpers/test-schema';
+
+// ---------------------------------------------------------------------------
+// FilterHandler unit tests (no DB)
+// ---------------------------------------------------------------------------
+
+const users = pgTable('users', {
+  id: uuid('id').primaryKey(),
+  name: text('name'),
+  role: text('role'),
+});
+const unitSchema = { users };
+
+function makeHandler(onInvalidFilter?: InvalidFilterBehavior): FilterHandler {
+  return new FilterHandler(
+    unitSchema,
+    new RelationshipManager(unitSchema, {}),
+    'postgres',
+    undefined,
+    onInvalidFilter
+  );
+}
+
+// `is` belongs to OPTION_OPERATORS, so it is invalid for a `text` column.
+const invalidOperatorLeaf = [
+  { columnId: 'role', type: 'text', operator: 'is' as FilterOperator, values: ['admin'] },
+] as unknown as FilterState[];
+
+// `contains` is valid for text, but the values are incomplete.
+const incompleteValuesLeaf: FilterState[] = [
+  { columnId: 'name', type: 'text', operator: 'contains', values: [] },
+];
+
+describe('onInvalidFilter — FilterHandler', () => {
+  describe("default ('skip')", () => {
+    it('drops an operator invalid for the type (with a warning) and does not throw', () => {
+      const handler = makeHandler();
+      const spy = spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        const { conditions } = handler.handleCrossTableFilters(invalidOperatorLeaf, 'users');
+        expect(conditions).toHaveLength(0);
+        expect(spy.mock.calls.length).toBe(1);
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    it('drops incomplete values silently and does not throw', () => {
+      const handler = makeHandler();
+      const spy = spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        const { conditions } = handler.handleCrossTableFilters(incompleteValuesLeaf, 'users');
+        expect(conditions).toHaveLength(0);
+        expect(spy.mock.calls.length).toBe(0);
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    it("is the behavior when the option is passed explicitly as 'skip'", () => {
+      const handler = makeHandler('skip');
+      const spy = spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        expect(() => handler.handleCrossTableFilters(invalidOperatorLeaf, 'users')).not.toThrow();
+      } finally {
+        spy.mockRestore();
+      }
+    });
+  });
+
+  describe("'throw'", () => {
+    it('throws a QueryError for an operator invalid for the type', () => {
+      const handler = makeHandler('throw');
+      expect(() => handler.handleCrossTableFilters(invalidOperatorLeaf, 'users')).toThrow(
+        QueryError
+      );
+    });
+
+    it('throws a QueryError for incomplete values on a supported operator', () => {
+      const handler = makeHandler('throw');
+      expect(() => handler.handleCrossTableFilters(incompleteValuesLeaf, 'users')).toThrow(
+        QueryError
+      );
+    });
+
+    it('names the column and mentions onInvalidFilter, without leaking values', () => {
+      const handler = makeHandler('throw');
+      const secret = 'super-secret-value';
+      try {
+        handler.handleCrossTableFilters(
+          [
+            { columnId: 'role', type: 'text', operator: 'is' as FilterOperator, values: [secret] },
+          ] as unknown as FilterState[],
+          'users'
+        );
+        throw new Error('expected handleCrossTableFilters to throw');
+      } catch (error) {
+        expect(error).toBeInstanceOf(QueryError);
+        const message = (error as QueryError).message;
+        expect(message).toContain('role');
+        expect(message).toContain('onInvalidFilter');
+        expect(message).not.toContain(secret);
+      }
+    });
+
+    it('does NOT throw for a valid, complete filter', () => {
+      const handler = makeHandler('throw');
+      const { conditions } = handler.handleCrossTableFilters(
+        [{ columnId: 'name', type: 'text', operator: 'contains', values: ['ada'] }],
+        'users'
+      );
+      expect(conditions).toHaveLength(1);
+    });
+
+    it('does NOT throw for the match-null intent (includeNull + empty values)', () => {
+      const handler = makeHandler('throw');
+      // A real "match null rows only" request, not a drop — must be unaffected.
+      const nullOnly: FilterState[] = [
+        { columnId: 'name', type: 'text', operator: 'contains', values: [], includeNull: true },
+      ];
+      expect(() => handler.handleCrossTableFilters(nullOnly, 'users')).not.toThrow();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end through adapter.fetchData (SQLite)
+// ---------------------------------------------------------------------------
+
+function makeAdapter(onInvalidFilter?: InvalidFilterBehavior, db?: BunSQLiteDatabase) {
+  const config: DrizzleAdapterConfig<typeof testSchema, 'sqlite'> = {
+    db: (db as unknown as DrizzleDatabase<'sqlite'>) ?? undefined,
+    schema: testSchema,
+    driver: 'sqlite',
+    autoDetectRelationships: true,
+    relations: relationsSchema,
+    options: onInvalidFilter
+      ? { defaultPrimaryTable: 'users', onInvalidFilter }
+      : { defaultPrimaryTable: 'users' },
+  } as DrizzleAdapterConfig<typeof testSchema, 'sqlite'>;
+  return new DrizzleAdapterClass(config);
+}
+
+// `is` is not a valid text operator — a malformed leaf that widens results.
+const malformedFilter = [
+  { columnId: 'name', type: 'text', operator: 'is' as FilterOperator, values: ['John Doe'] },
+] as unknown as FilterState[];
+
+describe('onInvalidFilter — adapter.fetchData', () => {
+  let db: BunSQLiteDatabase;
+  let sqlite: ReturnType<typeof createTestDatabase>['sqlite'];
+
+  beforeEach(async () => {
+    const created = createTestDatabase();
+    db = created.db;
+    sqlite = created.sqlite;
+    await setupTestDatabase(db);
+  });
+
+  afterEach(() => {
+    closeSQLiteDatabase(sqlite);
+  });
+
+  it('default drops the malformed filter and returns the full set (fail-open baseline)', async () => {
+    const adapter = makeAdapter(undefined, db);
+    const spy = spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const result = await adapter.fetchData({ filters: malformedFilter });
+      // 3 seeded users; the malformed filter was dropped, so all come back.
+      expect(result.total).toBe(3);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("'throw' rejects the whole fetch for a malformed flat filter", async () => {
+    const adapter = makeAdapter('throw', db);
+    await expect(adapter.fetchData({ filters: malformedFilter })).rejects.toThrow();
+  });
+
+  it("'throw' rejects for a malformed leaf nested inside a filter group", async () => {
+    const adapter = makeAdapter('throw', db);
+    const group: FilterGroupNode = {
+      kind: 'group',
+      logic: 'or',
+      children: [
+        { columnId: 'name', type: 'text', operator: 'is' as FilterOperator, values: ['x'] },
+        { columnId: 'email', type: 'text', operator: 'contains', values: ['example'] },
+      ],
+    } as unknown as FilterGroupNode;
+    await expect(adapter.fetchData({ filters: group })).rejects.toThrow();
+  });
+
+  it("'throw' still resolves normally for valid filters", async () => {
+    const adapter = makeAdapter('throw', db);
+    // 'Doe' matches only 'John Doe' ('John' would also match 'Bob Johnson').
+    const result = await adapter.fetchData({
+      filters: [{ columnId: 'name', type: 'text', operator: 'contains', values: ['Doe'] }],
+    });
+    expect(result.total).toBe(1);
+  });
+});

--- a/packages/adapters/drizzle/tests/on-invalid-filter.test.ts
+++ b/packages/adapters/drizzle/tests/on-invalid-filter.test.ts
@@ -152,6 +152,27 @@ describe('onInvalidFilter — FilterHandler', () => {
       expect(() => handler.handleCrossTableFilters(nullOnly, 'users')).not.toThrow();
     });
   });
+
+  describe('over-specified operators (surplus values core rejects)', () => {
+    // `contains` takes one value; a second is surplus. Core rejects it, but
+    // translation still builds a valid predicate from the first value — so the
+    // leaf applies rather than being dropped. This is the gap that let a
+    // core-invalid leaf slip past 'throw'.
+    const overSpecified: FilterState[] = [
+      { columnId: 'name', type: 'text', operator: 'contains', values: ['a', 'surplus'] },
+    ];
+
+    it("'skip' still applies it (surplus ignored — unchanged, no regression)", () => {
+      const { conditions } = makeHandler('skip').handleCrossTableFilters(overSpecified, 'users');
+      expect(conditions).toHaveLength(1);
+    });
+
+    it("'throw' now rejects it, so strict mode rejects every core-invalid leaf", () => {
+      expect(() => makeHandler('throw').handleCrossTableFilters(overSpecified, 'users')).toThrow(
+        QueryError
+      );
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Two independent hardening changes for `@better-tables/adapters-drizzle`, split cleanly across the diff.

## 1. `onInvalidFilter: 'skip' | 'throw'`

Closes the fail-open gap left from #97. When a filter leaf can't be translated to SQL — an operator invalid for the column's type, or a supported operator with missing/incomplete values — the adapter drops it so partial URL/UI filter state still fetches. But dropping a leaf **widens** the result set under implicit-AND: a scoping filter built server-side (a tenant or owner guard) that silently disappears reads as "no restriction".

The new `options.onInvalidFilter` makes the choice explicit:

| mode | behavior |
|---|---|
| `'skip'` (default, unchanged) | drop the leaf; invalid operator warns, incomplete values stay silent |
| `'throw'` | raise a `QueryError` instead of dropping |

```ts
const adapter = drizzleAdapter(db, {
  options: { onInvalidFilter: 'throw' },
});
```

- Threads through all three dialects (Postgres/MySQL/SQLite), following the same path `hooks` already takes.
- Applies to flat filters **and** leaves nested inside a `FilterGroupNode`.
- The legitimate "match null rows only" intent (`includeNull` + empty values) is a real condition, not a drop, and is unaffected.
- A `QueryError` raised during filter translation now propagates with its type intact instead of being flattened into a generic `Error`.

**Live-verified** against Neon Postgres on the same 1M-row dataset as #97:

```
skip  -> total=1,000,000  (malformed filter dropped, widened to full table)
throw -> QueryError: Filter on "role" cannot be applied: operator "is" is not valid for type "text"…
```

## 2. CI integration-database guard

While wiring this up I checked a claim I'd made on #97 — that the Postgres/MySQL integration suites were "dormant in CI." **That was wrong.** They already run against real `postgres:16-alpine` and `mysql:8.0` service containers (846 pass / 6 skip on the last main run). The original bug slipped through for lack of a *test case*, which #97 added — not because the suite was off.

But the suites self-skip when their `*_TEST_URL` is unset, so a future workflow refactor that drops a URL would turn them into a **silent green skip** — the real "dormant" risk. `tests/ci-integration-guard.test.ts` fails the adapter job (only under GitHub Actions) if either URL is missing, so "the integration tests didn't run" can never masquerade as "they passed." Verified in all three states: skips locally, passes with both URLs, fails with either missing.

## Verification

- Repo-wide typecheck ✓, `@better-tables/adapters-drizzle` **684 pass / 0 fail**, biome clean on all touched files.
- New unit + e2e tests (skip vs throw, both malformed branches, flat + group filters), each confirmed to fail without its fix.
- Changeset: minor bump (new option). The CI guard touches only tests + workflow, so no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds strict invalid-filter handling to `@better-tables/adapters-drizzle` via `options.onInvalidFilter`, and adds a CI guard to ensure Postgres/MySQL integration tests actually run.

- **New Features**
  - Add `options.onInvalidFilter: 'skip' | 'throw'` (default `'skip'`). `'throw'` raises a `QueryError` instead of dropping malformed filters. Works across Postgres/MySQL/SQLite and for flat/group filters.
  - In `'throw'` mode, reject every leaf that core validation rejects, including over‑specified operators with surplus values; `'skip'` still applies these (surplus ignored). “Match null rows only” (`includeNull` + empty values) is unchanged.
  - Filter `QueryError`s now propagate with their type instead of being flattened.

- **Bug Fixes**
  - Add `tests/ci-integration-guard.test.ts` to fail in GitHub Actions if `POSTGRES_TEST_URL` or `MYSQL_TEST_URL` is missing, preventing silent green skips.

<sup>Written for commit ee007ba11bc88276fabb85f205508ab08aedfa51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Better-Tables/better-tables/pull/98?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

