### PR TITLE
Plan 059: UI modules tier + actions as the first opt-in module

### DIFF
--- a/.changeset/ui-modules-and-actions.md
+++ b/.changeset/ui-modules-and-actions.md
@@ -1,0 +1,9 @@
+---
+"@better-tables/cli": minor
+---
+
+Add an opt-in **module** tier to the copied UI. `init` now copies the `core` module by default (the table, filters, hooks, and utilities) and accepts `--modules <names>` to opt in at init time; a new `better-tables add <module>` command copies opt-in modules on demand. The first opt-in module is `actions` — the bulk-actions toolbar (`actions-toolbar.tsx` + `action-confirmation-dialog.tsx`), which is no longer part of the default `init` set.
+
+Modules plug into the table through a new `slots` prop on `<BetterTable>` (`@better-tables/ui`, copied source — no npm surface): `slots={{ actionsToolbar: ActionsToolbar }}` installs the actions toolbar. Passing `actions` without wiring the slot renders nothing and warns once in dev, naming the fix. The manifest drift test now enforces that every UI source file belongs to exactly one module (union === tree, modules disjoint).
+
+Vocabulary: the copied-UI tier is "modules" (`better-tables add`); the core `betterTables({ plugins })` tier stays "plugins". They are different layers.

--- a/apps/marketing/content/docs/selection-and-actions.mdx
+++ b/apps/marketing/content/docs/selection-and-actions.mdx
@@ -18,17 +18,27 @@ Row selection adds a checkbox column (with select-all in the header) and tracks 
 
 Row identity comes from `rowConfig.getId(row)` when provided, falling back to the row's `id` field — set `getId` whenever your rows have a different key.
 
+Plain row selection needs no module — it is part of core.
+
 ## Bulk actions
 
-`actions` is a `TableAction[]`; the actions toolbar renders above the table and invokes handlers with the current selection:
+The actions toolbar is an opt-in [module](/docs/ui-and-cli#modules). Add it once:
+
+```bash
+bunx @better-tables/cli add actions
+```
+
+Then wire it into the table's `actionsToolbar` slot. `actions` is a `TableAction[]`; the toolbar renders above the table and invokes handlers with the current selection:
 
 ```tsx
 import { Archive, Trash2 } from 'lucide-react';
+import { ActionsToolbar } from '@/components/better-tables-ui/table/actions-toolbar';
 
 <BetterTable
   id="tickets"
   columns={columns}
   data={data}
+  slots={{ actionsToolbar: ActionsToolbar }}
   actions={[
     {
       id: 'archive',

--- a/apps/marketing/content/docs/troubleshooting.mdx
+++ b/apps/marketing/content/docs/troubleshooting.mdx
@@ -28,6 +28,14 @@ See [Next.js Integration](/docs/nextjs) and the reference implementation in `app
 
 `init` requires a working shadcn setup (`components.json`). It will print remediation steps; set up shadcn first, then re-run. It also checks for `@better-tables/core`, `@better-tables/adapters-drizzle`, and UI runtime deps (`zustand`, `@dnd-kit/*`) and offers to install them. Invoke as `bunx @better-tables/cli init`. Flags: `--skip-shadcn`, `-y`, `--components-path`, `--cwd` — see [UI & CLI](/docs/ui-and-cli).
 
+## Bulk actions don't render
+
+The actions toolbar is an opt-in [module](/docs/ui-and-cli#modules). If you pass `actions` but the toolbar never appears, either the module isn't added or the slot isn't wired — the table warns once in dev:
+
+> `actions` were provided but no `slots.actionsToolbar` is set, so the bulk-actions toolbar will not render. Install the actions module (`bunx better-tables add actions`) and pass `slots={{ actionsToolbar: ActionsToolbar }}`.
+
+Run `bunx @better-tables/cli add actions`, then pass `slots={{ actionsToolbar: ActionsToolbar }}` (imported from the copied `table/actions-toolbar`). Row selection itself is core and still turns on whenever `actions` is non-empty — only the toolbar needs the module. See [Selection & actions](/docs/selection-and-actions#bulk-actions).
+
 ## An editable cell renders read-only
 
 Save resolution walks a fixed order (see [Inline editing](/docs/inline-editing#save-resolution)) and falls back to read-only, logging **one dev `console.warn` per column** explaining which condition failed. Check, in order: `editing={false}` on the table, missing/false `editable` config (`when(row)` returning false), and — for the adapter path — `adapter.meta.features.update`, an `updateRecord` implementation, a resolvable write target, and a row id (`rowConfig.getId` or an `id` field).

--- a/apps/marketing/content/docs/ui-and-cli.mdx
+++ b/apps/marketing/content/docs/ui-and-cli.mdx
@@ -42,6 +42,31 @@ Import from the copied paths — there is no `@better-tables/ui` package to impo
 import { BetterTable } from '@/components/better-tables-ui/table/table';
 ```
 
+## Modules
+
+The copied UI ships in **modules** — named groups of source files you opt into. `init` copies the **core** module (the table, filters, hooks, and utilities). Everything else is added on demand:
+
+```bash
+bunx @better-tables/cli add actions   # bulk-action toolbar over selected rows
+```
+
+`init` also accepts `--modules` to opt in at init time:
+
+```bash
+bunx @better-tables/cli init --modules actions
+```
+
+| Module | What it copies | Wire-up |
+|---|---|---|
+| `core` | Table, filters, hooks, lib (always copied by `init`) | — |
+| `actions` | `actions-toolbar.tsx`, `action-confirmation-dialog.tsx` | `slots={{ actionsToolbar: ActionsToolbar }}` — see [Selection & actions](/docs/selection-and-actions) |
+
+Modules plug into the table through the `slots` prop — an absent module is a clean no-op, so core has no dead imports. `add <module>` reuses your init-time config; pass the same `--components-path` if you changed it. An unknown module name lists the valid ones and exits non-zero.
+
+<Callout>
+**Modules vs. plugins.** These are different tiers. **Modules** are copied UI source added with `better-tables add` (this page). **Plugins** are npm-distributed data hooks passed to `betterTables({ plugins: [...] })` — no UI. Keep the words distinct.
+</Callout>
+
 ## Why copy instead of npm?
 
 - You own the JSX — no fighting a black-box design system

--- a/apps/marketing/src/components/home/users-table-client.tsx
+++ b/apps/marketing/src/components/home/users-table-client.tsx
@@ -2,7 +2,7 @@
 
 import type { FilterState, PaginationState, SortingState } from '@better-tables/core';
 import { httpAdapter } from '@better-tables/core';
-import { BetterTable, useTableUrlSync } from '@better-tables/ui';
+import { ActionsToolbar, BetterTable, useTableUrlSync } from '@better-tables/ui';
 import { useRouter } from 'next/navigation';
 import { useMemo } from 'react';
 import { userActions } from '@/lib/actions/user-actions';
@@ -74,6 +74,10 @@ export function UsersTableClient({
       adapter={adapter}
       columns={userColumns}
       actions={actions}
+      // Actions is an opt-in UI module (plan 059) — wire its toolbar into the
+      // slot. In a CLI-copied project this is `better-tables add actions` +
+      // this same slot line.
+      slots={{ actionsToolbar: ActionsToolbar }}
       data={data}
       totalCount={totalCount}
       initialPagination={initialPagination}

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -3,6 +3,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Command } from 'commander';
 import { commandsRegistry, type RegisteredCommandName } from './commands';
+import { addCommand } from './commands/add';
 import { docsCommand } from './commands/docs';
 import { helpCommand } from './commands/help';
 import { initCommand } from './commands/init';
@@ -26,6 +27,7 @@ program
 registerCommandFactory('help', helpCommand);
 registerCommandFactory('docs', docsCommand);
 registerCommandFactory('init', initCommand);
+registerCommandFactory('add', addCommand);
 
 // Add all registered commands to the program
 // TypeScript ensures we can only reference commands that exist in the registry

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -42,6 +42,31 @@ export const commandsRegistry = {
         description:
           'Output path for components relative to components directory (default: better-tables-ui)',
       },
+      {
+        flags: '--modules <names...>',
+        description: 'Opt-in UI modules to copy alongside core (e.g. actions)',
+      },
+    ] as const,
+  },
+  add: {
+    name: 'add',
+    description: 'Add an opt-in UI module to a Better Tables project (e.g. actions)',
+    arguments: [
+      {
+        name: 'modules',
+        description: 'One or more module names to copy (e.g. actions)',
+        required: true,
+        variadic: true,
+      },
+    ] as const,
+    options: [
+      { flags: '--cwd <path>', description: 'Working directory (default: current directory)' },
+      { flags: '-y, --yes', description: 'Skip confirmation prompts' },
+      {
+        flags: '--components-path <path>',
+        description:
+          'Output path for components relative to components directory (must match init; default: better-tables-ui)',
+      },
     ] as const,
   },
 } as const satisfies CommandRegistry;

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -1,0 +1,147 @@
+import { join, resolve } from 'node:path';
+import { Command } from 'commander';
+import pc from 'picocolors';
+import type { RegisteredCommandName } from '../commands';
+import { getCommandDefinition } from '../lib/command-factory';
+import { getAliasPrefix, getConfig } from '../lib/config';
+import { type CopyResult, copyAllFiles } from '../lib/file-operations';
+import {
+  isValidRelativeSubpath,
+  printCopySummary,
+  resolveModuleNames,
+} from '../lib/module-install';
+import { confirm } from '../lib/prompts';
+
+interface AddOptions {
+  cwd?: string;
+  yes?: boolean;
+  componentsPath?: string;
+}
+
+/**
+ * Factory for the `add` command (plan 059): copies one or more opt-in UI
+ * modules into an already-initialized project. It reuses `init`'s config
+ * resolution and copy machinery but does NOT re-run the shadcn/package checks
+ * — those ran at `init`. It copies only the named modules (not `core`).
+ */
+export function addCommand(): Command {
+  const commandName: RegisteredCommandName = 'add';
+  const definition = getCommandDefinition(commandName);
+  const command = new Command(definition.name);
+  command.description(definition.description);
+
+  // Variadic module argument (the shared factory arg-loop doesn't emit
+  // variadic syntax, so declare it directly here).
+  command.argument('<modules...>', 'One or more module names to copy (e.g. actions)');
+
+  // Options from the registry definition.
+  if (definition.options && definition.options.length > 0) {
+    const options = definition.options as unknown as Array<{
+      flags: string;
+      description: string;
+      defaultValue?: string | boolean | number;
+    }>;
+    for (const option of options) {
+      command.option(option.flags, option.description, option.defaultValue as string | undefined);
+    }
+  }
+
+  command.action(async (modules: string[], options: AddOptions) => {
+    const cwd = resolve(options.cwd || process.cwd());
+    const skipPrompts = options.yes ?? false;
+    const componentsPath = options.componentsPath || 'better-tables-ui';
+
+    // Validate the components path (same rule as init).
+    if (!isValidRelativeSubpath(componentsPath)) {
+      console.error(
+        pc.red(
+          `✗ Invalid components path: "${componentsPath}". Path must be a safe relative subpath without path traversal sequences.`
+        )
+      );
+      console.error(
+        pc.dim('  Use a plain relative path instead, e.g. --components-path better-tables-ui')
+      );
+      process.exit(1);
+    }
+
+    // Validate module names against the manifest.
+    const moduleNames = resolveModuleNames(modules);
+    if (!moduleNames) {
+      process.exit(1);
+    }
+
+    console.log(pc.bold(`\n📦 Adding Better Tables module(s): ${moduleNames.join(', ')}\n`));
+    console.log(`Working directory: ${pc.cyan(cwd)}\n`);
+
+    // Resolve project config (shadcn components.json) — same resolution init
+    // uses. No shadcn/package re-check: those ran at init.
+    const configResult = getConfig(cwd);
+    if (!configResult) {
+      console.error(pc.red('✗ Failed to read components.json'));
+      console.error(
+        pc.dim('  Run `bunx better-tables init` first, or check components.json is valid JSON.')
+      );
+      process.exit(1);
+    }
+    const { config, resolvedPaths } = configResult;
+
+    const componentsBasePath = join(resolvedPaths.components, componentsPath);
+    let shouldCopy = true;
+    if (!skipPrompts) {
+      console.log(pc.dim('The following directories will be created/updated:'));
+      console.log(pc.dim(`  • ${componentsBasePath}/table/`));
+      console.log(pc.dim(`  • ${componentsBasePath}/filters/`));
+      console.log(pc.dim(`  • ${resolvedPaths.hooks}/`));
+      console.log(pc.dim(`  • ${resolvedPaths.lib}/\n`));
+      shouldCopy = await confirm('Proceed with copying files?', true);
+    }
+    if (!shouldCopy) {
+      console.log(pc.yellow('\nAborted. No files were copied.\n'));
+      process.exit(0);
+    }
+
+    let results: CopyResult[];
+    let categories: Record<string, number>;
+    try {
+      const copyResult = await copyAllFiles(
+        config,
+        resolvedPaths,
+        skipPrompts,
+        componentsPath,
+        moduleNames
+      );
+      results = copyResult.results;
+      categories = copyResult.categories;
+    } catch (error) {
+      console.error(
+        pc.red(`✗ Failed to copy files: ${error instanceof Error ? error.message : String(error)}`)
+      );
+      console.error(
+        pc.dim('  The bundled UI source may be corrupted — reinstall @better-tables/cli.')
+      );
+      process.exit(1);
+      return;
+    }
+
+    const ok = printCopySummary(results, categories);
+
+    console.log(pc.bold(pc.green('\n✓ Module(s) added.\n')));
+    if (moduleNames.includes('actions')) {
+      const aliasPrefix = getAliasPrefix(config);
+      console.log(pc.dim('Wire the actions toolbar into your table via the slot prop:'));
+      console.log(
+        pc.cyan(
+          `  import { ActionsToolbar } from '${aliasPrefix}components/${componentsPath}/table/actions-toolbar';`
+        )
+      );
+      console.log(pc.cyan('  <BetterTable ... slots={{ actionsToolbar: ActionsToolbar }} />'));
+      console.log('');
+    }
+
+    if (!ok) {
+      process.exit(1);
+    }
+  });
+
+  return command;
+}

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,10 +1,16 @@
-import { join, normalize, resolve } from 'node:path';
+import { join, resolve } from 'node:path';
 import { Command } from 'commander';
 import pc from 'picocolors';
 import type { RegisteredCommandName } from '../commands';
 import { getCommandDefinition } from '../lib/command-factory';
 import { getAliasPrefix, getConfig } from '../lib/config';
-import { type CopyResult, copyAllFiles } from '../lib/file-operations';
+import { type CopyResult, copyAllFiles, type UiModuleName } from '../lib/file-operations';
+import {
+  isValidRelativeSubpath,
+  printAvailableModules,
+  printCopySummary,
+  resolveModuleNames,
+} from '../lib/module-install';
 import {
   detectNextJS,
   detectPackageManager,
@@ -22,36 +28,7 @@ interface InitOptions {
   skipShadcn?: boolean;
   yes?: boolean;
   componentsPath?: string;
-}
-
-/**
- * Validate that a path is a safe relative subpath (no path traversal)
- *
- * @param path - The path to validate
- * @returns True if the path is safe, false otherwise
- */
-function isValidRelativeSubpath(path: string): boolean {
-  if (!path || path.length === 0) {
-    return false;
-  }
-  // Check for null bytes
-  if (path.includes('\0')) {
-    return false;
-  }
-  // Check for absolute paths (Unix: starts with /, Windows: starts with drive letter)
-  if (path.startsWith('/') || /^[a-zA-Z]:[\\/]/.test(path)) {
-    return false;
-  }
-  // Normalize the path and check for path traversal sequences
-  const normalized = normalize(path);
-  // Check for any occurrence of .. (parent directory traversal)
-  if (normalized.includes('..')) {
-    return false;
-  }
-  // Check for backslashes on Windows (should use forward slashes for cross-platform compatibility)
-  // But we'll allow them since path.join handles them
-  // Ensure it's a valid relative path
-  return !normalized.startsWith('..') && normalized !== '.';
+  modules?: string[];
 }
 
 /**
@@ -101,6 +78,14 @@ export function initCommand(): Command {
       );
       process.exit(1);
     }
+    // Resolve which modules to copy: `core` always, plus any opted in via
+    // `--modules`. An unknown name reports valid names and exits non-zero.
+    const optedIn = resolveModuleNames(options.modules ?? []);
+    if (!optedIn) {
+      process.exit(1);
+      return;
+    }
+    const modulesToCopy: UiModuleName[] = ['core', ...optedIn.filter((name) => name !== 'core')];
     console.log(pc.bold('\n🚀 Better Tables Initialization\n'));
     console.log(`Working directory: ${pc.cyan(cwd)}\n`);
     // Step 1: Detect project type
@@ -244,7 +229,13 @@ export function initCommand(): Command {
     let results: CopyResult[];
     let categories: Record<string, number>;
     try {
-      const copyResult = await copyAllFiles(config, resolvedPaths, skipPrompts, componentsPath);
+      const copyResult = await copyAllFiles(
+        config,
+        resolvedPaths,
+        skipPrompts,
+        componentsPath,
+        modulesToCopy
+      );
       results = copyResult.results;
       categories = copyResult.categories;
     } catch (error) {
@@ -257,32 +248,7 @@ export function initCommand(): Command {
       process.exit(1);
     }
     // Summary
-    const successful = results.filter((r) => r.success && !r.skipped).length;
-    const skipped = results.filter((r) => r.skipped).length;
-    const failed = results.filter((r) => !r.success).length;
-    console.log(pc.bold('\n📁 Files copied:\n'));
-    console.log(pc.green(`  • ${successful} files copied successfully`));
-    if (Object.keys(categories).length === 0) {
-      console.log(pc.yellow('  ⚠️  No files were copied. This may indicate:'));
-      console.log(pc.dim('     • UI package source files not found'));
-      console.log(pc.dim('     • Path resolution issue'));
-      console.log(pc.dim('     • All files already exist\n'));
-    } else {
-      for (const [category, count] of Object.entries(categories)) {
-        console.log(`  • ${category}: ${pc.green(String(count))} files`);
-      }
-      console.log('');
-    }
-    if (skipped > 0) {
-      console.log(pc.yellow(`  • ${skipped} files skipped (already exist)`));
-    }
-    if (failed > 0) {
-      console.error(pc.red(`  • ${failed} files failed to copy`));
-      const failedResults = results.filter((r) => !r.success);
-      for (const result of failedResults) {
-        console.error(pc.dim(`    - ${result.path}: ${result.error}`));
-      }
-    }
+    printCopySummary(results, categories);
     // Final message
     console.log(pc.bold(pc.green('\n✓ Better Tables initialized successfully!\n')));
     console.log(pc.dim('Next steps:'));
@@ -300,6 +266,8 @@ export function initCommand(): Command {
           '     • a database adapter, e.g. @better-tables/adapters-drizzle (install separately)'
       )
     );
+    // Discoverability: `init` copies `core` only — tell users what modules exist.
+    printAvailableModules();
     console.log('');
   });
   return command;

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -248,7 +248,7 @@ export function initCommand(): Command {
       process.exit(1);
     }
     // Summary
-    printCopySummary(results, categories);
+    const copiedOk = printCopySummary(results, categories);
     // Final message
     console.log(pc.bold(pc.green('\n✓ Better Tables initialized successfully!\n')));
     console.log(pc.dim('Next steps:'));
@@ -269,6 +269,11 @@ export function initCommand(): Command {
     // Discoverability: `init` copies `core` only — tell users what modules exist.
     printAvailableModules();
     console.log('');
+    // Genuine copy failures (not skips) must not report success — exit
+    // non-zero after showing the summary + failed-file details, like `add`.
+    if (!copiedOk) {
+      process.exit(1);
+    }
   });
   return command;
 }

--- a/packages/cli/src/lib/file-operations.ts
+++ b/packages/cli/src/lib/file-operations.ts
@@ -90,7 +90,22 @@ export async function readUiSourceFile(filePath: string): Promise<string> {
 }
 
 /**
- * Known list of files to copy from the bundled UI source.
+ * Shape of one UI **module** — a named, independently copyable group of files
+ * (plan 059). Every file under `packages/ui/src` belongs to EXACTLY ONE module
+ * (`tests/ui-source-manifest.test.ts` enforces the union AND disjointness).
+ */
+interface UiModuleFiles {
+  components?: {
+    table?: readonly string[];
+    filters?: readonly string[];
+  };
+  hooks?: readonly string[];
+  lib?: readonly string[];
+}
+
+/**
+ * The UI module manifest. `core` is the default set `init` copies; every other
+ * module is opt-in via `better-tables add <module>`.
  *
  * Must mirror `packages/ui/src` exactly (minus the exclusions below) —
  * `tests/ui-source-manifest.test.ts` fails the build on any drift in either
@@ -98,118 +113,180 @@ export async function readUiSourceFile(filePath: string): Promise<string> {
  * `styles/` (a reference theme; consumers own their Tailwind setup), and
  * `components/ui/` (shadcn primitives installed via the shadcn CLI).
  */
-const UI_SOURCE_FILES = {
-  components: {
-    table: [
-      'action-confirmation-dialog.tsx',
-      'actions-toolbar.tsx',
-      'column-order-drop-indicator.tsx',
-      'column-order-list.tsx',
-      'column-visibility-toggle.tsx',
-      'drop-indicator.tsx',
-      'editable-cell.tsx',
-      'empty-state.tsx',
-      'error-state.tsx',
+const UI_MODULES = {
+  /** The always-copied base: the table, filters, hooks, and lib utils. */
+  core: {
+    components: {
+      table: [
+        'column-order-drop-indicator.tsx',
+        'column-order-list.tsx',
+        'column-visibility-toggle.tsx',
+        'drop-indicator.tsx',
+        'editable-cell.tsx',
+        'empty-state.tsx',
+        'error-state.tsx',
+        'index.ts',
+        'sort-order-drop-indicator.tsx',
+        'sort-order-list.tsx',
+        'table-dnd-provider.tsx',
+        'table-header-context-menu.tsx',
+        'table-pagination.tsx',
+        'table-providers.tsx',
+        'table.tsx',
+        'virtualized-table.tsx',
+      ],
+      filters: [
+        'active-filters.tsx',
+        'faceted-filter-sidebar.tsx',
+        'filter-bar.tsx',
+        'filter-button.tsx',
+        'filter-dropdown.tsx',
+        'filter-operator-select.tsx',
+        'filter-type-styles.ts',
+        'filter-value-input.tsx',
+        'include-unknown-control.tsx',
+        'index.ts',
+        'inputs/boolean-filter-input.tsx',
+        'inputs/date-filter-input.tsx',
+        'inputs/multi-option-filter-input.tsx',
+        'inputs/number-filter-input.tsx',
+        'inputs/option-filter-input.tsx',
+        'inputs/text-filter-input.tsx',
+      ],
+    },
+    hooks: [
       'index.ts',
-      'sort-order-drop-indicator.tsx',
-      'sort-order-list.tsx',
-      'table-dnd-provider.tsx',
-      'table-header-context-menu.tsx',
-      'table-pagination.tsx',
-      'table-providers.tsx',
-      'table.tsx',
-      'virtualized-table.tsx',
+      'use-column-options.tsx',
+      'use-debounce.ts',
+      'use-editable-cells.ts',
+      'use-facets.ts',
+      'use-filter-validation.ts',
+      'use-keyboard-navigation.ts',
+      'use-table-data.ts',
+      'use-table-store.ts',
+      'use-table-url-sync.ts',
+      'use-virtualization.ts',
+      'use-virtualized-table-data.ts',
     ],
-    filters: [
-      'active-filters.tsx',
-      'faceted-filter-sidebar.tsx',
-      'filter-bar.tsx',
-      'filter-button.tsx',
-      'filter-dropdown.tsx',
-      'filter-operator-select.tsx',
-      'filter-type-styles.ts',
-      'filter-value-input.tsx',
-      'include-unknown-control.tsx',
-      'index.ts',
-      'inputs/boolean-filter-input.tsx',
-      'inputs/date-filter-input.tsx',
-      'inputs/multi-option-filter-input.tsx',
-      'inputs/number-filter-input.tsx',
-      'inputs/option-filter-input.tsx',
-      'inputs/text-filter-input.tsx',
-    ],
+    lib: ['utils.ts'],
   },
-  hooks: [
-    'index.ts',
-    'use-column-options.tsx',
-    'use-debounce.ts',
-    'use-editable-cells.ts',
-    'use-facets.ts',
-    'use-filter-validation.ts',
-    'use-keyboard-navigation.ts',
-    'use-table-data.ts',
-    'use-table-store.ts',
-    'use-table-url-sync.ts',
-    'use-virtualization.ts',
-    'use-virtualized-table-data.ts',
-  ],
-  lib: ['utils.ts'],
-} as const;
+  /** Bulk-action toolbar over selected rows — rides `table.tsx`'s slot seam. */
+  actions: {
+    components: {
+      table: ['action-confirmation-dialog.tsx', 'actions-toolbar.tsx'],
+    },
+  },
+} as const satisfies Record<string, UiModuleFiles>;
+
+/** A valid UI module name (`'core' | 'actions' | …`). */
+export type UiModuleName = keyof typeof UI_MODULES;
+
+/** Every module name, in declaration order (`core` first). */
+export const UI_MODULE_NAMES = Object.keys(UI_MODULES) as UiModuleName[];
+
+/** Opt-in module names (everything except the always-copied `core`). */
+export const OPTIONAL_UI_MODULE_NAMES = UI_MODULE_NAMES.filter(
+  (name) => name !== 'core'
+) as Exclude<UiModuleName, 'core'>[];
+
+/** Type guard: is `name` a real module? */
+export function isUiModuleName(name: string): name is UiModuleName {
+  return Object.hasOwn(UI_MODULES, name);
+}
+
+/** Category label + destination for a copied file, by its source subtree. */
+interface FileSlot {
+  category: string;
+  /** Destination path for `file`, given the resolved paths + components base. */
+  dest: (file: string, componentsBasePath: string, resolvedPaths: ResolvedPaths) => string;
+}
+
+const FILE_SLOTS = {
+  table: {
+    category: 'table',
+    source: (file: string) => `components/table/${file}`,
+    dest: (file, base) => join(base, 'table', file),
+  },
+  filters: {
+    category: 'filters',
+    source: (file: string) => `components/filters/${file}`,
+    dest: (file, base) => join(base, 'filters', file),
+  },
+  hooks: {
+    category: 'hooks',
+    source: (file: string) => `hooks/${file}`,
+    dest: (file, _base, paths) => join(paths.hooks, file),
+  },
+  lib: {
+    category: 'lib',
+    source: (file: string) => `lib/${file}`,
+    dest: (file, _base, paths) => join(paths.lib, file),
+  },
+} satisfies Record<string, FileSlot & { source: (file: string) => string }>;
+
+/** Yield `[slotKey, file]` for every file in one module. */
+function* iterModuleFiles(module: UiModuleFiles): Generator<[keyof typeof FILE_SLOTS, string]> {
+  for (const file of module.components?.table ?? []) yield ['table', file];
+  for (const file of module.components?.filters ?? []) yield ['filters', file];
+  for (const file of module.hooks ?? []) yield ['hooks', file];
+  for (const file of module.lib ?? []) yield ['lib', file];
+}
 
 /**
- * Source paths (relative to the bundled UI root) of every file `init` copies.
+ * Source paths (relative to the bundled UI root) of one module's files.
+ *
+ * @internal Exported for tests.
+ */
+export function getModuleSourceFilePaths(moduleName: UiModuleName): string[] {
+  const paths: string[] = [];
+  for (const [slotKey, file] of iterModuleFiles(UI_MODULES[moduleName])) {
+    paths.push(FILE_SLOTS[slotKey].source(file));
+  }
+  return paths;
+}
+
+/**
+ * Source paths of EVERY module's files (the union). The drift test pins this to
+ * the real `packages/ui/src` tree.
+ *
+ * @internal Exported for tests.
+ */
+export function getAllUiSourceFilePaths(): string[] {
+  return UI_MODULE_NAMES.flatMap((name) => getModuleSourceFilePaths(name));
+}
+
+/**
+ * Back-compat alias for the full union.
  *
  * @internal Exported for tests only.
  */
 export function getUiSourceFilePaths(): string[] {
-  return [
-    ...UI_SOURCE_FILES.components.table.map((file) => `components/table/${file}`),
-    ...UI_SOURCE_FILES.components.filters.map((file) => `components/filters/${file}`),
-    ...UI_SOURCE_FILES.hooks.map((file) => `hooks/${file}`),
-    ...UI_SOURCE_FILES.lib.map((file) => `lib/${file}`),
-  ];
+  return getAllUiSourceFilePaths();
 }
 
 /**
- * Generate file mappings for all Better Tables files
+ * Generate file mappings for the given modules (in the order provided). Unknown
+ * names are ignored here — callers validate first (see the `add`/`init`
+ * commands) so a bad name reports instead of silently copying nothing.
  */
 export function generateFileMappings(
   resolvedPaths: ResolvedPaths,
-  componentsOutputPath: string = 'better-tables-ui'
+  componentsOutputPath: string = 'better-tables-ui',
+  moduleNames: readonly UiModuleName[] = UI_MODULE_NAMES
 ): FileMapping[] {
   const mappings: FileMapping[] = [];
   const componentsBasePath = join(resolvedPaths.components, componentsOutputPath);
-  // Table components
-  for (const file of UI_SOURCE_FILES.components.table) {
-    mappings.push({
-      sourcePath: `components/table/${file}`,
-      destPath: join(componentsBasePath, 'table', file),
-      category: 'table',
-    });
-  }
-  // Filter components (including subdirectories like inputs/)
-  for (const file of UI_SOURCE_FILES.components.filters) {
-    mappings.push({
-      sourcePath: `components/filters/${file}`,
-      destPath: join(componentsBasePath, 'filters', file),
-      category: 'filters',
-    });
-  }
-  // Hooks
-  for (const file of UI_SOURCE_FILES.hooks) {
-    mappings.push({
-      sourcePath: `hooks/${file}`,
-      destPath: join(resolvedPaths.hooks, file),
-      category: 'hooks',
-    });
-  }
-  // Lib files
-  for (const file of UI_SOURCE_FILES.lib) {
-    mappings.push({
-      sourcePath: `lib/${file}`,
-      destPath: join(resolvedPaths.lib, file),
-      category: 'lib',
-    });
+  for (const moduleName of moduleNames) {
+    const module = UI_MODULES[moduleName];
+    if (!module) continue;
+    for (const [slotKey, file] of iterModuleFiles(module)) {
+      const slot = FILE_SLOTS[slotKey];
+      mappings.push({
+        sourcePath: slot.source(file),
+        destPath: slot.dest(file, componentsBasePath, resolvedPaths),
+        category: slot.category,
+      });
+    }
   }
   return mappings;
 }
@@ -362,9 +439,10 @@ export async function copyAllFiles(
   config: ShadcnConfig,
   resolvedPaths: ResolvedPaths,
   skipPrompts: boolean,
-  componentsOutputPath: string = 'better-tables-ui'
+  componentsOutputPath: string = 'better-tables-ui',
+  moduleNames: readonly UiModuleName[] = UI_MODULE_NAMES
 ): Promise<{ results: CopyResult[]; categories: Record<string, number> }> {
-  const mappings = generateFileMappings(resolvedPaths, componentsOutputPath);
+  const mappings = generateFileMappings(resolvedPaths, componentsOutputPath, moduleNames);
   const results: CopyResult[] = [];
   const categories: Record<string, number> = {};
   let conflictResolution: ConflictResolution | null = null;

--- a/packages/cli/src/lib/module-install.ts
+++ b/packages/cli/src/lib/module-install.ts
@@ -1,0 +1,125 @@
+import { normalize } from 'node:path';
+import pc from 'picocolors';
+import type { CopyResult } from './file-operations';
+import {
+  isUiModuleName,
+  OPTIONAL_UI_MODULE_NAMES,
+  UI_MODULE_NAMES,
+  type UiModuleName,
+} from './file-operations';
+
+/**
+ * Shared install helpers for the `init` and `add` commands (plan 059). Both
+ * validate the same components path, resolve module names against the same
+ * manifest, and print the same copy summary — this module is the one place
+ * that logic lives so `add` doesn't re-derive init's flow.
+ */
+
+/**
+ * One-line descriptions for the OPT-IN modules, shown by `init` so users
+ * discover them (discoverability is the cost of making modules opt-in).
+ */
+export const OPTIONAL_MODULE_DESCRIPTIONS: Record<Exclude<UiModuleName, 'core'>, string> = {
+  actions: 'bulk-action toolbar over selected rows',
+};
+
+/**
+ * Validate that a path is a safe relative subpath (no path traversal).
+ *
+ * Shared by `init` and `add` so both reject the same unsafe
+ * `--components-path` values identically.
+ */
+export function isValidRelativeSubpath(path: string): boolean {
+  if (!path || path.length === 0) {
+    return false;
+  }
+  // Null bytes
+  if (path.includes('\0')) {
+    return false;
+  }
+  // Absolute paths (Unix: leading /, Windows: drive letter)
+  if (path.startsWith('/') || /^[a-zA-Z]:[\\/]/.test(path)) {
+    return false;
+  }
+  const normalized = normalize(path);
+  // Parent-directory traversal anywhere
+  if (normalized.includes('..')) {
+    return false;
+  }
+  return !normalized.startsWith('..') && normalized !== '.';
+}
+
+/**
+ * Resolve a list of user-supplied module-name strings to validated
+ * {@link UiModuleName}s. On any unknown name, prints the valid names and
+ * returns `null` — callers exit non-zero.
+ */
+export function resolveModuleNames(names: readonly string[]): UiModuleName[] | null {
+  const unknown = names.filter((name) => !isUiModuleName(name));
+  if (unknown.length > 0) {
+    console.error(pc.red(`✗ Unknown module(s): ${unknown.join(', ')}`));
+    console.error(pc.dim(`  Available modules: ${UI_MODULE_NAMES.join(', ')}`));
+    return null;
+  }
+  // Dedupe while preserving order.
+  const seen = new Set<UiModuleName>();
+  const resolved: UiModuleName[] = [];
+  for (const name of names as UiModuleName[]) {
+    if (!seen.has(name)) {
+      seen.add(name);
+      resolved.push(name);
+    }
+  }
+  return resolved;
+}
+
+/**
+ * Print the standard copy summary shared by `init` and `add`.
+ * Returns `true` when nothing failed.
+ */
+export function printCopySummary(
+  results: CopyResult[],
+  categories: Record<string, number>
+): boolean {
+  const successful = results.filter((r) => r.success && !r.skipped).length;
+  const skipped = results.filter((r) => r.skipped).length;
+  const failed = results.filter((r) => !r.success).length;
+
+  console.log(pc.bold('\n📁 Files copied:\n'));
+  console.log(pc.green(`  • ${successful} files copied successfully`));
+  if (Object.keys(categories).length === 0) {
+    console.log(pc.yellow('  ⚠️  No files were copied. This may indicate:'));
+    console.log(pc.dim('     • UI package source files not found'));
+    console.log(pc.dim('     • Path resolution issue'));
+    console.log(pc.dim('     • All files already exist\n'));
+  } else {
+    for (const [category, count] of Object.entries(categories)) {
+      console.log(`  • ${category}: ${pc.green(String(count))} files`);
+    }
+    console.log('');
+  }
+  if (skipped > 0) {
+    console.log(pc.yellow(`  • ${skipped} files skipped (already exist)`));
+  }
+  if (failed > 0) {
+    console.error(pc.red(`  • ${failed} files failed to copy`));
+    for (const result of results.filter((r) => !r.success)) {
+      console.error(pc.dim(`    - ${result.path}: ${result.error}`));
+    }
+  }
+  return failed === 0;
+}
+
+/** Print the "available opt-in modules" block used by `init`'s next-steps. */
+export function printAvailableModules(): void {
+  if (OPTIONAL_UI_MODULE_NAMES.length === 0) return;
+  console.log(pc.dim('\n  Optional modules (add anytime):'));
+  for (const name of OPTIONAL_UI_MODULE_NAMES) {
+    console.log(
+      pc.dim(
+        `    • ${name} — ${OPTIONAL_MODULE_DESCRIPTIONS[name]}: ` +
+          pc.cyan(`bunx better-tables add ${name}`)
+      )
+    );
+  }
+}

--- a/packages/cli/tests/add.test.ts
+++ b/packages/cli/tests/add.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+import { addCommand } from '../src/commands/add';
+import * as configLib from '../src/lib/config';
+import type { CopyResult } from '../src/lib/file-operations';
+import * as fileOperationsLib from '../src/lib/file-operations';
+import * as promptsLib from '../src/lib/prompts';
+
+// Same spy-not-mock.module approach as init.test.ts (see its note): spying on
+// the real lib modules keeps other suites' unmocked imports intact.
+
+const defaultConfig: configLib.ShadcnConfig = {
+  style: 'default',
+  rsc: true,
+  tsx: true,
+  tailwind: { config: 'tailwind.config.ts', baseColor: 'slate', cssVariables: true, prefix: '' },
+  aliases: { components: '@/components', utils: '@/lib/utils' },
+};
+
+const defaultResolvedPaths: configLib.ResolvedPaths = {
+  components: '/tmp/project/src/components',
+  utils: '/tmp/project/src/lib/utils',
+  ui: '/tmp/project/src/components/ui',
+  lib: '/tmp/project/src/lib',
+  hooks: '/tmp/project/src/hooks',
+};
+
+const defaultCopyResults: CopyResult[] = [
+  { success: true, skipped: false, path: 'actions-toolbar.tsx' },
+  { success: true, skipped: false, path: 'action-confirmation-dialog.tsx' },
+];
+
+describe('add command', () => {
+  let consoleLogSpy: ReturnType<typeof spyOn>;
+  let consoleErrorSpy: ReturnType<typeof spyOn>;
+  let processExitSpy: ReturnType<typeof spyOn>;
+  let copyAllFilesSpy: ReturnType<typeof spyOn>;
+  let spies: ReturnType<typeof spyOn>[];
+
+  function getErrorOutput(): string {
+    return consoleErrorSpy.mock.calls.map((call: unknown[]) => String(call[0])).join('\n');
+  }
+
+  beforeEach(() => {
+    consoleLogSpy = spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
+    processExitSpy = spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called');
+    });
+    copyAllFilesSpy = spyOn(fileOperationsLib, 'copyAllFiles').mockImplementation(() =>
+      Promise.resolve({ results: defaultCopyResults, categories: { table: 2 } })
+    );
+    spies = [
+      copyAllFilesSpy,
+      spyOn(configLib, 'getConfig').mockImplementation(() => ({
+        config: defaultConfig,
+        configPath: '/tmp/project/components.json',
+        resolvedPaths: defaultResolvedPaths,
+        isTypeScript: true,
+      })),
+      spyOn(configLib, 'getAliasPrefix').mockImplementation(() => '@/'),
+      spyOn(promptsLib, 'confirm').mockImplementation(() => Promise.resolve(true)),
+    ];
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    processExitSpy.mockRestore();
+    for (const spy of spies) {
+      spy.mockRestore();
+    }
+  });
+
+  it('creates an add command', () => {
+    expect(addCommand().name()).toBe('add');
+  });
+
+  it('copies the requested module(s) via copyAllFiles', async () => {
+    const command = addCommand();
+    await command.parseAsync(['actions', '--yes'], { from: 'user' });
+
+    expect(copyAllFilesSpy).toHaveBeenCalledTimes(1);
+    const call = copyAllFilesSpy.mock.calls[0];
+    // 5th arg is the module list; `add` copies only the named modules (not core).
+    expect(call?.[4]).toEqual(['actions']);
+  });
+
+  it('exits 1 and lists valid modules for an unknown module', async () => {
+    const command = addCommand();
+    try {
+      await command.parseAsync(['bogus', '--yes'], { from: 'user' });
+    } catch {
+      // process.exit throws in tests
+    }
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+    expect(getErrorOutput()).toContain('Unknown module');
+    expect(getErrorOutput()).toContain('actions');
+    expect(copyAllFilesSpy).not.toHaveBeenCalled();
+  });
+
+  it('exits 1 for an invalid components path', async () => {
+    const command = addCommand();
+    try {
+      await command.parseAsync(['actions', '--yes', '--components-path', '../escape'], {
+        from: 'user',
+      });
+    } catch {
+      // Expected
+    }
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+    expect(getErrorOutput()).toContain('Invalid components path');
+  });
+
+  it('exits 1 with remediation when components.json cannot be read', async () => {
+    (configLib.getConfig as ReturnType<typeof spyOn>).mockImplementation(() => null);
+    const command = addCommand();
+    try {
+      await command.parseAsync(['actions', '--yes'], { from: 'user' });
+    } catch {
+      // Expected
+    }
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+    expect(getErrorOutput()).toContain('Failed to read components.json');
+  });
+
+  it('dedupes repeated module names', async () => {
+    const command = addCommand();
+    await command.parseAsync(['actions', 'actions', '--yes'], { from: 'user' });
+    expect(copyAllFilesSpy.mock.calls[0]?.[4]).toEqual(['actions']);
+  });
+});

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -1,10 +1,19 @@
 import { describe, expect, it } from 'bun:test';
 import { Command } from 'commander';
 import { commandsRegistry, type RegisteredCommandName } from '../src/commands';
+import { addCommand } from '../src/commands/add';
 import { docsCommand } from '../src/commands/docs';
 import { helpCommand } from '../src/commands/help';
 import { initCommand } from '../src/commands/init';
 import { createCommand, registerCommandFactory } from '../src/lib/command-factory';
+
+/** Register every command factory the registry declares (mirrors cli.ts). */
+function registerAllFactories(): void {
+  registerCommandFactory('help', helpCommand);
+  registerCommandFactory('docs', docsCommand);
+  registerCommandFactory('init', initCommand);
+  registerCommandFactory('add', addCommand);
+}
 
 describe('CLI', () => {
   it('should have correct name and description', () => {
@@ -20,10 +29,7 @@ describe('CLI', () => {
   });
 
   it('should register all commands from registry', () => {
-    // Register all command factories
-    registerCommandFactory('help', helpCommand);
-    registerCommandFactory('docs', docsCommand);
-    registerCommandFactory('init', initCommand);
+    registerAllFactories();
 
     const program = new Command();
     const commandNames = Object.keys(commandsRegistry) as RegisteredCommandName[];
@@ -43,9 +49,7 @@ describe('CLI', () => {
   });
 
   it('should have all commands from registry accessible', () => {
-    registerCommandFactory('help', helpCommand);
-    registerCommandFactory('docs', docsCommand);
-    registerCommandFactory('init', initCommand);
+    registerAllFactories();
 
     const program = new Command();
     const commandNames = Object.keys(commandsRegistry) as RegisteredCommandName[];

--- a/packages/cli/tests/init.test.ts
+++ b/packages/cli/tests/init.test.ts
@@ -268,7 +268,7 @@ describe('init command', () => {
     expect(getErrorOutput()).toContain('Unknown module');
   });
 
-  it('should print failed file details to stderr without exiting when some files fail to copy', async () => {
+  it('should print failed file details to stderr and exit non-zero when some files fail to copy', async () => {
     (fileOperationsLib.copyAllFiles as ReturnType<typeof spyOn>).mockImplementation(() =>
       Promise.resolve({
         results: [
@@ -283,10 +283,27 @@ describe('init command', () => {
     try {
       await command.parseAsync(['--yes'], { from: 'user' });
     } catch {
-      // Not expected to throw
+      // process.exit throws in tests
     }
 
     expect(getErrorOutput()).toContain('1 files failed to copy');
     expect(getErrorOutput()).toContain('permission denied');
+    // A genuine copy failure must not report success — exit non-zero.
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('does not exit non-zero when files are only skipped (not failed)', async () => {
+    (fileOperationsLib.copyAllFiles as ReturnType<typeof spyOn>).mockImplementation(() =>
+      Promise.resolve({
+        results: [
+          { success: true, skipped: false, path: 'a.ts' },
+          { success: true, skipped: true, path: 'b.ts' },
+        ] as CopyResult[],
+        categories: { table: 1 },
+      })
+    );
+    const command = initCommand();
+    await command.parseAsync(['--yes'], { from: 'user' });
+    expect(processExitSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/tests/init.test.ts
+++ b/packages/cli/tests/init.test.ts
@@ -233,6 +233,41 @@ describe('init command', () => {
     expect(output).toContain('initialized successfully');
   });
 
+  it('copies the core module only by default (excludes opt-in modules)', async () => {
+    const command = initCommand();
+    await command.parseAsync(['--yes'], { from: 'user' });
+
+    const call = (fileOperationsLib.copyAllFiles as ReturnType<typeof spyOn>).mock.calls[0];
+    // 5th arg is the module list.
+    expect(call?.[4]).toEqual(['core']);
+  });
+
+  it('opts modules in with --modules, always keeping core first', async () => {
+    const command = initCommand();
+    await command.parseAsync(['--yes', '--modules', 'actions'], { from: 'user' });
+
+    const call = (fileOperationsLib.copyAllFiles as ReturnType<typeof spyOn>).mock.calls[0];
+    expect(call?.[4]).toEqual(['core', 'actions']);
+  });
+
+  it('lists available opt-in modules in the next-steps output', async () => {
+    const command = initCommand();
+    await command.parseAsync(['--yes'], { from: 'user' });
+    const output = getLoggedOutput();
+    expect(output).toContain('better-tables add actions');
+  });
+
+  it('exits 1 and lists valid modules when --modules names an unknown module', async () => {
+    const command = initCommand();
+    try {
+      await command.parseAsync(['--yes', '--modules', 'bogus'], { from: 'user' });
+    } catch {
+      // process.exit throws in tests
+    }
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+    expect(getErrorOutput()).toContain('Unknown module');
+  });
+
   it('should print failed file details to stderr without exiting when some files fail to copy', async () => {
     (fileOperationsLib.copyAllFiles as ReturnType<typeof spyOn>).mockImplementation(() =>
       Promise.resolve({

--- a/packages/cli/tests/module-install.test.ts
+++ b/packages/cli/tests/module-install.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+import type { CopyResult } from '../src/lib/file-operations';
+import {
+  isValidRelativeSubpath,
+  printCopySummary,
+  resolveModuleNames,
+} from '../src/lib/module-install';
+
+/**
+ * Direct coverage for the shared `init`/`add` helpers so regressions in path
+ * validation, module resolution, and summary reporting are caught here rather
+ * than only through the full command flows.
+ */
+
+describe('isValidRelativeSubpath', () => {
+  it('accepts plain relative subpaths', () => {
+    expect(isValidRelativeSubpath('better-tables-ui')).toBe(true);
+    expect(isValidRelativeSubpath('ui/nested')).toBe(true);
+  });
+
+  it('rejects empty, absolute, traversal, and null-byte paths', () => {
+    expect(isValidRelativeSubpath('')).toBe(false);
+    expect(isValidRelativeSubpath('/abs')).toBe(false);
+    expect(isValidRelativeSubpath('C:\\abs')).toBe(false);
+    expect(isValidRelativeSubpath('../escape')).toBe(false);
+    expect(isValidRelativeSubpath('ui/../../escape')).toBe(false);
+    expect(isValidRelativeSubpath('.')).toBe(false);
+    expect(isValidRelativeSubpath('ui\0hidden')).toBe(false);
+  });
+});
+
+describe('resolveModuleNames', () => {
+  let errorSpy: ReturnType<typeof spyOn>;
+  beforeEach(() => {
+    errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  it('resolves known names, preserving order', () => {
+    expect(resolveModuleNames(['actions'])).toEqual(['actions']);
+    expect(resolveModuleNames(['core', 'actions'])).toEqual(['core', 'actions']);
+  });
+
+  it('dedupes repeated names', () => {
+    expect(resolveModuleNames(['actions', 'actions', 'core', 'actions'])).toEqual([
+      'actions',
+      'core',
+    ]);
+  });
+
+  it('returns an empty list for no names', () => {
+    expect(resolveModuleNames([])).toEqual([]);
+  });
+
+  it('returns null and lists valid modules for an unknown name', () => {
+    expect(resolveModuleNames(['bogus'])).toBeNull();
+    const output = errorSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
+    expect(output).toContain('Unknown module');
+    expect(output).toContain('bogus');
+    expect(output).toContain('actions');
+  });
+});
+
+describe('printCopySummary', () => {
+  let logSpy: ReturnType<typeof spyOn>;
+  let errorSpy: ReturnType<typeof spyOn>;
+  beforeEach(() => {
+    logSpy = spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('returns true and reports the count when nothing failed', () => {
+    const results: CopyResult[] = [
+      { success: true, skipped: false, path: 'a.ts' },
+      { success: true, skipped: true, path: 'b.ts' },
+    ];
+    const ok = printCopySummary(results, { table: 1 });
+    expect(ok).toBe(true);
+    const output = logSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
+    expect(output).toContain('1 files copied successfully');
+    expect(output).toContain('1 files skipped');
+  });
+
+  it('returns false and prints failed-file details when a copy fails', () => {
+    const results: CopyResult[] = [
+      { success: true, skipped: false, path: 'a.ts' },
+      { success: false, skipped: false, path: 'bad.ts', error: 'permission denied' },
+    ];
+    const ok = printCopySummary(results, { table: 1 });
+    expect(ok).toBe(false);
+    const errors = errorSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
+    expect(errors).toContain('1 files failed to copy');
+    expect(errors).toContain('permission denied');
+  });
+});

--- a/packages/cli/tests/module-mappings.test.ts
+++ b/packages/cli/tests/module-mappings.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'bun:test';
 import type { ResolvedPaths } from '../src/lib/config';
 import {
   generateFileMappings,
+  getAllUiSourceFilePaths,
   getModuleSourceFilePaths,
   isUiModuleName,
   UI_MODULE_NAMES,
@@ -51,13 +52,23 @@ describe('UI module mappings', () => {
     }
   });
 
-  it('core and actions modules are disjoint and their union is the full set', () => {
+  it('every module is disjoint and their union is the full source set', () => {
     const core = new Set(getModuleSourceFilePaths('core'));
     const actions = getModuleSourceFilePaths('actions');
     for (const file of actions) {
       expect(core.has(file)).toBe(false);
     }
     expect(actions.length).toBe(2);
+
+    // The union of every module's files (summed, since modules are disjoint)
+    // must equal the total unique source set — so adding a future module
+    // without covering it, or double-counting a file, fails here.
+    const perModuleTotal = UI_MODULE_NAMES.reduce(
+      (sum, name) => sum + getModuleSourceFilePaths(name).length,
+      0
+    );
+    const unionUnique = new Set(getAllUiSourceFilePaths()).size;
+    expect(perModuleTotal).toBe(unionUnique);
   });
 
   it('isUiModuleName recognizes real modules and rejects others', () => {

--- a/packages/cli/tests/module-mappings.test.ts
+++ b/packages/cli/tests/module-mappings.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'bun:test';
+import type { ResolvedPaths } from '../src/lib/config';
+import {
+  generateFileMappings,
+  getModuleSourceFilePaths,
+  isUiModuleName,
+  UI_MODULE_NAMES,
+} from '../src/lib/file-operations';
+
+/**
+ * Plan 059: `init` copies the `core` module by default; `add <module>` copies
+ * one opt-in module. These tests pin the module → file mapping so the default
+ * set and each opt-in module stay exactly what the docs promise.
+ */
+
+const paths: ResolvedPaths = {
+  components: '/proj/src/components',
+  utils: '/proj/src/lib/utils',
+  ui: '/proj/src/components/ui',
+  lib: '/proj/src/lib',
+  hooks: '/proj/src/hooks',
+};
+
+const ACTIONS_FILES = ['actions-toolbar.tsx', 'action-confirmation-dialog.tsx'];
+
+describe('UI module mappings', () => {
+  it('the default (core) copy set excludes the actions module files', () => {
+    const sources = generateFileMappings(paths, 'better-tables-ui', ['core']).map(
+      (m) => m.sourcePath
+    );
+    for (const file of ACTIONS_FILES) {
+      expect(sources).not.toContain(`components/table/${file}`);
+    }
+    // Sanity: core still copies the table itself.
+    expect(sources).toContain('components/table/table.tsx');
+  });
+
+  it('add actions copies exactly the two actions files into the table dir', () => {
+    const mappings = generateFileMappings(paths, 'better-tables-ui', ['actions']);
+    const sources = mappings.map((m) => m.sourcePath).sort();
+    expect(sources).toEqual(
+      [
+        'components/table/action-confirmation-dialog.tsx',
+        'components/table/actions-toolbar.tsx',
+      ].sort()
+    );
+    // Destinations land under <components>/<out>/table/.
+    for (const m of mappings) {
+      expect(m.destPath).toContain('/proj/src/components/better-tables-ui/table/');
+      expect(m.category).toBe('table');
+    }
+  });
+
+  it('core and actions modules are disjoint and their union is the full set', () => {
+    const core = new Set(getModuleSourceFilePaths('core'));
+    const actions = getModuleSourceFilePaths('actions');
+    for (const file of actions) {
+      expect(core.has(file)).toBe(false);
+    }
+    expect(actions.length).toBe(2);
+  });
+
+  it('isUiModuleName recognizes real modules and rejects others', () => {
+    expect(isUiModuleName('core')).toBe(true);
+    expect(isUiModuleName('actions')).toBe(true);
+    expect(isUiModuleName('nope')).toBe(false);
+    expect(UI_MODULE_NAMES[0]).toBe('core');
+  });
+
+  it('respects a custom components output path', () => {
+    const mappings = generateFileMappings(paths, 'custom-ui', ['actions']);
+    for (const m of mappings) {
+      expect(m.destPath).toContain('/proj/src/components/custom-ui/table/');
+    }
+  });
+});

--- a/packages/cli/tests/ui-source-manifest.test.ts
+++ b/packages/cli/tests/ui-source-manifest.test.ts
@@ -2,14 +2,21 @@ import { describe, expect, it } from 'bun:test';
 import { readdirSync, statSync } from 'node:fs';
 import { join, relative, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { getUiSourceFilePaths } from '../src/lib/file-operations';
+import {
+  getAllUiSourceFilePaths,
+  getModuleSourceFilePaths,
+  UI_MODULE_NAMES,
+} from '../src/lib/file-operations';
 
 /**
- * `UI_SOURCE_FILES` in src/lib/file-operations.ts is a hand-maintained
- * allow-list of everything `init` copies into a consumer project. This suite
- * pins it to the real `packages/ui/src` tree so a UI refactor (file added,
- * moved, or deleted) fails here instead of shipping an `init` that copies a
- * broken component set.
+ * `UI_MODULES` in src/lib/file-operations.ts is a hand-maintained manifest of
+ * the files each UI module copies into a consumer project (plan 059). This
+ * suite pins it to the real `packages/ui/src` tree so a UI refactor (file
+ * added, moved, or deleted) fails here instead of shipping an `init`/`add` that
+ * copies a broken component set. It enforces TWO invariants:
+ *
+ *   1. Union of all modules === the real copyable tree (both directions).
+ *   2. Modules are pairwise disjoint — every file belongs to exactly one.
  */
 
 // The workspace UI source is the source of truth. The bundled `ui-src`
@@ -19,7 +26,7 @@ const uiSrcRoot = join(fileURLToPath(import.meta.url), '..', '..', '..', 'ui', '
 
 /**
  * Files under packages/ui/src that `init` intentionally does NOT copy.
- * Keep in sync with the exclusion note on `UI_SOURCE_FILES`.
+ * Keep in sync with the exclusion note on `UI_MODULES`.
  */
 const INTENTIONALLY_NOT_COPIED = [
   // Package barrel for the (private) workspace package build — consumers
@@ -52,7 +59,7 @@ function walkFiles(dir: string, root: string, acc: string[] = []): string[] {
 }
 
 describe('UI source manifest', () => {
-  const manifestPaths = getUiSourceFilePaths();
+  const manifestPaths = getAllUiSourceFilePaths();
   const actualPaths = walkFiles(uiSrcRoot, uiSrcRoot).filter(
     (path) => !path.includes('.test.') && !isExcluded(path)
   );
@@ -67,7 +74,28 @@ describe('UI source manifest', () => {
     expect(uncovered).toEqual([]);
   });
 
-  it('has no duplicate entries', () => {
+  it('has no duplicate entries across the union', () => {
     expect(new Set(manifestPaths).size).toBe(manifestPaths.length);
+  });
+
+  it('assigns every file to exactly one module (pairwise disjoint)', () => {
+    const seen = new Map<string, string>();
+    const collisions: string[] = [];
+    for (const moduleName of UI_MODULE_NAMES) {
+      for (const path of getModuleSourceFilePaths(moduleName)) {
+        const owner = seen.get(path);
+        if (owner) {
+          collisions.push(`${path} in both "${owner}" and "${moduleName}"`);
+        } else {
+          seen.set(path, moduleName);
+        }
+      }
+    }
+    expect(collisions).toEqual([]);
+  });
+
+  it('has a non-empty core module', () => {
+    expect(UI_MODULE_NAMES).toContain('core');
+    expect(getModuleSourceFilePaths('core').length).toBeGreaterThan(0);
   });
 });

--- a/packages/ui/src/components/table/table.tsx
+++ b/packages/ui/src/components/table/table.tsx
@@ -14,6 +14,7 @@ import {
   type PaginationState,
   resolveTableColumns,
   type SortingState,
+  type TableAction,
   type TableConfig,
   type TableDefinition,
   tableNeedsColumnResolution,
@@ -46,7 +47,6 @@ import { Checkbox } from '../ui/checkbox';
 import { Skeleton } from '../ui/skeleton';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
-import { ActionsToolbar } from './actions-toolbar';
 import { EditableCell } from './editable-cell';
 import { EmptyState } from './empty-state';
 import { ErrorState } from './error-state';
@@ -78,6 +78,63 @@ const VIRTUAL_DEFAULT_OVERSCAN = 5;
  */
 function virtualSpacerStyle(height: number): React.CSSProperties {
   return { height, padding: 0, border: 0 };
+}
+
+/**
+ * Props the `actions` module's toolbar receives through
+ * {@link BetterTableSlots.actionsToolbar}. Rendered only when
+ * `actions.length > 0`, so `actions` is always non-empty here. The default
+ * `ActionsToolbar` component satisfies this shape unchanged.
+ */
+export interface ActionsToolbarSlotProps<TData = unknown> {
+  /** The `actions` passed to {@link BetterTableProps.actions} (non-empty). */
+  actions: TableAction<TData>[];
+  /** Ids of the currently selected rows. */
+  selectedIds: string[];
+  /** The selected rows' data, in row order. */
+  selectedData: TData[];
+  /** Called after an action's handler resolves (host may refetch/refresh). */
+  onActionMake: (actionId: string) => void;
+}
+
+/**
+ * Props the {@link BetterTableSlots.toolbarExtra} slot receives — everything an
+ * export/toolbar module needs to act on the current view. Reserved for plan
+ * 050's `ExportButton`; carries the adapter, resolved columns, and the live
+ * filter/sort state so a module can drive `adapter.exportData(...)`.
+ */
+export interface ToolbarExtraSlotProps<TData = unknown> {
+  /** Column definitions currently rendered (post auto-column resolution). */
+  columns: ColumnDefinition<TData, unknown>[];
+  /** The active adapter (may be undefined for pure `data`-driven tables). */
+  adapter?: TableConfig<TData>['adapter'];
+  /** The current filter tree (flat array or group node). */
+  filters: FilterState[] | FilterGroupNode;
+  /** The current sort state. */
+  sorting: SortingState;
+  /** Total row count if known. */
+  totalCount?: number;
+}
+
+/**
+ * Injection points for opt-in UI **modules** (the CLI-copied tier — distinct
+ * from core-tier `betterTables({ plugins })`). A module ships as copied source
+ * that the consumer wires into a slot; an absent slot is a clean no-op. See
+ * `plans/design/ui-modules.md`.
+ */
+export interface BetterTableSlots<TData = unknown> {
+  /**
+   * Installed by the `actions` module
+   * (`slots={{ actionsToolbar: ActionsToolbar }}`). Renders in the toolbar row
+   * when `actions.length > 0`. When `actions` are provided but this slot is
+   * unset, the table renders nothing here and warns once in dev.
+   */
+  actionsToolbar?: React.ComponentType<ActionsToolbarSlotProps<TData>>;
+  /**
+   * Extra toolbar controls (reserved for plan 050's `ExportButton`, shipping as
+   * the `export` module). Renders in the toolbar row when set; empty is silent.
+   */
+  toolbarExtra?: React.ComponentType<ToolbarExtraSlotProps<TData>>;
 }
 
 /**
@@ -268,6 +325,18 @@ export interface BetterTableProps<TData = unknown>
    * to render every cell read-only without changing column defs.
    */
   editing?: boolean;
+
+  /**
+   * Injection points for opt-in UI modules copied in via
+   * `better-tables add <module>`. E.g. the actions module wires
+   * `slots={{ actionsToolbar: ActionsToolbar }}`. Absent slots render nothing.
+   *
+   * `NoInfer` keeps the slot components out of `TData` inference — a slot's
+   * `ComponentType<…<TData>>` is a contravariant position that would otherwise
+   * collapse `TData` to `unknown`. `TData` is inferred from `data`/`columns`/
+   * `table`/`actions`; slots are then checked against it.
+   */
+  slots?: BetterTableSlots<NoInfer<TData>>;
 }
 
 /** Ref-latch a frequently-changing callback/value prop so a `useEffect` (or
@@ -666,6 +735,10 @@ function BetterTableInner<TData = unknown>({
   onCellEditError,
   saveAction,
   editing = true,
+
+  // UI modules (opt-in, CLI-copied) — destructured so it is not spread onto
+  // the wrapper div below via `...props`.
+  slots,
   ...props
 }: BetterTableProps<TData>) {
   // `table` (a defineTable() result) is sugar for columns={table.columns},
@@ -988,6 +1061,27 @@ function BetterTableInner<TData = unknown>({
     [id, store]
   );
 
+  // One-time dev diagnostic for the `actions` module seam: `actions` were
+  // provided (which enables row selection) but no `slots.actionsToolbar` is
+  // wired, so the bulk-actions toolbar renders nothing. Keyed by `id` (same
+  // rationale as `warnedFilterTreeIdRef`) and production-gated. Lives in an
+  // effect, not render, so it never fires a side effect during rendering.
+  const warnedMissingActionsSlotIdRef = useRef<string | null>(null);
+  const hasActions = actions.length > 0;
+  const hasActionsSlot = !!slots?.actionsToolbar;
+  useEffect(() => {
+    if (process.env.NODE_ENV === 'production') return;
+    if (!hasActions || hasActionsSlot) return;
+    if (warnedMissingActionsSlotIdRef.current === id) return;
+    warnedMissingActionsSlotIdRef.current = id;
+    console.warn(
+      `[better-tables] table "${id}": \`actions\` were provided but no ` +
+        '`slots.actionsToolbar` is set, so the bulk-actions toolbar will not ' +
+        'render. Install the actions module (`bunx better-tables add actions`) ' +
+        'and pass `slots={{ actionsToolbar: ActionsToolbar }}`.'
+    );
+  }, [id, hasActions, hasActionsSlot]);
+
   // Handle filter changes - just update store.
   //
   // The filter bar edits the FLAT leaf view, and the store's `setFilters`
@@ -1280,6 +1374,11 @@ function BetterTableInner<TData = unknown>({
     contextMenuEnabled &&
     (headerContextMenu?.showSortToggle || headerContextMenu?.showColumnVisibility);
 
+  // Module slots (opt-in UI tier). Capitalized locals so they render as JSX
+  // components; absent slots stay undefined and render nothing.
+  const ActionsToolbarSlot = slots?.actionsToolbar;
+  const ToolbarExtraSlot = slots?.toolbarExtra;
+
   const tableContent = (
     <div className={cn('space-y-4', className)} {...props} {...(name !== undefined && { name })}>
       {/* Always mounted so SSR/client DOM structure matches */}
@@ -1288,9 +1387,11 @@ function BetterTableInner<TData = unknown>({
       </div>
 
       <div className="flex items-center gap-2">
-        {/* Actions Toolbar - render independently of filtering */}
-        {actions.length > 0 && (
-          <ActionsToolbar
+        {/* Actions toolbar — an opt-in module rendered through the
+            `actionsToolbar` slot, independent of filtering. Absent slot with
+            `actions` present is a no-op (a one-time dev warn fires above). */}
+        {actions.length > 0 && ActionsToolbarSlot && (
+          <ActionsToolbarSlot
             actions={actions}
             selectedIds={Array.from(selectedRows)}
             selectedData={data.filter((row, index) => selectedRows.has(getRowId(row, index)))}
@@ -1298,6 +1399,18 @@ function BetterTableInner<TData = unknown>({
               // Action executed - could trigger data refresh
               // This callback can be used by parent to refetch data
             }}
+          />
+        )}
+
+        {/* Extra toolbar controls — an opt-in module (e.g. export) rendered
+            through the `toolbarExtra` slot. Empty slot renders nothing. */}
+        {ToolbarExtraSlot && (
+          <ToolbarExtraSlot
+            columns={columnsWithDefaults}
+            {...(adapter !== undefined && { adapter })}
+            filters={filters}
+            sorting={sortingState}
+            {...(totalCount !== undefined && { totalCount })}
           />
         )}
 

--- a/packages/ui/tests/components/table-module-slots.test.tsx
+++ b/packages/ui/tests/components/table-module-slots.test.tsx
@@ -1,0 +1,165 @@
+import { afterEach, describe, expect, it, spyOn } from 'bun:test';
+import { type ColumnDefinition, clearAllTableStores, type TableAction } from '@better-tables/core';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import {
+  type ActionsToolbarSlotProps,
+  BetterTable,
+  type ToolbarExtraSlotProps,
+} from '../../src/components/table/table';
+
+/**
+ * Plan 059 Step 2: the `slots` seam. `actions` (a core prop) no longer imports
+ * a toolbar directly — the `actions` module injects one through
+ * `slots.actionsToolbar`. These tests pin: the slot renders and receives live
+ * selection; an absent slot with `actions` present renders nothing and warns
+ * once in dev; no `actions` never warns; and `toolbarExtra` receives the
+ * current view (columns/filters/sorting) for a module like export.
+ */
+
+interface Row {
+  id: string;
+  name: string;
+}
+
+const columns: ColumnDefinition<Row>[] = [
+  { id: 'name', displayName: 'Name', type: 'text', accessor: (row) => row.name, filterable: true },
+];
+
+const rows: Row[] = [
+  { id: '1', name: 'Alice' },
+  { id: '2', name: 'Bob' },
+];
+
+const actions: TableAction<Row>[] = [{ id: 'archive', label: 'Archive', handler: () => {} }];
+
+/** A stub `actions` module component: renders the live selection count. */
+function StubActionsToolbar({ selectedIds }: ActionsToolbarSlotProps<Row>) {
+  return <div data-testid="actions-slot">selected:{selectedIds.length}</div>;
+}
+
+/** A stub `toolbarExtra` module component: echoes the injected view. */
+function StubToolbarExtra({ columns: cols, filters, sorting }: ToolbarExtraSlotProps<Row>) {
+  return (
+    <div data-testid="toolbar-extra">
+      cols:{cols.length} filters:{Array.isArray(filters) ? filters.length : 'tree'} sorts:
+      {sorting.length}
+    </div>
+  );
+}
+
+describe('BetterTable module slots', () => {
+  afterEach(() => {
+    clearAllTableStores();
+    cleanup();
+  });
+
+  it('renders the actionsToolbar slot and feeds it live selection', () => {
+    const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      render(
+        <BetterTable
+          id="slots-wired"
+          columns={columns}
+          data={rows}
+          totalCount={2}
+          virtualized={false}
+          actions={actions}
+          slots={{ actionsToolbar: StubActionsToolbar }}
+        />
+      );
+
+      // Slot is mounted (actions present + slot wired); nothing selected yet.
+      expect(screen.getByTestId('actions-slot').textContent).toBe('selected:0');
+
+      // Selecting rows flows through to the slot's props.
+      fireEvent.click(screen.getByRole('checkbox', { name: /select all rows/i }));
+      expect(screen.getByTestId('actions-slot').textContent).toBe('selected:2');
+
+      // Wiring the slot means no missing-slot warning.
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('renders nothing and warns exactly once when actions are set but the slot is absent', () => {
+    const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { rerender } = render(
+        <BetterTable
+          id="slots-absent"
+          columns={columns}
+          data={rows}
+          totalCount={2}
+          virtualized={false}
+          actions={actions}
+        />
+      );
+
+      // No toolbar rendered...
+      expect(screen.queryByTestId('actions-slot')).toBeNull();
+      // ...but row selection still turns on (actions imply selection).
+      expect(screen.getByRole('checkbox', { name: /select all rows/i })).toBeTruthy();
+
+      // Exactly one dev warn, naming the fix.
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const message = String(warnSpy.mock.calls[0]?.[0]);
+      expect(message).toContain('slots-absent');
+      expect(message).toContain('slots.actionsToolbar');
+      expect(message).toContain('better-tables add actions');
+
+      // A re-render of the same table does not warn again.
+      rerender(
+        <BetterTable
+          id="slots-absent"
+          columns={columns}
+          data={rows}
+          totalCount={2}
+          virtualized={false}
+          actions={actions}
+        />
+      );
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('does not warn when no actions are provided', () => {
+    const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      render(
+        <BetterTable
+          id="slots-no-actions"
+          columns={columns}
+          data={rows}
+          totalCount={2}
+          virtualized={false}
+        />
+      );
+
+      expect(screen.queryByTestId('actions-slot')).toBeNull();
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('renders the toolbarExtra slot with the current columns/filters/sorting', () => {
+    render(
+      <BetterTable
+        id="slots-extra"
+        columns={columns}
+        data={rows}
+        totalCount={2}
+        virtualized={false}
+        slots={{ toolbarExtra: StubToolbarExtra }}
+      />
+    );
+
+    const extra = screen.getByTestId('toolbar-extra').textContent ?? '';
+    expect(extra).toContain('cols:1');
+    expect(extra).toContain('filters:0');
+    expect(extra).toContain('sorts:0');
+  });
+});

--- a/plans/058-global-search.md
+++ b/plans/058-global-search.md
@@ -1,5 +1,11 @@
 # Plan 058: Ship global search as sugar over the filter pipeline
 
+> **STATUS: DEFERRED (2026-07-21, maintainer decision).** This plan is not
+> being executed this wave. It is intact and still valid — nothing here was
+> built. `FetchDataParams.search` remains declared-but-unconsumed on the
+> adapter contract. To revive: re-run the Drift check below first, then
+> proceed from Step 1. See `plans/README.md` → "Deferred by decision".
+>
 > **Executor instructions**: Follow this plan step by step. Run every
 > verification command and confirm the expected result before moving to the
 > next step. If anything in the "STOP conditions" section occurs, stop and

--- a/plans/README.md
+++ b/plans/README.md
@@ -126,7 +126,7 @@ the breaking window.
 | [055](055-direct-save-path.md) | **Zero-boilerplate saves** — `tables.cellEditAction(def)` (serializable, `'use server'`-ready; the PRIMARY monolith path), `saveAction` prop, opt-in double-sided cell-oriented HTTP write proxy, **joined-table editing** (`resolveCellWriteTarget`; related-row writes proven in browser + integration test), dogfood on the direct path (custom route deleted) | 053, 054 | DONE (merged to main, PR #86) |
 | [048](048-filter-group-builder-ui.md) | Visual filter group-builder UI (nested AND/OR) — fast-follow, contract already shipped | 015/016/017 (done) | TODO (reconciled 2026-07-18 — finding valid; see plan's reconcile note) |
 | [049](049-plugin-hook-execution.md) | Execute the plugin hook seam (`beforeFetch`/`afterFetch`), validated by one real plugin | 018 (done) | TODO (reconciled 2026-07-18 — seam still stored-only; line refs refreshed) |
-| [050](050-export-ui.md) | Export UI: `ExportButton`/`useTableExport` + `csvExport()` plugin + row-cap decision | 049, **059** | TODO (reconciled 2026-07-18; **2026-07-20: refresh against `plans/design/ui-modules.md` (created by 059 Step 1) before executing — `ExportButton` rides 059's `toolbarExtra` slot and ships as an `export` module; `TableConfig.exportOptions` is removed by 057, reintroduce only what the module needs as module-local props**) |
+| [050](050-export-ui.md) | Export UI: `ExportButton`/`useTableExport` + `csvExport()` plugin + row-cap decision | 049, **059 (DONE)** | TODO (reconciled 2026-07-18; **2026-07-21: `plans/design/ui-modules.md` now EXISTS (059 landed) — refresh 050 against it before executing. `ExportButton` rides 059's `toolbarExtra` slot (props: `columns`/`adapter`/`filters`/`sorting`/`totalCount` — validated against 050's needs in the design record) and ships as an `export` module; `TableConfig.exportOptions` was removed by 057, reintroduce only what the module needs as module-local props**) |
 | 008 | Prisma adapter spike (read path) | — | **SUPERSEDED** by [061](061-prisma-adapter-full-parity.md) (2026-07-20 maintainer directive: full parity, not a spike; 008's research is inlined there) |
 
 ### Wave D — maintainer-requested (planned 2026-07-20 at `27c59b9`)
@@ -139,8 +139,8 @@ rethink — action builder should be a plugin, not default-included").
 |------|------|------------|--------|
 | [056](056-toolkit-typecheck-ordering.md) | Deterministic root typecheck: `typecheck` gains `dependsOn: ["build", "^build"]` (same-package build/typecheck race — tsdown cleans `dist/` mid-`tsc`), **plus a `@better-tables/site#typecheck` override of `["^build"]`** so typecheck doesn't drag in the marketing `next build` (the literal one-liner tripped STOP #2 + exposed a marketing `.source` flake — see plan's "Resolution deviation") | none | DONE (branch `claude/next-implementation-plans-q0nlfu`) |
 | [057](057-contract-surface-truth.md) | Remove dead reserved surface: `TableConfig.defaultFilters/actionsConfig/exportOptions/theme/loadingState` + `TableFeatures.bulkActions/export/columnResizing/virtualScrolling/realTimeUpdates/rowExpansion` (0.6 removal policy; adapter contract untouched — `exportData`/`subscribe` are real) | none (coordinates with 050/058/059) | DONE (branch `claude/next-implementation-plans-q0nlfu`) — also removed orphaned `ExportConfig`/`LoadingStateConfig`/`TableTheme`/`ActionsConfig` types; `@ts-expect-error` pin added; `.changeset/contract-surface-truth.md` |
-| [058](058-global-search.md) | Global search as filter sugar: `buildSearchFilterGroup` OR-group over `.searchable()` columns, table-scoped `search` param (adapter-level field removed), `SearchInput` + URL sync — zero adapter changes | none | TODO |
-| [059](059-ui-modules-and-actions-extraction.md) | **UI modules tier** (`better-tables add <module>`, module-shaped CLI manifest, `slots` seam in `table.tsx`) + actions toolbar extracted as the first opt-in module (maintainer decision: not default-included) | none; validates slot vs 050's ExportButton | TODO |
+| [058](058-global-search.md) | Global search as filter sugar: `buildSearchFilterGroup` OR-group over `.searchable()` columns, table-scoped `search` param (adapter-level field removed), `SearchInput` + URL sync — zero adapter changes | none | **DEFERRED (2026-07-21, maintainer decision)** — plan intact; see "Deferred by decision". `FetchDataParams.search` stays declared-but-unconsumed until picked up |
+| [059](059-ui-modules-and-actions-extraction.md) | **UI modules tier** (`better-tables add <module>`, module-shaped CLI manifest, `slots` seam in `table.tsx`) + actions toolbar extracted as the first opt-in module (maintainer decision: not default-included) | none; validates slot vs 050's ExportButton | DONE (2026-07-21) — `plans/design/ui-modules.md` created; `slots` prop (`actionsToolbar`/`toolbarExtra`) on `BetterTable` with one-time dev warn; `UI_MODULES` manifest + drift test (union===tree AND disjoint); `add` command + `init --modules`/core-only default; homepage dogfooded (browser-verified: "Actions (10)" via slot); docs (ui-and-cli/selection-and-actions/troubleshooting); `.changeset/ui-modules-and-actions.md` (cli minor) |
 | [060](060-derived-aggregate-columns.md) | Server-derived aggregate columns: `t.count('posts')` renders/filters/sorts via correlated subqueries lowered into the drizzle computed-fields engine (tree-walk substitution closes 051 item 5 for specs); memoryAdapter nested-array aggregates; honest `filterable/sortable: false` defaults for `t.computed` | none (rebase order with 058 in `factory.ts`) | TODO |
 
 ### Wave E — adapter expansion (planned 2026-07-20 at `27c59b9`)
@@ -201,9 +201,10 @@ Notes for the record (all acceptable, none require action):
 - **Wave D ordering**: 056 any time (one-line turbo change — do it first for
   a stable gate). 057 before or parallel with 058/059 (disjoint fields;
   057 deliberately does NOT touch `FetchDataParams.search` — 058 owns it —
-  and does not touch `actions`/`TableAction` — 059 owns packaging). 058 and
-  060 both extend the instance fetch path in `packages/core/src/factory.ts`
-  — land in either order, rebase the second. **050 executes only after 059**
+  and does not touch `actions`/`TableAction` — 059 owns packaging). **058 is
+  DEFERRED (2026-07-21)** — 060 no longer needs to rebase around it; when 058
+  is revived it rebases onto whatever `factory.ts` fetch-path shape 060 left.
+  **050 executes only after 059**
   (slot seam + module packaging) and after refreshing its plan text against
   `plans/design/ui-modules.md` (created by 059 Step 1 — a forward deliverable,
   not an existing prerequisite). 049 remains independent (core-tier hooks);
@@ -423,6 +424,13 @@ hygiene · bun isolated-linker flaky typecheck (bunfig hoisted pin).
 
 ## Deferred by decision (maintainer chose not to plan this wave — revisit on request)
 
+- **[058](058-global-search.md) global search** — DEFERRED 2026-07-21 by
+  maintainer decision. The plan is fully written and still valid (global
+  search as pure filter sugar over `.searchable()` columns; zero adapter
+  changes). Nothing was built. `FetchDataParams.search?: string` remains
+  declared-but-unconsumed on the adapter contract (057 deliberately left it
+  for 058); it stays until this plan is picked up. Revisit on request — no
+  re-planning needed, just re-run the plan's drift check first.
 - **DIR-05 in-memory adapter** — **LANDED 2026-07-20** (not as originally
   scoped): `memoryAdapter(rows)` ships from `@better-tables/core`
   (`packages/core/src/adapters/memory-adapter.ts`) rather than as a

--- a/plans/design/ui-modules.md
+++ b/plans/design/ui-modules.md
@@ -1,0 +1,256 @@
+# Design: UI modules — an opt-in tier for the copied UI
+
+> Design deliverable for **Step 1** of `plans/059-ui-modules-and-actions-extraction.md`.
+> Decides the slot contract, the absent-module behavior, the module manifest
+> schema, and the `add` command surface. It is validated against TWO
+> consumers (the actions toolbar today, plan 050's ExportButton next) so the
+> seam is real, not speculative.
+>
+> **Verified against** (2026-07-21, at `27c59b9` per the plan's drift check —
+> no drift): `packages/ui/src/components/table/table.tsx` (props interface
+> `:88`, `shouldShowRowSelection` `:721`, ActionsToolbar import `:49` and
+> render `:1288-1301`, the `warnFilterTreeDropped` one-time-dev-warn pattern
+> `:975-987`), `packages/ui/src/components/table/actions-toolbar.tsx`
+> (`ActionsToolbarProps`), `packages/cli/src/lib/file-operations.ts`
+> (`UI_SOURCE_FILES`, `generateFileMappings`, `getUiSourceFilePaths`),
+> `packages/cli/src/commands/{init,docs}.ts`, `packages/cli/src/cli.ts`,
+> `packages/cli/src/commands.ts`, `packages/cli/tests/ui-source-manifest.test.ts`,
+> and plan 050's `ExportButton`/`useTableExport` requirements.
+
+---
+
+## Vocabulary rule (states the "Why this matters" decision for docs authors)
+
+Better Tables has two extension surfaces. They must NOT share a word:
+
+- **plugins** — core tier: `betterTables({ plugins: [...] })`, npm-distributed,
+  data hooks (`beforeFetch`/`afterFetch`). Plan 049's territory. No UI.
+- **modules** — copied-UI tier: `better-tables add <module>`, source copied
+  into the consumer app (shadcn model). This document defines it.
+
+Docs and code comments use "plugin" only for the core tier and "module" only
+for the copied-UI tier. A capability like saved views may ship as a
+plugin + module PAIR; name each half by its tier.
+
+---
+
+## 1. The seam: a `slots` prop on `BetterTable`
+
+A module is source the CLI copies in. The core table cannot `import` a module
+(the module may be absent), so an absent module must be a clean no-op. The
+table therefore exposes named **slots** — the consumer injects a module's
+component into a slot; an empty slot renders nothing.
+
+```ts
+// packages/ui/src/components/table/table.tsx (BetterTableProps addition)
+
+export interface ActionsToolbarSlotProps<TData = unknown> {
+  /** The actions passed to <BetterTable actions={...} />. Non-empty when this slot renders. */
+  actions: TableAction<TData>[];
+  /** Ids of the currently selected rows. */
+  selectedIds: string[];
+  /** The selected rows' data, in selection order. */
+  selectedData: TData[];
+  /** Called after an action's handler resolves (host may refetch/refresh). */
+  onActionMake: (actionId: string) => void;
+}
+
+export interface ToolbarExtraSlotProps<TData = unknown> {
+  /** Column definitions currently rendered (post-resolution). */
+  columns: ColumnDefinition<TData, unknown>[];
+  /** The active adapter (may be undefined for pure `data`-driven tables). */
+  adapter?: TableConfig<TData>['adapter'];
+  /** The current filter tree (flat array or group node) — what export must honor. */
+  filters: FilterState[] | FilterGroupNode;
+  /** The current sort state. */
+  sorting: SortingState;
+  /** Total row count if known (for row-cap/warn decisions). */
+  totalCount?: number;
+}
+
+export interface BetterTableSlots<TData = unknown> {
+  /**
+   * Rendered where the inline ActionsToolbar renders today (toolbar row, left
+   * of the FilterBar), ONLY when `actions.length > 0`. Installed by the
+   * `actions` module: `slots={{ actionsToolbar: ActionsToolbar }}`.
+   */
+  actionsToolbar?: ComponentType<ActionsToolbarSlotProps<TData>>;
+  /**
+   * Rendered in the toolbar row for extra controls. Reserved for plan 050's
+   * ExportButton (ships as the `export` module) and future toolbar content.
+   */
+  toolbarExtra?: ComponentType<ToolbarExtraSlotProps<TData>>;
+}
+```
+
+`BetterTableProps` gains `slots?: BetterTableSlots<TData>`.
+
+### Why component-injection slots and not children/render-props
+
+The composition guides (`vercel-composition-patterns`) prefer children over
+`renderX` props and warn against boolean-prop proliferation. Both concerns are
+respected here, not violated:
+
+- This is NOT a boolean mode flag — there is no `showActions`/`enableExport`
+  boolean. Presence of a slot component IS the composition. (`architecture-avoid-boolean-props`.)
+- Children composition can't express this seam: the table decides WHERE in its
+  own toolbar the control renders and feeds it INTERNAL state the consumer
+  never holds (live selection set, resolved columns, the current filter tree).
+  That is dependency injection of a component into a known extension point —
+  the slot/compound pattern (`state-decouple-implementation`,
+  `state-context-interface`), which the guides endorse for exactly this shape.
+- `ComponentType` (not a `renderActionsToolbar(props) => ReactNode` render
+  prop) keeps the prop a stable component identity, avoids an inline-closure
+  child re-mounting, and reads as "install this component here."
+
+### Slot-props validation — consumer 1: actions toolbar
+
+Today's inline render (`table.tsx:1288-1301`) passes `ActionsToolbar`:
+`actions`, `selectedIds={Array.from(selectedRows)}`,
+`selectedData={data.filter((row, i) => selectedRows.has(getRowId(row, i)))}`,
+`onActionMake={() => {}}`. `ActionsToolbarProps`
+(`actions-toolbar.tsx:15-20`) is exactly `{ actions, selectedIds, selectedData?, onActionMake }`.
+`ActionsToolbarSlotProps` is a superset (it makes `selectedData` required and
+non-optional, which the call site already always provides), so
+`ActionsToolbar` satisfies `ComponentType<ActionsToolbarSlotProps<TData>>`
+with ZERO changes to `actions-toolbar.tsx`. ✔
+
+### Slot-props validation — consumer 2: plan 050 ExportButton
+
+Plan 050 Step 2–3: `useTableExport` "takes the adapter (+ current
+columns/filters/sorting), calls `adapter.exportData(...)`" and `<ExportButton>`
+gates on `adapter.meta.features.export`. `ToolbarExtraSlotProps` supplies
+`adapter`, `columns`, `filters`, `sorting` (and `totalCount` for 050's row-cap
+UI) — everything `exportData` and the capability gate need. The export button
+reads `adapter?.meta?.features?.export` off the injected `adapter` and hides
+itself when absent — no extra slot field required. ✔
+
+**Result: two slot points, no more** (same minimalism rule as plan 049). The
+export sketch did NOT force a slot-shape change beyond confirming
+`toolbarExtra` must carry `adapter`/`columns`/`filters`/`sorting`/`totalCount`
+(all included above). If a future module needs the *live selection* in
+`toolbarExtra`, that is a new design conversation, not a speculative field now.
+
+---
+
+## 2. Absent-module behavior
+
+`actions` provided but `slots.actionsToolbar` absent → render nothing and
+`console.warn` ONCE in dev, naming the fix. Reuse the existing keyed
+one-time-dev-warn pattern (`table.tsx:975-987`, `warnFilterTreeDropped`):
+production-gated (`process.env.NODE_ENV === 'production'` early-return), keyed
+by table `id` in a `useRef` so re-pointing at a new `id` re-arms it.
+
+Warn text (quoted verbatim in troubleshooting docs):
+
+```
+[better-tables] table "<id>": `actions` were provided but no `slots.actionsToolbar` is set, so the bulk-actions toolbar will not render. Install the actions module (`bunx better-tables add actions`) and pass `slots={{ actionsToolbar: ActionsToolbar }}`.
+```
+
+`toolbarExtra` has no such warn — nothing signals intent-to-export the way a
+non-empty `actions` array signals intent-to-show-actions, so an empty
+`toolbarExtra` is simply "no extra toolbar content."
+
+Row selection is unaffected: `shouldShowRowSelection = actions.length > 0 || rowSelection`
+(`table.tsx:721`) stays exactly as is. Passing `actions` still turns on the
+checkbox column even when the toolbar module is absent (the selection is a core
+feature; only the toolbar is a module). The warn tells the user why the toolbar
+they expected is missing.
+
+---
+
+## 3. Module manifest schema (CLI)
+
+`UI_SOURCE_FILES` (flat) becomes `UI_MODULES` (named groups). Every file under
+`packages/ui/src` belongs to EXACTLY ONE module; the drift test enforces both
+`union(modules) === real tree (minus exclusions)` AND pairwise disjointness.
+
+```ts
+// packages/cli/src/lib/file-operations.ts
+const UI_MODULES = {
+  core: {
+    components: {
+      table: [ /* today's table[] minus the 2 actions files */ ],
+      filters: [ /* today's filters[] unchanged */ ],
+    },
+    hooks: [ /* unchanged */ ],
+    lib: ['utils.ts'],
+  },
+  actions: {
+    components: {
+      table: ['action-confirmation-dialog.tsx', 'actions-toolbar.tsx'],
+    },
+  },
+} as const;
+```
+
+- `core` is everything shipped today except the two actions files. It is always
+  copied (by `init` and as the base of any `add`).
+- `actions` is the two files at `table.tsx:1288`'s render target.
+- A future `export` module (plan 050) adds
+  `{ components: { table: ['export-button.tsx'] }, hooks: ['use-table-export.ts'] }`.
+
+**Path-mapping generality**: `generateFileMappings(resolvedPaths, componentsOutputPath, moduleNames)`
+walks the selected modules' `components.table` / `components.filters` / `hooks`
+/ `lib` shapes with the SAME destination rules as today (table → `<components>/<out>/table/`,
+filters → `<components>/<out>/filters/`, hooks → `resolvedPaths.hooks`, lib →
+`resolvedPaths.lib`). `core` is implicitly included whenever any module set is
+requested (you can't add `actions` without `core`'s `table.tsx` present, but
+`add` assumes `core` was already copied by `init` — see §4). A per-module
+`getModuleSourceFilePaths(name)` plus a `getAllUiSourceFilePaths()` (union) are
+exported for the drift test; `getUiSourceFilePaths()` stays as an alias of the
+union so existing importers don't break.
+
+---
+
+## 4. Command surface
+
+- **`better-tables add <modules...>`** (variadic). Reuses init's config
+  resolution (`getConfig(cwd)`) and `copyFile` machinery. Flags: `--cwd`,
+  `--yes`, `--components-path <path>` — the last MUST match the init-time path
+  (read from the same `getConfig`/`resolvedPaths` init uses; the user passes it
+  the same way today, there is no persisted record of it). No shadcn re-check
+  beyond the config read (shadcn primitives were installed at `init`).
+  - Copies ONLY the named modules' files (not `core`) — `add` assumes `init`
+    already laid down `core`. `add core` is accepted as a no-op/refresh.
+  - Unknown module → print the valid module names and `process.exit(1)`.
+- **`init`** copies `core` by default (NOT the flat everything-set it copies
+  today — this is the user-visible behavior change). `--modules <names...>`
+  opts modules in at init time (`init --modules actions`). The next-steps
+  output gains a "Modules" line listing available modules with one-liners, e.g.
+  `actions — bulk-action toolbar over selected rows: bunx better-tables add actions`.
+  The copy-confirmation dir list is unchanged in shape (the same four
+  directories can receive files); it does not enumerate individual files.
+- **Shared helper**: `add` needs init's config resolution + copy loop. To stay
+  under the plan's ~30-line-duplication STOP, extract a
+  `resolveInitPaths(cwd)` → `{ config, resolvedPaths }` (thin wrapper over
+  `getConfig` with the same error handling) and reuse `copyAllFiles`-style
+  iteration by passing selected module names down to `generateFileMappings`.
+  If that helper wants to grow past config+paths, STOP and report.
+
+Registry (`commands.ts`) gains an `add` entry with a variadic `modules`
+argument and the three flags; `add.ts` follows the `docs.ts`/`init.ts` factory
+pattern but builds the variadic argument as `command.argument('<modules...>', …)`
+(the shared factory-arg loop in `docs.ts` does not emit variadic syntax, so
+`add.ts` adds its argument directly). `cli.ts` registers the `add` factory
+alongside the existing three.
+
+---
+
+## 5. What stays put (non-goals, for the record)
+
+- `TableAction` type stays in `@better-tables/core` — types are cheap and every
+  tier references them; only the toolbar COMPONENTS move to a module.
+- Row selection / checkbox column stay in `core` (unchanged behavior).
+- No npm packaging of modules — modules are copied source, full stop.
+- Core-tier plugins (049) are orthogonal and out of scope here.
+
+---
+
+## Open follow-ups (not this plan)
+
+- Plan 050's `ExportButton` becomes the first `toolbarExtra` occupant and ships
+  as an `export` module; refresh 050 against this record before executing.
+- Plan 048's filter-group builder is a natural third module but REPLACES the
+  filter bar rather than adding toolbar content — a different slot question,
+  designed when 048 is planned.


### PR DESCRIPTION
## What & why

Gives the copied-UI (shadcn-style) tier a real structure: named, independently copyable **modules**. `init` now copies a `core` module by default; the bulk-actions toolbar is extracted as the first opt-in `actions` module, added on demand via a new `better-tables add <module>` command. This stops every consumer from inheriting the actions toolbar whether they want it or not, and gives future capabilities (export, saved views, filter-group builder) a seam to ride.

Modules plug into the table through a new `slots` prop — an absent module is a clean no-op, so `core` has no dead imports. Passing `actions` without wiring the slot renders nothing and warns once in dev, naming the fix.

Implements [plans/059](plans/059-ui-modules-and-actions-extraction.md). Also defers [plan 058](plans/058-global-search.md) (global search) by maintainer decision — plan left fully intact.

## Changes

- **`table.tsx`** — `slots` prop (`actionsToolbar` / `toolbarExtra`) with slot-props types validated against **both** the actions toolbar and plan 050's ExportButton (two slots, no more). Direct `ActionsToolbar` import removed; render goes through the slot. `NoInfer<TData>` on `slots` so the contravariant slot position doesn't collapse `BetterTable`'s type inference (consumers wire slots without an explicit type arg).
- **CLI** — flat `UI_SOURCE_FILES` → `UI_MODULES`; the manifest drift test now enforces `union === tree` **and** module disjointness. New `add` command + `init --modules`; shared `module-install.ts` helper (path validation, module resolution, copy summary).
- **Dogfood** — the homepage wires `slots={{ actionsToolbar: ActionsToolbar }}`. Browser-verified: "Actions (10)" renders through the slot after select-all, no console warnings.
- **Docs** — `ui-and-cli` (new Modules section + plugins-vs-modules vocabulary), `selection-and-actions` (install step + slot wiring), `troubleshooting` ("bulk actions don't render", quoting the dev warn).
- **Design record** — `plans/design/ui-modules.md`. **Changeset** — `@better-tables/cli` minor.

## Vocabulary

Two tiers, kept distinct: **plugins** = core `betterTables({ plugins })` (npm, data hooks); **modules** = copied UI added with `better-tables add` (this PR).

## Reviewer notes

- `@better-tables/ui` is private/copied — no npm surface change; the `slots` prop is the user-visible seam, documented in the CLI changeset.
- `TableAction` stays in `@better-tables/core`; row selection stays core (still turns on whenever `actions` is non-empty — only the toolbar is a module).
- Scrutiny points: absent-module path (no crash, one warn), drift-test disjointness, and that `init` output actually tells users modules exist.

## Verification

- typecheck 11/11 · cli 160 · ui 172 · marketing 66 · 0 failures · biome clean
- `add actions` smoke: copies exactly `actions-toolbar.tsx` + `action-confirmation-dialog.tsx`; default `init` excludes them

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in UI modules tier for the copied UI. `init` now installs the `core` module only, the bulk‑actions toolbar moves to an `actions` module that plugs into `<BetterTable>` via a new `slots` prop, and `init` now exits non‑zero on real copy failures.

- **New Features**
  - `slots` on `<BetterTable>`: `actionsToolbar` for the actions module, and `toolbarExtra` for future export.
  - New `better-tables add <module>` command and `init --modules`; default is `core` only.
  - Actions toolbar extracted to `actions`; one-time dev warn if `actions` are passed without wiring `slots.actionsToolbar`.
  - CLI manifest refactored to `UI_MODULES` with tests enforcing union-with-source and module disjointness; homepage dogfoods the slot; docs updated; `init` exits non‑zero on copy failures with added helper coverage and stricter module-mapping tests.

- **Migration**
  - To use bulk actions: `bunx @better-tables/cli add actions`, then wire `slots={{ actionsToolbar: ActionsToolbar }}`.
  - At setup: `bunx @better-tables/cli init --modules actions` to include it on init.
  - No npm surface change; row selection stays core.

<sup>Written for commit 207ea793c9470fa6f644f7f669115edcf490988e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Better-Tables/better-tables/pull/100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

