### PR TITLE
feat: derived aggregate columns (plan 060)

### DIFF
--- a/.changeset/derived-aggregate-columns-core.md
+++ b/.changeset/derived-aggregate-columns-core.md
@@ -1,0 +1,9 @@
+---
+"@better-tables/core": minor
+---
+
+Add declarative derived aggregate columns (`t.count` / `t.aggregate`), serializable
+`DerivedColumnSpec` on column defs and `FetchDataParams.derived`, and
+`AdapterMeta.capabilities.aggregates`. Instance `fetchData` and `memoryAdapter`
+attach/evaluate specs; `'custom'` builders (`t.computed` / `t.custom`) now default
+to `filterable: false` and `sortable: false`.

--- a/.changeset/derived-aggregate-columns-drizzle.md
+++ b/.changeset/derived-aggregate-columns-drizzle.md
@@ -1,0 +1,8 @@
+---
+"@better-tables/adapters-drizzle": minor
+---
+
+Lower `FetchDataParams.derived` aggregate specs to correlated subqueries via the
+computed-fields pipeline (SELECT / WHERE / ORDER BY). `filterSql`-backed fields
+and derived aggregates walk `FilterGroupNode` trees in place (OR semantics preserved);
+legacy callback-`filter` computed fields still throw with updated guidance.

--- a/.changeset/robustness-computed-tree-gap.md
+++ b/.changeset/robustness-computed-tree-gap.md
@@ -2,8 +2,7 @@
 "@better-tables/adapters-drizzle": patch
 ---
 
-Computed-field filters inside a `FilterGroupNode` tree are now rejected with
-an explicit `QueryError` instead of being treated as real schema columns
-(plan 051). Substitution still only walks a flat `FilterState[]`, so pass
-computed-field filters as a flat filter array (implicit AND) or flatten the
-tree at the call site — tree-walking substitution remains a known gap.
+Legacy callback-`filter` computed fields inside a `FilterGroupNode` throw an
+explicit `QueryError` instead of being treated as schema columns (plan 051).
+Tree-walking substitution for `filterSql` / plan-060 derived aggregates landed
+separately — see the derived-aggregate-columns changeset.

--- a/apps/marketing/content/docs/adapters/custom.mdx
+++ b/apps/marketing/content/docs/adapters/custom.mdx
@@ -23,6 +23,8 @@ const result = await tables.fetchData(ticketsTable, {
 
 Options: `getRowId` (row identity for edits; defaults to the `id` field), `tableName`, and `enumInferenceLimit` (distinct-string ceiling for inferring `option` columns; default 12, `0` disables). Scope: own-table columns only — dot-path ids walk nested objects, but there's no relationship model or JOIN semantics; use a database adapter for relational data.
 
+`memoryAdapter` does support plan-060 **derived aggregates** when rows already carry nested arrays (`posts: [...]`): it materializes `t.count` / `t.aggregate` values before filter/sort and declares `meta.capabilities.aggregates` (all fns, render/filter/sort).
+
 ## The contract
 
 ```ts
@@ -37,7 +39,7 @@ import type { TableAdapter } from '@better-tables/core';
 | `getFilterOptions(columnId, params?)` | Distinct choices for option filters → `FilterOption[]` |
 | `getFacetedValues(columnId, params?)` | Value counts → `Map<string, number>` (self-exclusion is YOUR job: a column's own filter must not narrow its own facet) |
 | `getMinMaxValues(columnId, params?)` | `[min, max]` for range facets |
-| `meta` | `AdapterMeta` — name, version, and the `features` flags below |
+| `meta` | `AdapterMeta` — name, version, `features`, and optional `capabilities` (e.g. `aggregates` for `t.count` / `t.aggregate`) |
 
 **Optional** — declare only what you support; `features` must match:
 
@@ -52,7 +54,7 @@ import type { TableAdapter } from '@better-tables/core';
 
 `AdapterFeatures` flags: `create`, `read`, `update`, `delete`, `bulkOperations`, `realTimeUpdates`, `export`, `transactions`. The UI checks these before offering behavior — `features.update: false` renders adapter-saved editable cells read-only.
 
-`fetchData` params to honor: `pagination` (1-based), `sorting[]`, `filters` (`FilterState[]` = implicit AND, **or** a `FilterGroupNode` tree — core does not canonicalize before dispatch; support both), `columns`, `primaryTable`, `params`, `signal`. The `search` param is declared on the contract but not yet consumed by first-party callers.
+`fetchData` params to honor: `pagination` (1-based), `sorting[]`, `filters` (`FilterState[]` = implicit AND, **or** a `FilterGroupNode` tree — core does not canonicalize before dispatch; support both), `columns`, `derived` (serializable aggregate specs from `t.count` / `t.aggregate`), `primaryTable`, `params`, `signal`. The `search` param is declared on the contract but not yet consumed by first-party callers. If you do not implement aggregates, omit `capabilities.aggregates` — instance fetch throws a clear error when specs are present.
 
 ## What the toolkit provides
 

--- a/apps/marketing/content/docs/adapters/custom.mdx
+++ b/apps/marketing/content/docs/adapters/custom.mdx
@@ -23,7 +23,7 @@ const result = await tables.fetchData(ticketsTable, {
 
 Options: `getRowId` (row identity for edits; defaults to the `id` field), `tableName`, and `enumInferenceLimit` (distinct-string ceiling for inferring `option` columns; default 12, `0` disables). Scope: own-table columns only — dot-path ids walk nested objects, but there's no relationship model or JOIN semantics; use a database adapter for relational data.
 
-`memoryAdapter` does support plan-060 **derived aggregates** when rows already carry nested arrays (`posts: [...]`): it materializes `t.count` / `t.aggregate` values before filter/sort and declares `meta.capabilities.aggregates` (all fns, render/filter/sort).
+`memoryAdapter` supports **derived aggregates** when rows already carry nested arrays (`posts: [...]`): it materializes `t.count` / `t.aggregate` values before filter/sort and declares `meta.capabilities.aggregates` (all fns, render/filter/sort).
 
 ## The contract
 

--- a/apps/marketing/content/docs/adapters/drizzle.mdx
+++ b/apps/marketing/content/docs/adapters/drizzle.mdx
@@ -74,7 +74,7 @@ PostgreSQL `.array()` foreign keys (with `.references()`) are detected automatic
 
 Try it live: [/examples/relationship-filtering](/examples/relationship-filtering).
 
-## Derived aggregates (`t.count`)
+## Derived aggregates (t.count)
 
 Prefer declarative columns over hand-rolled `computedFields` for relation counts:
 

--- a/apps/marketing/content/docs/adapters/drizzle.mdx
+++ b/apps/marketing/content/docs/adapters/drizzle.mdx
@@ -74,6 +74,18 @@ PostgreSQL `.array()` foreign keys (with `.references()`) are detected automatic
 
 Try it live: [/examples/relationship-filtering](/examples/relationship-filtering).
 
+## Derived aggregates (`t.count`)
+
+Prefer declarative columns over hand-rolled `computedFields` for relation counts:
+
+```ts
+t.count('posts').displayName('Posts'), // id: postsCount
+```
+
+The adapter validates the many-relation on the primary table, lowers the spec to a correlated subquery on SELECT / WHERE / ORDER BY (via the existing computed-fields pipeline), and supports filters inside `FilterGroupNode` trees. Index the FK on the related table (`posts.user_id`) — each row pays one subquery.
+
+See [Derived columns](/docs/columns#derived-columns-server-aggregates).
+
 ## Facets
 
 `getFacetedValues` / `getMinMaxValues` / `fetchData({ faceted })` power filter option counts and range facets, with self-exclusion handled by the adapter. See the [Facets guide](/docs/facets) and [/examples/facets](/examples/facets).

--- a/apps/marketing/content/docs/better-table.mdx
+++ b/apps/marketing/content/docs/better-table.mdx
@@ -17,7 +17,7 @@ Pass `data` plus either a `table` definition (supplies identity and columns) or 
 |---|---|---|
 | `id` | `string` | Unique table instance id (keys the state store and URL params). Defaults to `table.tableName` when `table` is given |
 | `name` | `string` | Human-readable display name. Defaults to `table.tableName` |
-| `columns` | `ColumnDefinition[]` | Column definitions. Defaults to `table.columns` |
+| `columns` | `ColumnDefinition[]` | Column definitions. Defaults to `table.columns`. Server aggregates: [`t.count` / `t.aggregate`](/docs/columns#derived-columns-server-aggregates) |
 | `table` | `TableDefinition` | A `defineTable()` / `tables.define()` definition — sugar for `columns`/`id`/`name` (explicit props still win). Enables [auto columns](/docs/columns/auto-columns) resolution when paired with `adapter` |
 
 ## Data & fetching

--- a/apps/marketing/content/docs/columns/index.mdx
+++ b/apps/marketing/content/docs/columns/index.mdx
@@ -39,8 +39,21 @@ export const usersTable = tables.define('users', (t) => ({
 
 ## Escape hatches
 
-- `t.computed(id, accessor)` — derived display values
-- `t.custom()` — full fluent builder when you need total control
+- `t.computed(id, accessor)` — client-only derived display values (`type: 'custom'`). Defaults to **not** filterable/sortable — there is no DB column behind the id.
+- `t.custom()` — full fluent builder when you need total control (same honest defaults)
+
+## Derived columns (server aggregates)
+
+For relation counts and aggregates the adapter can render, filter, and sort in SQL, use declarative builders — not hand-rolled `computedFields`:
+
+```ts
+t.count('posts').displayName('Posts'),
+// → column id `postsCount`, type number, filterable + sortable
+
+t.aggregate('revenueTotal', { relation: 'orders', fn: 'sum', field: 'amount' }),
+```
+
+Specs travel on `FetchDataParams.derived` (attached by instance `fetchData` / `useTableData`). Drizzle lowers them to correlated subqueries; `memoryAdapter` evaluates nested arrays. Adapters advertise support via `meta.capabilities.aggregates`. Acceptance one-liner: **a users table with `t.count('posts')` you can render, filter (`greaterThan` 5), and sort**.
 
 ## Standalone columns (no schema)
 

--- a/apps/marketing/content/docs/filtering.mdx
+++ b/apps/marketing/content/docs/filtering.mdx
@@ -87,7 +87,9 @@ await tables.fetchData(ticketsTable, {
 });
 ```
 
-Nested groups round-trip through URL sync and programmatic `setFilterNode` (see [URL State](/docs/url-state)). The filter bar stays a flat implicit-AND chip list — visual AND/OR tree editing is not shipped yet:
+Nested groups round-trip through URL sync and programmatic `setFilterNode` (see [URL State](/docs/url-state)). Server-derived aggregate columns (`t.count` / `t.aggregate` — see [Derived columns](/docs/columns#derived-columns-server-aggregates)) participate in the same trees: Drizzle substitutes correlated-subquery predicates in place so OR groups keep union semantics.
+
+The filter bar stays a flat implicit-AND chip list — visual AND/OR tree editing is not shipped yet:
 
 <Cards>
   <Card title="Query groups example" href="/examples/query-groups" description="AND/OR filter trees with URL share." />

--- a/apps/marketing/content/docs/packages/core.mdx
+++ b/apps/marketing/content/docs/packages/core.mdx
@@ -34,7 +34,7 @@ pnpm add @better-tables/core
 | Area | Exports |
 |---|---|
 | Factory | `betterTables`, `defineTable` — the flagship entry points ([Quick Start](/docs/quick-start)) |
-| Path builders | The `t` callback surface: `t.text` / `t.number` / `t.date` / `t.option` / `t.multiOption` / `t.boolean` / `t.computed` / `t.custom` / `t.auto` ([Columns](/docs/columns)) |
+| Path builders | The `t` callback surface: `t.text` / `t.number` / `t.date` / `t.option` / `t.multiOption` / `t.boolean` / `t.count` / `t.aggregate` / `t.computed` / `t.custom` / `t.auto` ([Columns](/docs/columns)) |
 | Column resolution | `resolveTableColumns` — auto-column resolution at mount ([Auto columns](/docs/columns/auto-columns)) |
 | Editing | `cellEditAction` on the factory, `ValidationRule`, `EditableConfig` ([Inline editing](/docs/inline-editing)) |
 | Managers | `TableStateManager`, `FilterManager`, `PaginationManager`, `SortingManager`, `SelectionManager`, `VirtualizationManager` |

--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -14,7 +14,7 @@
     "postinstall": "fumadocs-mdx",
     "lint": "biome check .",
     "format": "biome format --write .",
-    "typecheck": "next typegen && tsc --noEmit",
+    "typecheck": "next typegen && fumadocs-mdx && tsc --noEmit",
     "test": "bun test",
     "clean": "git clean -xdf .cache .next .turbo .source node_modules"
   },

--- a/apps/marketing/src/lib/demo/users/columns.test.ts
+++ b/apps/marketing/src/lib/demo/users/columns.test.ts
@@ -33,4 +33,17 @@ describe('homepage demo columns', () => {
     expect(byId.name?.filterable).toBe(true);
     expect(byId.name?.sortable).toBe(true);
   });
+
+  it('exposes a server-derived postsCount aggregate column (plan 060)', () => {
+    const column = byId.postsCount;
+    expect(column).toBeDefined();
+    expect(column?.type).toBe('number');
+    expect(column?.filterable).toBe(true);
+    expect(column?.sortable).toBe(true);
+    expect(column?.derived).toEqual({
+      kind: 'aggregate',
+      relation: 'posts',
+      fn: 'count',
+    });
+  });
 });

--- a/apps/marketing/src/lib/demo/users/columns.tsx
+++ b/apps/marketing/src/lib/demo/users/columns.tsx
@@ -77,11 +77,8 @@ export const usersTable = defineTable<UsersTables>()('users', (t) => ({
         </Badge>
       )),
 
-    // Derived display values: computed client-side from the fetched row.
-    // Builders default to filterable/sortable, so both must be turned OFF
-    // explicitly — there is no DB column behind these ids, and letting the
-    // controls through would send `hasBio` / `roleTags` to the query builder
-    // as if they were storage fields.
+    // Client-only display values (`type: 'custom'`). Honest defaults are
+    // filterable/sortable false (plan 060); explicit flags kept for clarity.
     t
       .computed('hasBio', (row) => Boolean(row.profile?.bio))
       .displayName('Has Bio')
@@ -107,6 +104,9 @@ export const usersTable = defineTable<UsersTables>()('users', (t) => ({
           ))}
         </div>
       )),
+
+    // Server-derived relation count (plan 060) — filterable/sortable via SQL.
+    t.count('posts').displayName('Posts'),
 
     t.date('createdAt').displayName('Joined').filterable().sortable().editable(),
 
@@ -190,6 +190,7 @@ export const allUserColumnIds = [
   'age',
   'role',
   'status',
+  'postsCount',
   'createdAt',
   'profile.id',
   'profile.bio',
@@ -205,6 +206,7 @@ export const defaultVisibleColumns = [
   'age',
   'role',
   'status',
+  'postsCount',
   'hasBio',
   'roleTags',
   'createdAt',

--- a/apps/marketing/src/lib/demo/users/columns.tsx
+++ b/apps/marketing/src/lib/demo/users/columns.tsx
@@ -106,7 +106,9 @@ export const usersTable = defineTable<UsersTables>()('users', (t) => ({
       )),
 
     // Server-derived relation count (plan 060) — filterable/sortable via SQL.
-    t.count('posts').displayName('Posts'),
+    t
+      .count('posts')
+      .displayName('Posts'),
 
     t.date('createdAt').displayName('Joined').filterable().sortable().editable(),
 

--- a/apps/marketing/src/lib/demo/users/fetch-users.test.ts
+++ b/apps/marketing/src/lib/demo/users/fetch-users.test.ts
@@ -37,7 +37,9 @@ const actualUserColumns = await import('@/lib/demo/users/columns');
 
 mock.module('@/lib/demo/users/columns', () => ({
   ...actualUserColumns,
-  usersTable: { id: 'users' },
+  // Minimal stub for fetchUsers unit tests — keep `columns` so other suites
+  // that share this process (e.g. postgres smoke) don't see `undefined`.
+  usersTable: { id: 'users', tableName: 'users', columns: [] },
 }));
 
 const { fetchUsers } = await import('./fetch-users');

--- a/apps/marketing/src/lib/demo/users/fetch-users.ts
+++ b/apps/marketing/src/lib/demo/users/fetch-users.ts
@@ -57,7 +57,7 @@ export async function fetchUsers({
         // result rows (plan 030, finding 10), and column visibility is
         // client-side, so hidden-but-toggleable columns need their data too.
         // Includes `id` / `profile.id` for cell-edit row addressing.
-        // (hasBio / roleTags are computed client-side from these.)
+        // (hasBio / roleTags are client-only; postsCount attaches via derived.)
         columns: [...allUserColumnIds],
       })
     );

--- a/packages/adapters/drizzle/docs/ADVANCED_USAGE.md
+++ b/packages/adapters/drizzle/docs/ADVANCED_USAGE.md
@@ -444,6 +444,11 @@ const columns = [
 
 ## Computed Fields
 
+> **Preferred for relation counts:** use `t.count('posts')` / `t.aggregate(...)` on
+> `defineTable` (see [Derived columns](https://better-tables.com/docs/columns#derived-columns-server-aggregates)).
+> Those specs lower into this same pipeline automatically. Prefer that path over
+> hand-rolling `computedFields` for single-hop many-relation aggregates.
+
 Computed fields allow you to add virtual columns that are calculated at runtime. These fields don't exist in the database schema but are computed from the row data, related tables, or any other source.
 
 ### Basic Computed Field

--- a/packages/adapters/drizzle/src/adapter-meta.ts
+++ b/packages/adapters/drizzle/src/adapter-meta.ts
@@ -37,6 +37,14 @@ export function buildAdapterMeta(
     supportedOperators,
     supportsFilterGroups: true,
     maxGroupDepth: 3,
+    capabilities: {
+      aggregates: {
+        fns: ['count', 'sum', 'avg', 'min', 'max'],
+        render: true,
+        filter: true,
+        sort: true,
+      },
+    },
     ...customMeta,
   };
 }

--- a/packages/adapters/drizzle/src/derived-aggregates.ts
+++ b/packages/adapters/drizzle/src/derived-aggregates.ts
@@ -12,7 +12,7 @@ import type {
   ComputedFieldConfig,
   ComputedFieldContext,
 } from './types';
-import { SchemaError } from './types';
+import { QueryError, SchemaError } from './types';
 import { getColumnInfo } from './utils/drizzle-schema-utils';
 
 function resolveColumn(table: AnyTableType, fieldName: string, tableKey: string): AnyColumnType {
@@ -56,30 +56,61 @@ function aggregateExpression(
   }
 }
 
+function requireNumericFilterValue(
+  raw: unknown,
+  filter: FilterState,
+  slot: 'value' | 'lower bound' | 'upper bound'
+): number {
+  const n = Number(raw);
+  if (Number.isNaN(n)) {
+    throw new QueryError(
+      `Derived aggregate filter on '${filter.columnId}' (${filter.operator}) requires a numeric ${slot} but received '${String(raw)}'.`,
+      { columnId: filter.columnId, operator: filter.operator, value: raw, slot }
+    );
+  }
+  return n;
+}
+
 function compareSubquery(subquery: SQL, filter: FilterState): SQL | SQLWrapper {
   const values = filter.values ?? [];
-  const n0 = Number(values[0]);
-  const n1 = Number(values[1]);
 
   switch (filter.operator) {
     case 'equals':
-    case 'is':
+    case 'is': {
+      const n0 = requireNumericFilterValue(values[0], filter, 'value');
       return sql`(${subquery}) = ${n0}`;
+    }
     case 'notEquals':
-    case 'isNot':
+    case 'isNot': {
+      const n0 = requireNumericFilterValue(values[0], filter, 'value');
       return sql`(${subquery}) <> ${n0}`;
-    case 'greaterThan':
+    }
+    case 'greaterThan': {
+      const n0 = requireNumericFilterValue(values[0], filter, 'value');
       return sql`(${subquery}) > ${n0}`;
-    case 'greaterThanOrEqual':
+    }
+    case 'greaterThanOrEqual': {
+      const n0 = requireNumericFilterValue(values[0], filter, 'value');
       return sql`(${subquery}) >= ${n0}`;
-    case 'lessThan':
+    }
+    case 'lessThan': {
+      const n0 = requireNumericFilterValue(values[0], filter, 'value');
       return sql`(${subquery}) < ${n0}`;
-    case 'lessThanOrEqual':
+    }
+    case 'lessThanOrEqual': {
+      const n0 = requireNumericFilterValue(values[0], filter, 'value');
       return sql`(${subquery}) <= ${n0}`;
-    case 'between':
+    }
+    case 'between': {
+      const n0 = requireNumericFilterValue(values[0], filter, 'lower bound');
+      const n1 = requireNumericFilterValue(values[1], filter, 'upper bound');
       return sql`(${subquery}) BETWEEN ${n0} AND ${n1}`;
-    case 'notBetween':
+    }
+    case 'notBetween': {
+      const n0 = requireNumericFilterValue(values[0], filter, 'lower bound');
+      const n1 = requireNumericFilterValue(values[1], filter, 'upper bound');
       return sql`(${subquery}) NOT BETWEEN ${n0} AND ${n1}`;
+    }
     case 'isNull':
       return sql`(${subquery}) IS NULL`;
     case 'isNotNull':
@@ -118,6 +149,13 @@ export function lowerDerivedAggregateSpec(
     throw new SchemaError(
       `Derived aggregates require a many-relation; '${spec.relation}' on '${primaryTable}' is '${relationship.cardinality}'.`,
       { primaryTable, relation: spec.relation, cardinality: relationship.cardinality }
+    );
+  }
+
+  if (relationship.isArray) {
+    throw new SchemaError(
+      `Derived aggregates on array-FK relations are not supported in v1; '${spec.relation}' on '${primaryTable}' is an array relationship.`,
+      { primaryTable, relation: spec.relation, isArray: true }
     );
   }
 

--- a/packages/adapters/drizzle/src/derived-aggregates.ts
+++ b/packages/adapters/drizzle/src/derived-aggregates.ts
@@ -4,7 +4,7 @@
  */
 
 import type { DerivedFetchSpec, FilterState } from '@better-tables/core';
-import { getTableName, sql, type SQL, type SQLWrapper } from 'drizzle-orm';
+import { getTableName, type SQL, type SQLWrapper, sql } from 'drizzle-orm';
 import type { RelationshipManager } from './relationship-manager';
 import type {
   AnyColumnType,
@@ -15,11 +15,7 @@ import type {
 import { SchemaError } from './types';
 import { getColumnInfo } from './utils/drizzle-schema-utils';
 
-function resolveColumn(
-  table: AnyTableType,
-  fieldName: string,
-  tableKey: string
-): AnyColumnType {
+function resolveColumn(table: AnyTableType, fieldName: string, tableKey: string): AnyColumnType {
   const info = getColumnInfo(table, fieldName);
   if (!info) {
     throw new SchemaError(
@@ -60,10 +56,7 @@ function aggregateExpression(
   }
 }
 
-function compareSubquery(
-  subquery: SQL,
-  filter: FilterState
-): SQL | SQLWrapper {
+function compareSubquery(subquery: SQL, filter: FilterState): SQL | SQLWrapper {
   const values = filter.values ?? [];
   const n0 = Number(values[0]);
   const n1 = Number(values[1]);
@@ -145,11 +138,7 @@ export function lowerDerivedAggregateSpec(
   }
 
   const localColumn = resolveColumn(primaryTableSchema, relationship.localKey, primaryTable);
-  const foreignColumn = resolveColumn(
-    relatedTableSchema,
-    relationship.foreignKey,
-    relationship.to
-  );
+  const foreignColumn = resolveColumn(relatedTableSchema, relationship.foreignKey, relationship.to);
 
   let fieldColumn: AnyColumnType | undefined;
   if (spec.fn !== 'count') {
@@ -187,8 +176,7 @@ export function lowerDerivedAggregateSpec(
       return typeof value === 'number' ? value : Number(value ?? 0);
     },
     sortSql: () => buildSubquery(),
-    filterSql: (filter, _context: ComputedFieldContext) =>
-      compareSubquery(buildSubquery(), filter),
+    filterSql: (filter, _context: ComputedFieldContext) => compareSubquery(buildSubquery(), filter),
   };
 }
 

--- a/packages/adapters/drizzle/src/derived-aggregates.ts
+++ b/packages/adapters/drizzle/src/derived-aggregates.ts
@@ -1,0 +1,206 @@
+/**
+ * Lower plan-060 `FetchDataParams.derived` specs into the existing
+ * `ComputedFieldConfig` pipeline (correlated subqueries for SELECT/WHERE/ORDER BY).
+ */
+
+import type { DerivedFetchSpec, FilterState } from '@better-tables/core';
+import { getTableName, sql, type SQL, type SQLWrapper } from 'drizzle-orm';
+import type { RelationshipManager } from './relationship-manager';
+import type {
+  AnyColumnType,
+  AnyTableType,
+  ComputedFieldConfig,
+  ComputedFieldContext,
+} from './types';
+import { SchemaError } from './types';
+import { getColumnInfo } from './utils/drizzle-schema-utils';
+
+function resolveColumn(
+  table: AnyTableType,
+  fieldName: string,
+  tableKey: string
+): AnyColumnType {
+  const info = getColumnInfo(table, fieldName);
+  if (!info) {
+    throw new SchemaError(
+      `Column '${fieldName}' not found on table '${tableKey}' for derived aggregate.`,
+      { table: tableKey, field: fieldName }
+    );
+  }
+  return info.column;
+}
+
+function qualifiedColumn(table: AnyTableType, column: AnyColumnType): SQL {
+  // Unqualified column names inside a correlated subquery bind to the INNER
+  // FROM (e.g. posts.id), breaking correlation to the outer primary key.
+  // Always emit "table"."column" from schema metadata — never client strings.
+  return sql`${sql.identifier(getTableName(table))}.${sql.identifier(column.name)}`;
+}
+
+function aggregateExpression(
+  fn: DerivedFetchSpec['fn'],
+  relatedTable: AnyTableType,
+  fieldColumn: AnyColumnType | undefined
+): SQL {
+  if (fn === 'count' || fieldColumn == null) {
+    return sql`count(*)`;
+  }
+  const field = qualifiedColumn(relatedTable, fieldColumn);
+  switch (fn) {
+    case 'sum':
+      return sql`coalesce(sum(${field}), 0)`;
+    case 'avg':
+      return sql`coalesce(avg(${field}), 0)`;
+    case 'min':
+      return sql`min(${field})`;
+    case 'max':
+      return sql`max(${field})`;
+    default:
+      return sql`count(*)`;
+  }
+}
+
+function compareSubquery(
+  subquery: SQL,
+  filter: FilterState
+): SQL | SQLWrapper {
+  const values = filter.values ?? [];
+  const n0 = Number(values[0]);
+  const n1 = Number(values[1]);
+
+  switch (filter.operator) {
+    case 'equals':
+    case 'is':
+      return sql`(${subquery}) = ${n0}`;
+    case 'notEquals':
+    case 'isNot':
+      return sql`(${subquery}) <> ${n0}`;
+    case 'greaterThan':
+      return sql`(${subquery}) > ${n0}`;
+    case 'greaterThanOrEqual':
+      return sql`(${subquery}) >= ${n0}`;
+    case 'lessThan':
+      return sql`(${subquery}) < ${n0}`;
+    case 'lessThanOrEqual':
+      return sql`(${subquery}) <= ${n0}`;
+    case 'between':
+      return sql`(${subquery}) BETWEEN ${n0} AND ${n1}`;
+    case 'notBetween':
+      return sql`(${subquery}) NOT BETWEEN ${n0} AND ${n1}`;
+    case 'isNull':
+      return sql`(${subquery}) IS NULL`;
+    case 'isNotNull':
+      return sql`(${subquery}) IS NOT NULL`;
+    default:
+      throw new SchemaError(
+        `Unsupported operator '${filter.operator}' for derived aggregate column '${filter.columnId}'.`,
+        { columnId: filter.columnId, operator: filter.operator }
+      );
+  }
+}
+
+/**
+ * Validate a derived aggregate spec against the relationship map and build a
+ * `ComputedFieldConfig` that reuses filterSql/sortSql correlated subqueries.
+ */
+export function lowerDerivedAggregateSpec(
+  spec: DerivedFetchSpec,
+  primaryTable: string,
+  schema: Record<string, AnyTableType>,
+  relationshipManager: RelationshipManager
+): ComputedFieldConfig {
+  const relationship = relationshipManager.getRelationshipByAlias(primaryTable, spec.relation);
+  if (!relationship) {
+    const available = Object.keys(relationshipManager.getRelationships())
+      .filter((key) => key.startsWith(`${primaryTable}.`))
+      .map((key) => key.slice(primaryTable.length + 1));
+    throw new SchemaError(
+      `Unknown relation '${spec.relation}' on table '${primaryTable}' for derived column '${spec.columnId}'.` +
+        (available.length > 0 ? ` Available relations: ${available.join(', ')}.` : ''),
+      { primaryTable, relation: spec.relation, columnId: spec.columnId, available }
+    );
+  }
+
+  if (relationship.cardinality !== 'many') {
+    throw new SchemaError(
+      `Derived aggregates require a many-relation; '${spec.relation}' on '${primaryTable}' is '${relationship.cardinality}'.`,
+      { primaryTable, relation: spec.relation, cardinality: relationship.cardinality }
+    );
+  }
+
+  if (!relationship.localKey || !relationship.foreignKey) {
+    throw new SchemaError(
+      `Relation '${spec.relation}' on '${primaryTable}' is missing join keys (localKey/foreignKey) needed for a correlated aggregate subquery.`,
+      { primaryTable, relation: spec.relation, relationship }
+    );
+  }
+
+  const primaryTableSchema = schema[primaryTable];
+  const relatedTableSchema = schema[relationship.to];
+  if (!primaryTableSchema || !relatedTableSchema) {
+    throw new SchemaError(
+      `Schema tables missing for derived aggregate '${spec.columnId}' (primary='${primaryTable}', related='${relationship.to}').`,
+      { primaryTable, related: relationship.to }
+    );
+  }
+
+  const localColumn = resolveColumn(primaryTableSchema, relationship.localKey, primaryTable);
+  const foreignColumn = resolveColumn(
+    relatedTableSchema,
+    relationship.foreignKey,
+    relationship.to
+  );
+
+  let fieldColumn: AnyColumnType | undefined;
+  if (spec.fn !== 'count') {
+    if (!spec.field) {
+      throw new SchemaError(
+        `Derived aggregate '${spec.columnId}' with fn '${spec.fn}' requires a 'field'.`,
+        { columnId: spec.columnId, fn: spec.fn }
+      );
+    }
+    fieldColumn = resolveColumn(relatedTableSchema, spec.field, relationship.to);
+    const dataType = getColumnInfo(relatedTableSchema, spec.field)?.dataType ?? '';
+    if (dataType && !/number|int|numeric|decimal|real|double|float/i.test(dataType)) {
+      throw new SchemaError(
+        `Derived aggregate field '${spec.field}' on '${relationship.to}' must be numeric (got '${dataType}').`,
+        { field: spec.field, dataType, table: relationship.to }
+      );
+    }
+  }
+
+  const buildSubquery = (): SQL => {
+    const agg = aggregateExpression(spec.fn, relatedTableSchema, fieldColumn);
+    // Interpolate the related table as a Table chunk so join planning treats
+    // this as a correlated subquery (no outer one-to-many LEFT JOIN). Qualify
+    // both sides of the join predicate so the outer PK is not shadowed by an
+    // inner column of the same name (SQLite binds bare "id" to posts.id).
+    return sql`(select ${agg} from ${relatedTableSchema} where ${qualifiedColumn(relatedTableSchema, foreignColumn)} = ${qualifiedColumn(primaryTableSchema, localColumn)})`;
+  };
+
+  return {
+    field: spec.columnId,
+    type: 'number',
+    includeByDefault: false,
+    compute: (row) => {
+      const value = (row as Record<string, unknown>)[spec.columnId];
+      return typeof value === 'number' ? value : Number(value ?? 0);
+    },
+    sortSql: () => buildSubquery(),
+    filterSql: (filter, _context: ComputedFieldContext) =>
+      compareSubquery(buildSubquery(), filter),
+  };
+}
+
+/** Lower every derived fetch spec for a primary table into computed-field configs. */
+export function lowerDerivedAggregateSpecs(
+  specs: readonly DerivedFetchSpec[] | undefined,
+  primaryTable: string,
+  schema: Record<string, AnyTableType>,
+  relationshipManager: RelationshipManager
+): ComputedFieldConfig[] {
+  if (!specs || specs.length === 0) return [];
+  return specs.map((spec) =>
+    lowerDerivedAggregateSpec(spec, primaryTable, schema, relationshipManager)
+  );
+}

--- a/packages/adapters/drizzle/src/drizzle-adapter.ts
+++ b/packages/adapters/drizzle/src/drizzle-adapter.ts
@@ -78,7 +78,11 @@ import { AdapterCache } from './adapter-cache';
 import { buildAdapterMeta } from './adapter-meta';
 import { lowerDerivedAggregateSpecs } from './derived-aggregates';
 import { convertToExportFormat, getMimeType } from './export-format';
-import { collectFilterLeaves, pruneFilterNodeForColumn } from './filter-handler';
+import {
+  collectFilterLeaves,
+  pruneFilterNodeForColumn,
+  resolveJoinPlanningLeaves,
+} from './filter-handler';
 import { getOperationsFactory } from './operations';
 import { type BaseQueryBuilder, getQueryBuilderFactory } from './query-builders';
 import { RelationshipDetector } from './relationship-detector';
@@ -1682,10 +1686,10 @@ export class DrizzleAdapter<TSchema extends Record<string, unknown>, TDriver ext
     // contributes its JOIN to the count -- must agree with buildCompleteQuery's
     // own context (base-query-builder.ts), or `total` and page contents would
     // diverge under OR queries (plan 017 emphasis: count/data agreement).
-    const joinPlanningLeaves =
-      collectFilterLeaves(params.filters).length > 0
-        ? collectFilterLeaves(params.filters)
-        : (params.filterJoinLeaves ?? []);
+    const joinPlanningLeaves = resolveJoinPlanningLeaves({
+      filters: params.filters,
+      filterJoinLeaves: params.filterJoinLeaves,
+    });
     const context = this.relationshipManager.buildQueryContext(
       {
         columns: columnsForContext,

--- a/packages/adapters/drizzle/src/drizzle-adapter.ts
+++ b/packages/adapters/drizzle/src/drizzle-adapter.ts
@@ -73,8 +73,10 @@ import {
   normalizeFilterNode,
 } from '@better-tables/core';
 import type { Relations, SQL, SQLWrapper } from 'drizzle-orm';
+import { and, or } from 'drizzle-orm';
 import { AdapterCache } from './adapter-cache';
 import { buildAdapterMeta } from './adapter-meta';
+import { lowerDerivedAggregateSpecs } from './derived-aggregates';
 import { convertToExportFormat, getMimeType } from './export-format';
 import { collectFilterLeaves, pruneFilterNodeForColumn } from './filter-handler';
 import { getOperationsFactory } from './operations';
@@ -458,8 +460,18 @@ export class DrizzleAdapter<TSchema extends Record<string, unknown>, TDriver ext
     const primaryTable = this.resolvePrimaryTableForRead(params.columns, params.primaryTable);
 
     try {
-      // Get computed fields for this table
-      const tableComputedFields = this.computedFields[primaryTable] || [];
+      // Configured computed fields + plan-060 derived aggregates lowered into
+      // the same ComputedFieldConfig pipeline for this request only.
+      const derivedComputedFields = lowerDerivedAggregateSpecs(
+        params.derived,
+        primaryTable,
+        this.schema as Record<string, AnyTableType>,
+        this.relationshipManager
+      );
+      const tableComputedFields = [
+        ...(this.computedFields[primaryTable] || []),
+        ...derivedComputedFields,
+      ];
 
       // Filter out computed fields from columns and track which ones were requested
       const requestedComputedFields: ComputedFieldConfig[] = [];
@@ -472,6 +484,13 @@ export class DrizzleAdapter<TSchema extends Record<string, unknown>, TDriver ext
       // Note: Both undefined and [] (empty array) are treated as "no columns specified"
       // Use spread operator to avoid mutating the input parameter
       const columnsToProcess = params.columns ? [...params.columns] : [];
+      // Derived specs always participate when present (even if columns is empty /
+      // omitted) so SELECT gets the correlated subquery aliases.
+      for (const derivedField of derivedComputedFields) {
+        if (!columnsToProcess.includes(derivedField.field)) {
+          columnsToProcess.push(derivedField.field);
+        }
+      }
       if (columnsToProcess.length === 0) {
         // Include computed fields that should be included by default
         // These will be processed like regular columns and added to finalColumns
@@ -507,11 +526,9 @@ export class DrizzleAdapter<TSchema extends Record<string, unknown>, TDriver ext
       // Handle computed field filtering. `params.filters` may be a flat
       // FilterState[] (implicit AND) or a FilterGroupNode tree (plan 017);
       // normalizeIncomingFilters validates/normalizes a tree at this public
-      // API boundary (depth cap, dropping malformed nodes) and leaves a flat
-      // array untouched. Computed-field filter substitution below only
-      // understands the flat shape (computed fields are not real columns, so
-      // matching/replacing them inside an arbitrary AND/OR tree is out of
-      // scope for this plan) — it's skipped entirely when filters is a tree.
+      // API boundary. filterSql-backed fields (incl. plan-060 derived
+      // aggregates) substitute in place for both shapes; legacy callback
+      // `filter` still rejects trees.
       let processedFilters: FilterState[] | FilterGroupNode =
         this.normalizeIncomingFilters(params.filters) ?? [];
       const computedFieldFilters: Array<{ filter: FilterState; config: ComputedFieldConfig }> = [];
@@ -525,7 +542,24 @@ export class DrizzleAdapter<TSchema extends Record<string, unknown>, TDriver ext
           }
         }
       } else {
-        this.rejectComputedFieldFiltersInTree(processedFilters, tableComputedFields);
+        // Compile the whole tree so filterSql leaves keep AND/OR position
+        // (extracting them to top-level additionalConditions would AND them
+        // and break OR groups).
+        const treeSql = await this.compileTreeFiltersWithComputed(
+          processedFilters,
+          tableComputedFields,
+          {
+            primaryTable,
+            allRows: [],
+            db: this.db,
+            schema: this.schema,
+          },
+          primaryTable
+        );
+        if (treeSql) {
+          additionalSqlConditions.push(treeSql);
+        }
+        processedFilters = [];
       }
 
       // Build cache params early (needed for error handling)
@@ -632,9 +666,11 @@ export class DrizzleAdapter<TSchema extends Record<string, unknown>, TDriver ext
         };
       }
 
-      // Resolve sortSql expressions for computed fields that are being sorted
+      // Resolve sortSql for requested computed fields (SELECT alias) and sorts.
+      // Derived aggregates always carry sortSql so the correlated subquery
+      // lands in SELECT even when the column is not being sorted.
       const computedFieldsForSorting: Record<string, ComputedFieldWithResolvedSortSql> = {};
-      if (params.sorting && params.sorting.length > 0) {
+      {
         const context: ComputedFieldContext<TSchema, TDriver> = {
           primaryTable,
           allRows: [],
@@ -642,42 +678,39 @@ export class DrizzleAdapter<TSchema extends Record<string, unknown>, TDriver ext
           schema: this.schema,
         };
 
-        for (const sort of params.sorting) {
-          const computedField = tableComputedFields.find((cf) => cf.field === sort.columnId);
-          if (computedField?.sortSql) {
-            try {
-              // Resolve sortSql expression (handle both sync and async)
-              const sqlExpression = computedField.sortSql(context);
-              const resolvedExpression =
-                sqlExpression instanceof Promise ? await sqlExpression : sqlExpression;
+        const fieldsNeedingSelect = new Set<string>(
+          requestedComputedFields.filter((cf) => cf.sortSql).map((cf) => cf.field)
+        );
+        for (const sort of params.sorting ?? []) {
+          fieldsNeedingSelect.add(sort.columnId);
+        }
 
-              // Validate that sortSql returned a valid SQL expression
-              if (!resolvedExpression) {
-                throw new QueryError(
-                  `sortSql returned null or undefined for computed field: ${sort.columnId}`,
-                  { columnId: sort.columnId, field: computedField.field }
-                );
-              }
-
-              computedFieldsForSorting[sort.columnId] = {
-                ...computedField,
-                __resolvedSortSql: resolvedExpression,
-              };
-            } catch (error) {
-              // Re-throw QueryError as-is (already has proper context)
-              if (error instanceof QueryError) {
-                throw error;
-              }
-              // Wrap other errors with context
+        for (const fieldName of fieldsNeedingSelect) {
+          const computedField = tableComputedFields.find((cf) => cf.field === fieldName);
+          if (!computedField?.sortSql) continue;
+          try {
+            const sqlExpression = computedField.sortSql(context);
+            const resolvedExpression =
+              sqlExpression instanceof Promise ? await sqlExpression : sqlExpression;
+            if (!resolvedExpression) {
               throw new QueryError(
-                `Failed to resolve sortSql for computed field: ${sort.columnId}`,
-                {
-                  columnId: sort.columnId,
-                  field: computedField.field,
-                  originalError: error instanceof Error ? error.message : String(error),
-                }
+                `sortSql returned null or undefined for computed field: ${fieldName}`,
+                { columnId: fieldName, field: computedField.field }
               );
             }
+            computedFieldsForSorting[fieldName] = {
+              ...computedField,
+              __resolvedSortSql: resolvedExpression,
+            };
+          } catch (error) {
+            if (error instanceof QueryError) {
+              throw error;
+            }
+            throw new QueryError(`Failed to resolve sortSql for computed field: ${fieldName}`, {
+              columnId: fieldName,
+              field: computedField.field,
+              originalError: error instanceof Error ? error.message : String(error),
+            });
           }
         }
       }
@@ -795,6 +828,9 @@ export class DrizzleAdapter<TSchema extends Record<string, unknown>, TDriver ext
 
       return result;
     } catch (error) {
+      if (error instanceof SchemaError || error instanceof QueryError) {
+        throw error;
+      }
       throw new QueryError(
         `Failed to fetch data: ${error instanceof Error ? error.message : 'Unknown error'}`,
         { params, error }
@@ -1447,29 +1483,45 @@ export class DrizzleAdapter<TSchema extends Record<string, unknown>, TDriver ext
    */
 
   /**
-   * Computed-field filter substitution (plan 017) only runs on flat
-   * `FilterState[]` inputs. Filter trees must fail loudly until the
-   * computed-fields owner extends substitution to walk `FilterGroupNode`
-   * trees (plan 051 — documented, not implemented here).
+   * Compile a FilterGroupNode to SQL, substituting filterSql-backed computed
+   * leaves in place so AND/OR structure is preserved (plan 060). Legacy
+   * callback-`filter` computed fields still reject trees.
    */
-  private rejectComputedFieldFiltersInTree(
-    node: FilterGroupNode,
-    tableComputedFields: ComputedFieldConfig[]
-  ): void {
-    for (const child of node.children) {
-      if (isFilterGroupNode(child)) {
-        this.rejectComputedFieldFiltersInTree(child, tableComputedFields);
-        continue;
-      }
-
-      const computedField = tableComputedFields.find((cf) => cf.field === child.columnId);
-      if (computedField?.filter || computedField?.filterSql) {
-        throw new QueryError(
-          `Computed-field filters inside a FilterGroupNode are not supported yet (columnId: "${child.columnId}"). Use a flat FilterState[] (implicit AND) for computed-field filters, or flatten the tree at the call site.`,
-          { columnId: child.columnId, field: computedField.field }
+  private async compileTreeFiltersWithComputed(
+    node: FilterNode,
+    tableComputedFields: ComputedFieldConfig[],
+    context: ComputedFieldContext<TSchema, TDriver>,
+    primaryTable: string
+  ): Promise<SQL | SQLWrapper | undefined> {
+    if (isFilterGroupNode(node)) {
+      const parts: (SQL | SQLWrapper)[] = [];
+      for (const child of node.children) {
+        const part = await this.compileTreeFiltersWithComputed(
+          child,
+          tableComputedFields,
+          context,
+          primaryTable
         );
+        if (part !== undefined) parts.push(part);
       }
+      if (parts.length === 0) return undefined;
+      if (parts.length === 1) return parts[0];
+      const combined = node.logic === 'or' ? or(...parts) : and(...parts);
+      return combined ?? undefined;
     }
+
+    const computedField = tableComputedFields.find((cf) => cf.field === node.columnId);
+    if (computedField?.filterSql) {
+      return Promise.resolve(computedField.filterSql(node, context));
+    }
+    if (computedField?.filter) {
+      throw new QueryError(
+        `Computed-field filters that use the callback \`filter\` form are not supported inside a FilterGroupNode (columnId: "${node.columnId}"). Restructure so those filters are top-level AND'd, or provide filterSql on the computed field.`,
+        { columnId: node.columnId, field: computedField.field }
+      );
+    }
+
+    return this.queryBuilder.buildLeafFilterCondition(node, primaryTable);
   }
 
   /**

--- a/packages/adapters/drizzle/src/drizzle-adapter.ts
+++ b/packages/adapters/drizzle/src/drizzle-adapter.ts
@@ -533,6 +533,8 @@ export class DrizzleAdapter<TSchema extends Record<string, unknown>, TDriver ext
         this.normalizeIncomingFilters(params.filters) ?? [];
       const computedFieldFilters: Array<{ filter: FilterState; config: ComputedFieldConfig }> = [];
       const additionalSqlConditions: (SQL | SQLWrapper)[] = [];
+      /** Join-planning leaves preserved when a tree is compiled to filterSql SQL. */
+      let filterJoinLeaves: FilterState[] | undefined;
 
       if (Array.isArray(processedFilters)) {
         for (const filter of processedFilters) {
@@ -541,10 +543,17 @@ export class DrizzleAdapter<TSchema extends Record<string, unknown>, TDriver ext
             computedFieldFilters.push({ filter, config: computedField });
           }
         }
-      } else {
+      } else if (this.treeContainsFilterSqlLeaves(processedFilters, tableComputedFields)) {
         // Compile the whole tree so filterSql leaves keep AND/OR position
         // (extracting them to top-level additionalConditions would AND them
-        // and break OR groups).
+        // and break OR groups). Plain-column leaves still need multi-hop JOINs
+        // via filterJoinLeaves once processedFilters is blanked. Exclude
+        // filterSql-backed computed leaves — they are in additionalConditions
+        // and are not real column paths for join planning.
+        filterJoinLeaves = collectFilterLeaves(processedFilters).filter((leaf) => {
+          const computedField = tableComputedFields.find((cf) => cf.field === leaf.columnId);
+          return !computedField?.filterSql;
+        });
         const treeSql = await this.compileTreeFiltersWithComputed(
           processedFilters,
           tableComputedFields,
@@ -560,6 +569,18 @@ export class DrizzleAdapter<TSchema extends Record<string, unknown>, TDriver ext
           additionalSqlConditions.push(treeSql);
         }
         processedFilters = [];
+      } else {
+        // Pre-060 path: reject callback-filter computed leaves, keep the tree
+        // for collectFilterLeaves + buildTreeCondition join/WHERE planning.
+        for (const leaf of collectFilterLeaves(processedFilters)) {
+          const computedField = tableComputedFields.find((cf) => cf.field === leaf.columnId);
+          if (computedField?.filter) {
+            throw new QueryError(
+              `Computed-field filters that use the callback \`filter\` form are not supported inside a FilterGroupNode (columnId: "${leaf.columnId}"). Restructure so those filters are top-level AND'd, or provide filterSql on the computed field.`,
+              { columnId: leaf.columnId, field: computedField.field }
+            );
+          }
+        }
       }
 
       // Build cache params early (needed for error handling)
@@ -571,6 +592,7 @@ export class DrizzleAdapter<TSchema extends Record<string, unknown>, TDriver ext
         computedFields?: string[];
         computedFieldsRequiringColumns?: string[];
         computedFieldFilters?: FilterState[]; // Include original filters for cache key
+        filterJoinLeaves?: FilterState[];
       } = {
         ...params,
         columns: columnsWithoutComputed,
@@ -580,6 +602,7 @@ export class DrizzleAdapter<TSchema extends Record<string, unknown>, TDriver ext
           .filter((cf) => cf.requiresColumn)
           .map((cf) => cf.field),
         computedFieldFilters: originalComputedFieldFilters, // Include for cache key
+        ...(filterJoinLeaves !== undefined && { filterJoinLeaves }),
       };
 
       // Process computed field filters
@@ -746,6 +769,9 @@ export class DrizzleAdapter<TSchema extends Record<string, unknown>, TDriver ext
       }
       if (Object.keys(computedFieldsForSorting).length > 0) {
         queryParams.computedFields = computedFieldsForSorting;
+      }
+      if (filterJoinLeaves !== undefined && filterJoinLeaves.length > 0) {
+        queryParams.filterJoinLeaves = filterJoinLeaves;
       }
       const { dataQuery, countQuery, columnMetadata, isNested, autoEmbedColumns } =
         this.queryBuilder.buildCompleteQuery(queryParams);
@@ -1483,6 +1509,23 @@ export class DrizzleAdapter<TSchema extends Record<string, unknown>, TDriver ext
    */
 
   /**
+   * True when any leaf in the tree targets a computed field with `filterSql`
+   * (incl. plan-060 derived aggregates). Only those trees need compile-and-blank.
+   */
+  private treeContainsFilterSqlLeaves(
+    node: FilterNode,
+    tableComputedFields: ComputedFieldConfig[]
+  ): boolean {
+    if (isFilterGroupNode(node)) {
+      return node.children.some((child) =>
+        this.treeContainsFilterSqlLeaves(child, tableComputedFields)
+      );
+    }
+    const computedField = tableComputedFields.find((cf) => cf.field === node.columnId);
+    return computedField?.filterSql !== undefined;
+  }
+
+  /**
    * Compile a FilterGroupNode to SQL, substituting filterSql-backed computed
    * leaves in place so AND/OR structure is preserved (plan 060). Legacy
    * callback-`filter` computed fields still reject trees.
@@ -1609,6 +1652,7 @@ export class DrizzleAdapter<TSchema extends Record<string, unknown>, TDriver ext
       computedFields?: string[];
       computedFieldsRequiringColumns?: string[];
       computedFieldFilters?: FilterState[];
+      filterJoinLeaves?: FilterState[];
     }
   ): number {
     // Determine primary table from params - use explicit if provided.
@@ -1638,10 +1682,14 @@ export class DrizzleAdapter<TSchema extends Record<string, unknown>, TDriver ext
     // contributes its JOIN to the count -- must agree with buildCompleteQuery's
     // own context (base-query-builder.ts), or `total` and page contents would
     // diverge under OR queries (plan 017 emphasis: count/data agreement).
+    const joinPlanningLeaves =
+      collectFilterLeaves(params.filters).length > 0
+        ? collectFilterLeaves(params.filters)
+        : (params.filterJoinLeaves ?? []);
     const context = this.relationshipManager.buildQueryContext(
       {
         columns: columnsForContext,
-        filters: collectFilterLeaves(params.filters).map((filter) => ({
+        filters: joinPlanningLeaves.map((filter) => ({
           columnId: filter.columnId,
         })),
         sorts: sortsForContext,

--- a/packages/adapters/drizzle/src/filter-handler.ts
+++ b/packages/adapters/drizzle/src/filter-handler.ts
@@ -88,6 +88,21 @@ export function collectFilterLeaves(
 }
 
 /**
+ * Leaves used for JOIN planning when filters may have been compiled away to
+ * opaque SQL (plan 060). Prefer real filter leaves; fall back to
+ * `filterJoinLeaves` preserved by the adapter. Shared by
+ * `buildCompleteQuery` and `getJoinCount` so count/data join sets stay aligned.
+ */
+export function resolveJoinPlanningLeaves(params: {
+  filters?: FilterState[] | FilterGroupNode | undefined;
+  filterJoinLeaves?: FilterState[] | undefined;
+}): FilterState[] {
+  const fromFilters = collectFilterLeaves(params.filters);
+  if (fromFilters.length > 0) return fromFilters;
+  return params.filterJoinLeaves ?? [];
+}
+
+/**
  * Recursively drop every leaf targeting `excludeColumnId` from a
  * {@link FilterNode}, per plan 021's self-exclusion faceting convention (see
  * `FacetQueryParams` in `@better-tables/core`): a group that becomes empty

--- a/packages/adapters/drizzle/src/filter-handler.ts
+++ b/packages/adapters/drizzle/src/filter-handler.ts
@@ -211,6 +211,17 @@ export class FilterHandler {
   }
 
   /**
+   * Validate + build a leaf (shared by flat filters and tree compilation).
+   * Honors `onInvalidFilter` the same way as {@link buildTreeCondition}.
+   */
+  buildValidatedLeafCondition(
+    filter: FilterState,
+    primaryTable: string
+  ): SQL | SQLWrapper | undefined {
+    return this.buildLeafCondition(filter, primaryTable);
+  }
+
+  /**
    * Build filter condition from filter state.
    *
    * @description
@@ -233,18 +244,6 @@ export class FilterHandler {
    * );
    * ```
    */
-  /**
-   * Validate + build a leaf (shared by flat filters and plan-060 tree
-   * compilation). Honors `onInvalidFilter` the same way as
-   * {@link buildTreeCondition}.
-   */
-  buildValidatedLeafCondition(
-    filter: FilterState,
-    primaryTable: string
-  ): SQL | SQLWrapper | undefined {
-    return this.buildLeafCondition(filter, primaryTable);
-  }
-
   buildFilterCondition(filter: FilterState, primaryTable: string): SQL | SQLWrapper | undefined {
     // Apply beforeBuildFilterCondition hook if provided
     let processedFilter = filter;

--- a/packages/adapters/drizzle/src/filter-handler.ts
+++ b/packages/adapters/drizzle/src/filter-handler.ts
@@ -233,6 +233,18 @@ export class FilterHandler {
    * );
    * ```
    */
+  /**
+   * Validate + build a leaf (shared by flat filters and plan-060 tree
+   * compilation). Honors `onInvalidFilter` the same way as
+   * {@link buildTreeCondition}.
+   */
+  buildValidatedLeafCondition(
+    filter: FilterState,
+    primaryTable: string
+  ): SQL | SQLWrapper | undefined {
+    return this.buildLeafCondition(filter, primaryTable);
+  }
+
   buildFilterCondition(filter: FilterState, primaryTable: string): SQL | SQLWrapper | undefined {
     // Apply beforeBuildFilterCondition hook if provided
     let processedFilter = filter;

--- a/packages/adapters/drizzle/src/query-builders/base-query-builder.ts
+++ b/packages/adapters/drizzle/src/query-builders/base-query-builder.ts
@@ -1368,6 +1368,8 @@ export abstract class BaseQueryBuilder {
   buildCompleteQuery(params: {
     columns?: string[];
     filters?: FilterState[] | FilterGroupNode;
+    /** Plain-column leaves from a compiled filter tree (join planning only). */
+    filterJoinLeaves?: FilterState[];
     sorting?: SortingParams[];
     pagination?: PaginationParams;
     primaryTable: string;
@@ -1402,10 +1404,16 @@ export abstract class BaseQueryBuilder {
     // Join planning must see every leaf's columnId, including ones nested
     // inside a FilterGroupNode tree (plan 017) — collectFilterLeaves flattens
     // either shape so a leaf buried in a group still contributes its JOIN.
+    // When filters were compiled to filterSql (plan 060), filterJoinLeaves
+    // carries the plain-column paths that additionalConditions no longer expose.
+    const joinPlanningLeaves =
+      collectFilterLeaves(params.filters).length > 0
+        ? collectFilterLeaves(params.filters)
+        : (params.filterJoinLeaves ?? []);
     const context = this.relationshipManager.buildQueryContext(
       {
         columns: params.columns || [],
-        filters: collectFilterLeaves(params.filters).map((filter) => ({
+        filters: joinPlanningLeaves.map((filter) => ({
           columnId: filter.columnId,
         })),
         sorts: sortsForContext,

--- a/packages/adapters/drizzle/src/query-builders/base-query-builder.ts
+++ b/packages/adapters/drizzle/src/query-builders/base-query-builder.ts
@@ -703,6 +703,20 @@ export abstract class BaseQueryBuilder {
    * this layer either way, with leaf predicate construction behind the
    * `PredicateEmitter` interface.
    */
+  /**
+   * Public leaf filter builder for plan-060 tree compilation (filterSql
+   * leaves must compose inside AND/OR groups, not only as top-level ANDs).
+   */
+  buildLeafFilterCondition(
+    filter: FilterState,
+    primaryTable: string
+  ): SQL | SQLWrapper | undefined {
+    // Must use the validated leaf path so `onInvalidFilter: 'throw'` still
+    // rejects malformed operators inside trees compiled by the adapter
+    // (plan 060 tree walk); raw `buildFilterCondition` skips that gate.
+    return this.filterHandler.buildValidatedLeafCondition(filter, primaryTable);
+  }
+
   applyFilters(
     query: QueryBuilderWithJoins,
     filters: FilterState[] | FilterGroupNode,

--- a/packages/adapters/drizzle/src/query-builders/base-query-builder.ts
+++ b/packages/adapters/drizzle/src/query-builders/base-query-builder.ts
@@ -39,7 +39,7 @@ import {
   sql,
   sum,
 } from 'drizzle-orm';
-import { collectFilterLeaves, FilterHandler } from '../filter-handler';
+import { collectFilterLeaves, FilterHandler, resolveJoinPlanningLeaves } from '../filter-handler';
 import type { RelationshipManager } from '../relationship-manager';
 import type {
   AggregateFunction,
@@ -1402,14 +1402,13 @@ export abstract class BaseQueryBuilder {
         .map((sort) => ({ columnId: sort.columnId })) || [];
 
     // Join planning must see every leaf's columnId, including ones nested
-    // inside a FilterGroupNode tree (plan 017) — collectFilterLeaves flattens
-    // either shape so a leaf buried in a group still contributes its JOIN.
-    // When filters were compiled to filterSql (plan 060), filterJoinLeaves
-    // carries the plain-column paths that additionalConditions no longer expose.
-    const joinPlanningLeaves =
-      collectFilterLeaves(params.filters).length > 0
-        ? collectFilterLeaves(params.filters)
-        : (params.filterJoinLeaves ?? []);
+    // inside a FilterGroupNode tree (plan 017). When filters were compiled to
+    // filterSql (plan 060), filterJoinLeaves carries the plain-column paths
+    // that additionalConditions no longer expose — must match getJoinCount.
+    const joinPlanningLeaves = resolveJoinPlanningLeaves({
+      filters: params.filters,
+      filterJoinLeaves: params.filterJoinLeaves,
+    });
     const context = this.relationshipManager.buildQueryContext(
       {
         columns: params.columns || [],

--- a/packages/adapters/drizzle/tests/base-query-builder.test.ts
+++ b/packages/adapters/drizzle/tests/base-query-builder.test.ts
@@ -578,6 +578,24 @@ describe('BaseQueryBuilder', () => {
       expect(queryBuilder.validateQuery(countQuery)).toBe(true);
     });
 
+    it('uses filterJoinLeaves for join planning when filters=[]', () => {
+      const { autoEmbedColumns } = queryBuilder.buildCompleteQuery({
+        columns: ['name'],
+        filters: [],
+        filterJoinLeaves: [
+          {
+            columnId: 'profile.bio',
+            type: 'text',
+            operator: 'equals',
+            values: ['Designer'],
+          },
+        ],
+        primaryTable: 'users',
+      });
+
+      expect(autoEmbedColumns.some((col) => col.startsWith('profile.'))).toBe(true);
+    });
+
     it('should build query with only sorting', () => {
       const { dataQuery, countQuery } = queryBuilder.buildCompleteQuery({
         sorting: [{ columnId: 'name', direction: 'asc' }],

--- a/packages/adapters/drizzle/tests/computed-field-tree-gap.test.ts
+++ b/packages/adapters/drizzle/tests/computed-field-tree-gap.test.ts
@@ -1,7 +1,6 @@
 /**
- * Plan 051: computed-field filter substitution is intentionally limited to
- * flat FilterState[] inputs. Trees must fail loudly (documented in
- * the changeset's known-gaps note).
+ * Plan 051/060: callback-`filter` computed fields still reject FilterGroupNode
+ * trees. filterSql-backed fields (incl. derived aggregates) substitute in place.
  */
 import { describe, expect, it } from 'bun:test';
 import type { FilterGroupNode } from '@better-tables/core';
@@ -32,8 +31,56 @@ const mockDb = {
   },
 } as unknown as PostgresDatabaseType;
 
-describe('Computed-field filters inside FilterGroupNode (plan 051)', () => {
-  it('throws QueryError instead of treating the computed field as a real column', async () => {
+describe('Computed-field filters inside FilterGroupNode', () => {
+  it('throws QueryError for legacy callback-filter computed fields in a tree', async () => {
+    const config: DrizzleAdapterConfig<typeof schema, 'postgres'> = {
+      db: mockDb,
+      schema,
+      driver: 'postgres',
+      computedFields: {
+        users: [
+          {
+            field: 'fullName',
+            type: 'text',
+            compute: async (row) => row.email,
+            filter: async () => [],
+          },
+        ],
+      },
+    };
+
+    const adapter = new DrizzleAdapter(config);
+    const filters: FilterGroupNode = {
+      kind: 'group',
+      logic: 'and',
+      children: [
+        {
+          columnId: 'email',
+          type: 'text',
+          operator: 'contains',
+          values: ['a'],
+        },
+        {
+          columnId: 'fullName',
+          type: 'text',
+          operator: 'contains',
+          values: ['alice'],
+        },
+      ],
+    };
+
+    await expect(
+      adapter.fetchData({
+        columns: ['email'],
+        filters,
+        primaryTable: 'users',
+      })
+    ).rejects.toMatchObject({
+      message: expect.stringContaining('callback `filter`'),
+    });
+  });
+
+  it('does not reject filterSql-backed computed fields in a tree (extracts SQL)', async () => {
     const config: DrizzleAdapterConfig<typeof schema, 'postgres'> = {
       db: mockDb,
       schema,
@@ -70,14 +117,19 @@ describe('Computed-field filters inside FilterGroupNode (plan 051)', () => {
       ],
     };
 
-    await expect(
-      adapter.fetchData({
+    // Mock DB will fail later in query building/execution — the important
+    // assertion is that we no longer throw the tree-gap QueryError up front.
+    try {
+      await adapter.fetchData({
         columns: ['email'],
         filters,
         primaryTable: 'users',
-      })
-    ).rejects.toMatchObject({
-      message: expect.stringContaining('FilterGroupNode'),
-    });
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      expect(message).not.toContain('callback `filter`');
+      expect(message).not.toContain('flatten the tree');
+      expect(message).not.toContain('not supported yet');
+    }
   });
 });

--- a/packages/adapters/drizzle/tests/computed-field-tree-gap.test.ts
+++ b/packages/adapters/drizzle/tests/computed-field-tree-gap.test.ts
@@ -117,19 +117,18 @@ describe('Computed-field filters inside FilterGroupNode', () => {
       ],
     };
 
-    // Mock DB will fail later in query building/execution — the important
-    // assertion is that we no longer throw the tree-gap QueryError up front.
-    try {
-      await adapter.fetchData({
+    // Mock DB returns empty rows — the important assertion is that filterSql
+    // trees compile without the legacy tree-gap QueryError.
+    // Mock DB lacks limit/offset — assert compile succeeds past the tree-gap
+    // guard (rejects with a downstream QueryError, not callback-filter text).
+    await expect(
+      adapter.fetchData({
         columns: ['email'],
         filters,
         primaryTable: 'users',
-      });
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      expect(message).not.toContain('callback `filter`');
-      expect(message).not.toContain('flatten the tree');
-      expect(message).not.toContain('not supported yet');
-    }
+      })
+    ).rejects.toMatchObject({
+      message: expect.not.stringContaining('callback `filter`'),
+    });
   });
 });

--- a/packages/adapters/drizzle/tests/derived-aggregates-dialects.test.ts
+++ b/packages/adapters/drizzle/tests/derived-aggregates-dialects.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Plan 060: derived-aggregate matrix mirrored on Postgres/MySQL when env URLs
+ * are set (skipped otherwise — same guard pattern as adapter-postgres/mysql).
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import type { FilterGroupNode } from '@better-tables/core';
+import { DrizzleAdapter } from '../src/drizzle-adapter';
+import type { DrizzleDatabase } from '../src/types';
+import {
+  closeMySQLDatabase,
+  closePostgresDatabase,
+  createMySQLDatabase,
+  createPostgresDatabase,
+  ensureMySQLDatabase,
+  ensurePostgresDatabase,
+  setupMySQLDatabase,
+  setupPostgresDatabase,
+} from './helpers/test-fixtures';
+import { relationsSchema as testRelations, schema as testSchema } from './helpers/test-schema';
+
+function derivedMatrix(
+  label: string,
+  driver: 'postgres' | 'mysql',
+  createAdapter: () => Promise<{
+    adapter: DrizzleAdapter<typeof testSchema, 'postgres' | 'mysql'>;
+    cleanup: () => Promise<void>;
+  }>
+) {
+  describe.skipIf(
+    driver === 'postgres' ? !process.env.POSTGRES_TEST_URL : !process.env.MYSQL_TEST_URL
+  )(`Derived aggregates (plan 060) — ${label}`, () => {
+    let adapter: DrizzleAdapter<typeof testSchema, 'postgres' | 'mysql'>;
+    let cleanup: () => Promise<void>;
+
+    beforeAll(async () => {
+      const created = await createAdapter();
+      adapter = created.adapter;
+      cleanup = created.cleanup;
+    });
+
+    afterAll(async () => {
+      await cleanup();
+    });
+
+    it('renders counts, filters (flat + OR tree), and sorts', async () => {
+      const rendered = await adapter.fetchData({
+        primaryTable: 'users',
+        columns: ['id', 'name', 'postsCount'],
+        derived: [{ columnId: 'postsCount', kind: 'aggregate', relation: 'posts', fn: 'count' }],
+        sorting: [{ columnId: 'id', direction: 'asc' }],
+      });
+      const byName = Object.fromEntries(
+        rendered.data.map((row) => {
+          const r = row as { name: string; postsCount?: number };
+          return [r.name, Number(r.postsCount)];
+        })
+      );
+      expect(byName['John Doe']).toBe(2);
+      expect(byName['Jane Smith']).toBe(1);
+      expect(byName['Bob Johnson']).toBe(0);
+
+      const filtered = await adapter.fetchData({
+        primaryTable: 'users',
+        columns: ['name', 'postsCount'],
+        derived: [{ columnId: 'postsCount', kind: 'aggregate', relation: 'posts', fn: 'count' }],
+        filters: [
+          { columnId: 'postsCount', type: 'number', operator: 'greaterThan', values: [1] },
+        ],
+      });
+      expect(filtered.total).toBe(1);
+
+      const orTree: FilterGroupNode = {
+        kind: 'group',
+        logic: 'or',
+        children: [
+          { columnId: 'postsCount', type: 'number', operator: 'greaterThan', values: [1] },
+          { columnId: 'name', type: 'text', operator: 'equals', values: ['Bob Johnson'] },
+        ],
+      };
+      const orResult = await adapter.fetchData({
+        primaryTable: 'users',
+        columns: ['name', 'postsCount'],
+        derived: [{ columnId: 'postsCount', kind: 'aggregate', relation: 'posts', fn: 'count' }],
+        filters: orTree,
+      });
+      expect(orResult.data.map((r) => (r as { name: string }).name).sort()).toEqual([
+        'Bob Johnson',
+        'John Doe',
+      ]);
+
+      const sorted = await adapter.fetchData({
+        primaryTable: 'users',
+        columns: ['name', 'postsCount'],
+        derived: [{ columnId: 'postsCount', kind: 'aggregate', relation: 'posts', fn: 'count' }],
+        sorting: [{ columnId: 'postsCount', direction: 'desc' }],
+      });
+      expect(sorted.data.map((r) => (r as { name: string }).name)).toEqual([
+        'John Doe',
+        'Jane Smith',
+        'Bob Johnson',
+      ]);
+    });
+  });
+}
+
+derivedMatrix('PostgreSQL', 'postgres', async () => {
+  const connectionString = process.env.POSTGRES_TEST_URL as string;
+  await ensurePostgresDatabase(connectionString);
+  const { db, client } = createPostgresDatabase(connectionString);
+  await setupPostgresDatabase(db);
+  const adapter = new DrizzleAdapter({
+    db: db as unknown as DrizzleDatabase<'postgres'>,
+    schema: testSchema,
+    driver: 'postgres',
+    relations: testRelations,
+  });
+  return {
+    adapter,
+    cleanup: async () => {
+      await closePostgresDatabase(client);
+    },
+  };
+});
+
+derivedMatrix('MySQL', 'mysql', async () => {
+  const connectionString = process.env.MYSQL_TEST_URL as string;
+  await ensureMySQLDatabase(connectionString);
+  const { db, connection } = await createMySQLDatabase(connectionString);
+  await setupMySQLDatabase(connection);
+  const adapter = new DrizzleAdapter({
+    db: db as unknown as DrizzleDatabase<'mysql'>,
+    schema: testSchema,
+    driver: 'mysql',
+    relations: testRelations,
+  });
+  return {
+    adapter,
+    cleanup: async () => {
+      await closeMySQLDatabase(connection);
+    },
+  };
+});

--- a/packages/adapters/drizzle/tests/derived-aggregates-dialects.test.ts
+++ b/packages/adapters/drizzle/tests/derived-aggregates-dialects.test.ts
@@ -64,9 +64,7 @@ function derivedMatrix(
         primaryTable: 'users',
         columns: ['name', 'postsCount'],
         derived: [{ columnId: 'postsCount', kind: 'aggregate', relation: 'posts', fn: 'count' }],
-        filters: [
-          { columnId: 'postsCount', type: 'number', operator: 'greaterThan', values: [1] },
-        ],
+        filters: [{ columnId: 'postsCount', type: 'number', operator: 'greaterThan', values: [1] }],
       });
       expect(filtered.total).toBe(1);
 

--- a/packages/adapters/drizzle/tests/derived-aggregates-dialects.test.ts
+++ b/packages/adapters/drizzle/tests/derived-aggregates-dialects.test.ts
@@ -31,7 +31,7 @@ function derivedMatrix(
     driver === 'postgres' ? !process.env.POSTGRES_TEST_URL : !process.env.MYSQL_TEST_URL
   )(`Derived aggregates (plan 060) — ${label}`, () => {
     let adapter: DrizzleAdapter<typeof testSchema, 'postgres' | 'mysql'>;
-    let cleanup: () => Promise<void>;
+    let cleanup: () => Promise<void> = async () => {};
 
     beforeAll(async () => {
       const created = await createAdapter();

--- a/packages/adapters/drizzle/tests/derived-aggregates-guards.test.ts
+++ b/packages/adapters/drizzle/tests/derived-aggregates-guards.test.ts
@@ -73,12 +73,10 @@ describe('lowerDerivedAggregateSpec guards', () => {
       values: ['1', 'NaN'],
     } as unknown as FilterState;
 
-    expect(() =>
-      config.filterSql?.(badGt, { primaryTable: 'users' } as never)
-    ).toThrow(QueryError);
+    expect(() => config.filterSql?.(badGt, { primaryTable: 'users' } as never)).toThrow(QueryError);
 
-    expect(() =>
-      config.filterSql?.(badBetween, { primaryTable: 'users' } as never)
-    ).toThrow(QueryError);
+    expect(() => config.filterSql?.(badBetween, { primaryTable: 'users' } as never)).toThrow(
+      QueryError
+    );
   });
 });

--- a/packages/adapters/drizzle/tests/derived-aggregates-guards.test.ts
+++ b/packages/adapters/drizzle/tests/derived-aggregates-guards.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Regression guards for plan-060 derived aggregate lowering
+ * (non-numeric filter values, array-FK relations).
+ */
+
+import { describe, expect, it } from 'bun:test';
+import type { FilterState } from '@better-tables/core';
+import { lowerDerivedAggregateSpec } from '../src/derived-aggregates';
+import { RelationshipDetector } from '../src/relationship-detector';
+import { RelationshipManager } from '../src/relationship-manager';
+import type { RelationshipMap } from '../src/types';
+import { QueryError, SchemaError } from '../src/types';
+import { relationsSchema, schema } from './helpers/test-schema';
+
+describe('lowerDerivedAggregateSpec guards', () => {
+  it('throws SchemaError for array-FK relations', () => {
+    const relationships: RelationshipMap = {
+      'users.arrayPosts': {
+        from: 'users',
+        to: 'posts',
+        foreignKey: 'userId',
+        localKey: 'id',
+        cardinality: 'many',
+        joinType: 'left',
+        isArray: true,
+      },
+    };
+    const manager = new RelationshipManager(schema, relationships);
+
+    expect(() =>
+      lowerDerivedAggregateSpec(
+        {
+          columnId: 'arrayPostsCount',
+          kind: 'aggregate',
+          relation: 'arrayPosts',
+          fn: 'count',
+        },
+        'users',
+        schema,
+        manager
+      )
+    ).toThrow(SchemaError);
+  });
+
+  it('throws QueryError when a filter value is non-numeric', () => {
+    const detector = new RelationshipDetector();
+    const relationships = detector.detectFromSchema(relationsSchema, schema);
+    const manager = new RelationshipManager(schema, relationships);
+    const config = lowerDerivedAggregateSpec(
+      {
+        columnId: 'postsCount',
+        kind: 'aggregate',
+        relation: 'posts',
+        fn: 'count',
+      },
+      'users',
+      schema,
+      manager
+    );
+
+    expect(config.filterSql).toBeDefined();
+    // Runtime may still pass non-numeric strings; the guard must reject them.
+    const badGt = {
+      columnId: 'postsCount',
+      type: 'number',
+      operator: 'greaterThan',
+      values: ['not-a-number'],
+    } as unknown as FilterState;
+    const badBetween = {
+      columnId: 'postsCount',
+      type: 'number',
+      operator: 'between',
+      values: ['1', 'NaN'],
+    } as unknown as FilterState;
+
+    expect(() =>
+      config.filterSql?.(badGt, { primaryTable: 'users' } as never)
+    ).toThrow(QueryError);
+
+    expect(() =>
+      config.filterSql?.(badBetween, { primaryTable: 'users' } as never)
+    ).toThrow(QueryError);
+  });
+});

--- a/packages/adapters/drizzle/tests/derived-aggregates-sqlite.test.ts
+++ b/packages/adapters/drizzle/tests/derived-aggregates-sqlite.test.ts
@@ -113,6 +113,39 @@ describe('Derived aggregates (plan 060) — SQLite', () => {
     expect(names).toEqual(['Bob Johnson', 'John Doe']);
   });
 
+  it('OR tree with filterSql aggregate + cross-table plain leaf still plans profile join', async () => {
+    // When the tree is compiled to filterSql SQL, plain-column leaves must
+    // still drive join planning via filterJoinLeaves (not only opaque SQL).
+    const filters: FilterGroupNode = {
+      kind: 'group',
+      logic: 'or',
+      children: [
+        {
+          columnId: 'postsCount',
+          type: 'number',
+          operator: 'greaterThan',
+          values: [1],
+        },
+        {
+          columnId: 'profile.bio',
+          type: 'text',
+          operator: 'equals',
+          values: ['Designer'],
+        },
+      ],
+    };
+
+    const result = await adapter.fetchData({
+      primaryTable: 'users',
+      columns: ['id', 'name', 'postsCount'],
+      derived: [{ columnId: 'postsCount', kind: 'aggregate', relation: 'posts', fn: 'count' }],
+      filters,
+    });
+
+    const names = result.data.map((row) => (row as { name: string }).name).sort();
+    expect(names).toEqual(['Jane Smith', 'John Doe']);
+  });
+
   it('sorts by derived count', async () => {
     const result = await adapter.fetchData({
       primaryTable: 'users',

--- a/packages/adapters/drizzle/tests/derived-aggregates-sqlite.test.ts
+++ b/packages/adapters/drizzle/tests/derived-aggregates-sqlite.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Plan 060: derived aggregate columns via FetchDataParams.derived
+ * (correlated subqueries on sqlite).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import type { FilterGroupNode } from '@better-tables/core';
+import { DrizzleAdapter } from '../src/drizzle-adapter';
+import type { DrizzleDatabase } from '../src/types';
+import { SchemaError } from '../src/types';
+import {
+  closeDatabase,
+  createTestDatabase,
+  setupTestDatabase,
+} from './helpers/test-fixtures';
+import { relationsSchema as testRelations, schema as testSchema } from './helpers/test-schema';
+
+describe('Derived aggregates (plan 060) — SQLite', () => {
+  let adapter: DrizzleAdapter<typeof testSchema, 'sqlite'>;
+  let testDb: ReturnType<typeof createTestDatabase>['db'];
+  let sqlite: ReturnType<typeof createTestDatabase>['sqlite'];
+
+  beforeEach(async () => {
+    const created = createTestDatabase();
+    testDb = created.db;
+    sqlite = created.sqlite;
+    await setupTestDatabase(testDb);
+    adapter = new DrizzleAdapter({
+      db: testDb as unknown as DrizzleDatabase<'sqlite'>,
+      schema: testSchema,
+      driver: 'sqlite',
+      relations: testRelations,
+    });
+  });
+
+  afterEach(() => {
+    closeDatabase(sqlite);
+  });
+
+  it('declares aggregates capabilities', () => {
+    expect(adapter.meta.capabilities?.aggregates).toMatchObject({
+      render: true,
+      filter: true,
+      sort: true,
+      fns: expect.arrayContaining(['count', 'sum']),
+    });
+  });
+
+  it('renders per-row relation counts', async () => {
+    const result = await adapter.fetchData({
+      primaryTable: 'users',
+      columns: ['id', 'name', 'postsCount'],
+      derived: [{ columnId: 'postsCount', kind: 'aggregate', relation: 'posts', fn: 'count' }],
+      sorting: [{ columnId: 'id', direction: 'asc' }],
+    });
+
+    expect(result.data.length).toBe(3);
+    const byName = Object.fromEntries(
+      result.data.map((row) => {
+        const r = row as { name: string; postsCount?: number };
+        return [r.name, Number(r.postsCount)];
+      })
+    );
+    // Seed: John 2 posts, Jane 1, Bob 0
+    expect(byName['John Doe']).toBe(2);
+    expect(byName['Jane Smith']).toBe(1);
+    expect(byName['Bob Johnson']).toBe(0);
+  });
+
+  it('filters with greaterThan on count (flat AND)', async () => {
+    const result = await adapter.fetchData({
+      primaryTable: 'users',
+      columns: ['id', 'name', 'postsCount'],
+      derived: [{ columnId: 'postsCount', kind: 'aggregate', relation: 'posts', fn: 'count' }],
+      filters: [
+        {
+          columnId: 'postsCount',
+          type: 'number',
+          operator: 'greaterThan',
+          values: [1],
+        },
+      ],
+    });
+
+    expect(result.total).toBe(1);
+    expect((result.data[0] as { name: string }).name).toBe('John Doe');
+  });
+
+  it('filters with count inside an OR FilterGroupNode (tree walk)', async () => {
+    const filters: FilterGroupNode = {
+      kind: 'group',
+      logic: 'or',
+      children: [
+        {
+          columnId: 'postsCount',
+          type: 'number',
+          operator: 'greaterThan',
+          values: [1],
+        },
+        {
+          columnId: 'name',
+          type: 'text',
+          operator: 'equals',
+          values: ['Bob Johnson'],
+        },
+      ],
+    };
+
+    const result = await adapter.fetchData({
+      primaryTable: 'users',
+      columns: ['id', 'name', 'postsCount'],
+      derived: [{ columnId: 'postsCount', kind: 'aggregate', relation: 'posts', fn: 'count' }],
+      filters,
+    });
+
+    const names = result.data.map((row) => (row as { name: string }).name).sort();
+    expect(names).toEqual(['Bob Johnson', 'John Doe']);
+  });
+
+  it('sorts by derived count', async () => {
+    const result = await adapter.fetchData({
+      primaryTable: 'users',
+      columns: ['id', 'name', 'postsCount'],
+      derived: [{ columnId: 'postsCount', kind: 'aggregate', relation: 'posts', fn: 'count' }],
+      sorting: [{ columnId: 'postsCount', direction: 'desc' }],
+    });
+
+    const names = result.data.map((row) => (row as { name: string }).name);
+    expect(names).toEqual(['John Doe', 'Jane Smith', 'Bob Johnson']);
+  });
+
+  it('throws SchemaError for an unknown relation', async () => {
+    await expect(
+      adapter.fetchData({
+        primaryTable: 'users',
+        columns: ['id'],
+        derived: [
+          { columnId: 'widgetsCount', kind: 'aggregate', relation: 'widgets', fn: 'count' },
+        ],
+      })
+    ).rejects.toBeInstanceOf(SchemaError);
+  });
+
+  it('sums a numeric field on the related table', async () => {
+    const result = await adapter.fetchData({
+      primaryTable: 'users',
+      columns: ['id', 'name', 'postsIdSum'],
+      derived: [
+        {
+          columnId: 'postsIdSum',
+          kind: 'aggregate',
+          relation: 'posts',
+          fn: 'sum',
+          field: 'id',
+        },
+      ],
+      sorting: [{ columnId: 'id', direction: 'asc' }],
+    });
+
+    const byName = Object.fromEntries(
+      result.data.map((row) => {
+        const r = row as { name: string; postsIdSum?: number };
+        return [r.name, Number(r.postsIdSum)];
+      })
+    );
+    expect(byName['John Doe']).toBe(1 + 2);
+    expect(byName['Bob Johnson']).toBe(0);
+  });
+});

--- a/packages/adapters/drizzle/tests/derived-aggregates-sqlite.test.ts
+++ b/packages/adapters/drizzle/tests/derived-aggregates-sqlite.test.ts
@@ -8,11 +8,7 @@ import type { FilterGroupNode } from '@better-tables/core';
 import { DrizzleAdapter } from '../src/drizzle-adapter';
 import type { DrizzleDatabase } from '../src/types';
 import { SchemaError } from '../src/types';
-import {
-  closeDatabase,
-  createTestDatabase,
-  setupTestDatabase,
-} from './helpers/test-fixtures';
+import { closeDatabase, createTestDatabase, setupTestDatabase } from './helpers/test-fixtures';
 import { relationsSchema as testRelations, schema as testSchema } from './helpers/test-schema';
 
 describe('Derived aggregates (plan 060) — SQLite', () => {

--- a/packages/adapters/drizzle/tests/filter-handler.test.ts
+++ b/packages/adapters/drizzle/tests/filter-handler.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'bun:test';
-import type { FilterState } from '@better-tables/core';
+import type { FilterGroupNode, FilterState } from '@better-tables/core';
 import { datetime, mysqlTable } from 'drizzle-orm/mysql-core';
 import { pgTable, timestamp } from 'drizzle-orm/pg-core';
 import { integer, sqliteTable } from 'drizzle-orm/sqlite-core';
-import { FilterHandler } from '../src/filter-handler';
+import { FilterHandler, resolveJoinPlanningLeaves } from '../src/filter-handler';
 import { RelationshipManager } from '../src/relationship-manager';
 
 // Create actual Drizzle tables for testing
@@ -368,5 +368,67 @@ describe('FilterHandler - Date Logic', () => {
       expect(condition).toBeDefined();
       // Should only have IS NULL, not duplicate it
     });
+  });
+});
+
+describe('resolveJoinPlanningLeaves', () => {
+  const nameFilter: FilterState = {
+    columnId: 'name',
+    type: 'text',
+    operator: 'contains',
+    values: ['a'],
+  };
+  const profileFilter: FilterState = {
+    columnId: 'profile.bio',
+    type: 'text',
+    operator: 'contains',
+    values: ['x'],
+  };
+  const joinOnlyLeaf: FilterState = {
+    columnId: 'posts.title',
+    type: 'text',
+    operator: 'contains',
+    values: ['y'],
+  };
+
+  it('prefers leaves from filters when present', () => {
+    const leaves = resolveJoinPlanningLeaves({
+      filters: [nameFilter, profileFilter],
+      filterJoinLeaves: [joinOnlyLeaf],
+    });
+    expect(leaves).toEqual([nameFilter, profileFilter]);
+  });
+
+  it('falls back to filterJoinLeaves when filters are empty or absent', () => {
+    expect(
+      resolveJoinPlanningLeaves({
+        filters: [],
+        filterJoinLeaves: [joinOnlyLeaf],
+      })
+    ).toEqual([joinOnlyLeaf]);
+
+    expect(
+      resolveJoinPlanningLeaves({
+        filterJoinLeaves: [joinOnlyLeaf],
+      })
+    ).toEqual([joinOnlyLeaf]);
+  });
+
+  it('returns an empty array when both sources are empty', () => {
+    expect(resolveJoinPlanningLeaves({})).toEqual([]);
+    expect(resolveJoinPlanningLeaves({ filters: [], filterJoinLeaves: [] })).toEqual([]);
+  });
+
+  it('flattens FilterGroupNode trees before preferring them over the fallback', () => {
+    const tree: FilterGroupNode = {
+      kind: 'group',
+      logic: 'or',
+      children: [nameFilter, profileFilter],
+    };
+    const leaves = resolveJoinPlanningLeaves({
+      filters: tree,
+      filterJoinLeaves: [joinOnlyLeaf],
+    });
+    expect(leaves).toEqual([nameFilter, profileFilter]);
   });
 });

--- a/packages/core/src/adapters/memory-adapter.ts
+++ b/packages/core/src/adapters/memory-adapter.ts
@@ -100,6 +100,12 @@ export interface MemoryAdapterOptions<TData> {
    * to disable enum inference.
    */
   enumInferenceLimit?: number;
+  /**
+   * Derived aggregate column ids (from `t.count` / `t.aggregate`). Facets and
+   * min/max on these ids throw until facet transport carries derived specs.
+   * Ids seen on `fetchData({ derived })` are also tracked automatically.
+   */
+  derivedColumnIds?: string[];
 }
 
 const DEFAULT_FACET_LIMIT = 100;
@@ -500,6 +506,7 @@ export function memoryAdapter<TData>(
   const tableName = options.tableName ?? 'memory';
   const enumLimit = options.enumInferenceLimit ?? 12;
   const getRowId = options.getRowId ?? ((row: TData) => String((row as { id?: unknown }).id ?? ''));
+  const knownDerivedColumnIds = new Set<string>(options.derivedColumnIds ?? []);
   const accessorCache = new Map<string, (row: unknown) => unknown>();
   const getAccessor = (columnId: string) => {
     let accessor = accessorCache.get(columnId);
@@ -508,6 +515,13 @@ export function memoryAdapter<TData>(
       accessorCache.set(columnId, accessor);
     }
     return accessor;
+  };
+
+  const rejectDerivedFacet = (columnId: string): void => {
+    if (!knownDerivedColumnIds.has(columnId)) return;
+    throw new Error(
+      `[better-tables] memoryAdapter does not support facets or min/max on derived aggregate columns yet (column '${columnId}').`
+    );
   };
 
   const applyFilters = (source: TData[], filters: FetchDataParams['filters']): TData[] => {
@@ -537,6 +551,9 @@ export function memoryAdapter<TData>(
   return {
     async fetchData(params: FetchDataParams = {}): Promise<FetchDataResult<TData>> {
       throwIfAborted(params.signal);
+      for (const spec of params.derived ?? []) {
+        knownDerivedColumnIds.add(spec.columnId);
+      }
       const materialised = withDerivedValues(rows, params.derived);
       const filtered = applySorting(applyFilters(materialised, params.filters), params.sorting);
       const total = filtered.length;
@@ -569,6 +586,7 @@ export function memoryAdapter<TData>(
       params?: FacetQueryParams
     ): Promise<Map<string, number>> {
       throwIfAborted(params?.signal);
+      rejectDerivedFacet(columnId);
       const filters = excludeColumn(params?.filters, columnId);
       const accessor = getAccessor(columnId);
       const counts = new Map<string, number>();
@@ -588,6 +606,7 @@ export function memoryAdapter<TData>(
 
     async getMinMaxValues(columnId: string, params?: FacetQueryParams): Promise<[number, number]> {
       throwIfAborted(params?.signal);
+      rejectDerivedFacet(columnId);
       const filters = excludeColumn(params?.filters, columnId);
       const accessor = getAccessor(columnId);
       let min = Number.POSITIVE_INFINITY;

--- a/packages/core/src/adapters/memory-adapter.ts
+++ b/packages/core/src/adapters/memory-adapter.ts
@@ -39,9 +39,7 @@ const ALL_AGGREGATE_FNS: AggregateFn[] = ['count', 'sum', 'avg', 'min', 'max'];
 /** Evaluate a derived aggregate over a nested array relation on the row. */
 function evaluateDerivedAggregate(row: unknown, spec: DerivedFetchSpec): number {
   const relationValue =
-    row && typeof row === 'object'
-      ? (row as Record<string, unknown>)[spec.relation]
-      : undefined;
+    row && typeof row === 'object' ? (row as Record<string, unknown>)[spec.relation] : undefined;
   const items = Array.isArray(relationValue) ? relationValue : [];
 
   if (spec.fn === 'count') {
@@ -512,10 +510,7 @@ export function memoryAdapter<TData>(
     return accessor;
   };
 
-  const applyFilters = (
-    source: TData[],
-    filters: FetchDataParams['filters']
-  ): TData[] => {
+  const applyFilters = (source: TData[], filters: FetchDataParams['filters']): TData[] => {
     if (!filters || (Array.isArray(filters) && filters.length === 0)) return [...source];
     return source.filter((row) => matchesNode(filters, row, getAccessor));
   };

--- a/packages/core/src/adapters/memory-adapter.ts
+++ b/packages/core/src/adapters/memory-adapter.ts
@@ -23,6 +23,7 @@ import type {
   TableAdapter,
 } from '../types/adapter';
 import type { ColumnType } from '../types/column';
+import type { AggregateFn, DerivedFetchSpec } from '../types/derived';
 import type {
   FilterGroupNode,
   FilterNode,
@@ -32,6 +33,59 @@ import type {
 } from '../types/filter';
 import { FILTER_OPERATORS, getDefaultOperatorsForType } from '../types/filter-operators';
 import type { SortingParams } from '../types/sorting';
+
+const ALL_AGGREGATE_FNS: AggregateFn[] = ['count', 'sum', 'avg', 'min', 'max'];
+
+/** Evaluate a derived aggregate over a nested array relation on the row. */
+function evaluateDerivedAggregate(row: unknown, spec: DerivedFetchSpec): number {
+  const relationValue =
+    row && typeof row === 'object'
+      ? (row as Record<string, unknown>)[spec.relation]
+      : undefined;
+  const items = Array.isArray(relationValue) ? relationValue : [];
+
+  if (spec.fn === 'count') {
+    return items.length;
+  }
+
+  const field = spec.field;
+  const numbers: number[] = [];
+  for (const item of items) {
+    if (!item || typeof item !== 'object' || field == null) continue;
+    const raw = (item as Record<string, unknown>)[field];
+    const n = typeof raw === 'number' ? raw : Number(raw);
+    if (!Number.isNaN(n)) numbers.push(n);
+  }
+
+  if (numbers.length === 0) {
+    return 0;
+  }
+
+  switch (spec.fn) {
+    case 'sum':
+      return numbers.reduce((a, b) => a + b, 0);
+    case 'avg':
+      return numbers.reduce((a, b) => a + b, 0) / numbers.length;
+    case 'min':
+      return Math.min(...numbers);
+    case 'max':
+      return Math.max(...numbers);
+    default:
+      return 0;
+  }
+}
+
+/** Materialize derived column values onto shallow row copies. */
+function withDerivedValues<TData>(rows: TData[], derived: DerivedFetchSpec[] | undefined): TData[] {
+  if (!derived || derived.length === 0) return rows;
+  return rows.map((row) => {
+    const copy: Record<string, unknown> = { ...(row as object as Record<string, unknown>) };
+    for (const spec of derived) {
+      copy[spec.columnId] = evaluateDerivedAggregate(row, spec);
+    }
+    return copy as TData;
+  });
+}
 
 /** Options for {@link memoryAdapter}. */
 export interface MemoryAdapterOptions<TData> {
@@ -458,9 +512,12 @@ export function memoryAdapter<TData>(
     return accessor;
   };
 
-  const applyFilters = (filters: FetchDataParams['filters']): TData[] => {
-    if (!filters || (Array.isArray(filters) && filters.length === 0)) return [...rows];
-    return rows.filter((row) => matchesNode(filters, row, getAccessor));
+  const applyFilters = (
+    source: TData[],
+    filters: FetchDataParams['filters']
+  ): TData[] => {
+    if (!filters || (Array.isArray(filters) && filters.length === 0)) return [...source];
+    return source.filter((row) => matchesNode(filters, row, getAccessor));
   };
 
   const applySorting = (data: TData[], sorting: SortingParams[] | undefined): TData[] => {
@@ -485,7 +542,8 @@ export function memoryAdapter<TData>(
   return {
     async fetchData(params: FetchDataParams = {}): Promise<FetchDataResult<TData>> {
       throwIfAborted(params.signal);
-      const filtered = applySorting(applyFilters(params.filters), params.sorting);
+      const materialised = withDerivedValues(rows, params.derived);
+      const filtered = applySorting(applyFilters(materialised, params.filters), params.sorting);
       const total = filtered.length;
       const limit = Math.max(1, params.pagination?.limit ?? (total || 1));
       const totalPages = Math.max(1, Math.ceil(total / limit));
@@ -519,7 +577,7 @@ export function memoryAdapter<TData>(
       const filters = excludeColumn(params?.filters, columnId);
       const accessor = getAccessor(columnId);
       const counts = new Map<string, number>();
-      for (const row of applyFilters(filters)) {
+      for (const row of applyFilters(rows, filters)) {
         const raw = accessor(row);
         if (raw == null) continue;
         const values = Array.isArray(raw) ? raw : [raw];
@@ -539,7 +597,7 @@ export function memoryAdapter<TData>(
       const accessor = getAccessor(columnId);
       let min = Number.POSITIVE_INFINITY;
       let max = Number.NEGATIVE_INFINITY;
-      for (const row of applyFilters(filters)) {
+      for (const row of applyFilters(rows, filters)) {
         const raw = accessor(row);
         const value = raw instanceof Date ? raw.getTime() : Number(raw);
         if (raw == null || Number.isNaN(value)) continue;
@@ -613,6 +671,14 @@ export function memoryAdapter<TData>(
         ])
       ) as Record<ColumnType, FilterOperator[]>,
       supportsFilterGroups: true,
+      capabilities: {
+        aggregates: {
+          fns: [...ALL_AGGREGATE_FNS],
+          render: true,
+          filter: true,
+          sort: true,
+        },
+      },
     },
   };
 }

--- a/packages/core/src/adapters/memory-adapter.ts
+++ b/packages/core/src/adapters/memory-adapter.ts
@@ -101,9 +101,12 @@ export interface MemoryAdapterOptions<TData> {
    */
   enumInferenceLimit?: number;
   /**
-   * Derived aggregate column ids (from `t.count` / `t.aggregate`). Facets and
-   * min/max on these ids throw until facet transport carries derived specs.
-   * Ids seen on `fetchData({ derived })` are also tracked automatically.
+   * Derived aggregate column ids (from `t.count` / `t.aggregate`).
+   * **Required** when those columns exist and you may call facets/min-max —
+   * otherwise `getFacetedValues` / `getMinMaxValues` cannot tell a derived id
+   * from a missing field and would silently return empty/zero results.
+   * Pass the same ids you send on `fetchData({ derived })`. Facets on these
+   * ids throw until facet transport carries derived specs.
    */
   derivedColumnIds?: string[];
 }
@@ -506,6 +509,8 @@ export function memoryAdapter<TData>(
   const tableName = options.tableName ?? 'memory';
   const enumLimit = options.enumInferenceLimit ?? 12;
   const getRowId = options.getRowId ?? ((row: TData) => String((row as { id?: unknown }).id ?? ''));
+  // Explicit only — do not infer from fetchData order (that silently no-ops
+  // when facets run before the first derived fetch).
   const knownDerivedColumnIds = new Set<string>(options.derivedColumnIds ?? []);
   const accessorCache = new Map<string, (row: unknown) => unknown>();
   const getAccessor = (columnId: string) => {
@@ -520,7 +525,7 @@ export function memoryAdapter<TData>(
   const rejectDerivedFacet = (columnId: string): void => {
     if (!knownDerivedColumnIds.has(columnId)) return;
     throw new Error(
-      `[better-tables] memoryAdapter does not support facets or min/max on derived aggregate columns yet (column '${columnId}').`
+      `[better-tables] memoryAdapter does not support facets or min/max on derived aggregate columns yet (column '${columnId}'). Pass derivedColumnIds when constructing the adapter.`
     );
   };
 
@@ -551,9 +556,6 @@ export function memoryAdapter<TData>(
   return {
     async fetchData(params: FetchDataParams = {}): Promise<FetchDataResult<TData>> {
       throwIfAborted(params.signal);
-      for (const spec of params.derived ?? []) {
-        knownDerivedColumnIds.add(spec.columnId);
-      }
       const materialised = withDerivedValues(rows, params.derived);
       const filtered = applySorting(applyFilters(materialised, params.filters), params.sorting);
       const total = filtered.length;

--- a/packages/core/src/builders/column-builder.ts
+++ b/packages/core/src/builders/column-builder.ts
@@ -18,6 +18,7 @@ import type {
   ValidationRule,
 } from '../types/column';
 import type { IconComponent } from '../types/common';
+import type { DerivedColumnSpec } from '../types/derived';
 import type { FilterConfig, FilterOperator } from '../types/filter';
 
 /**
@@ -77,10 +78,13 @@ export class ColumnBuilder<TData = unknown, TValue = unknown, TId extends string
    * ```
    */
   constructor(type: ColumnType) {
+    // Client-only custom/computed columns have no DB backing — honest
+    // defaults suppress filter/sort until the caller opts in (plan 060).
+    const isCustom = type === 'custom';
     this.config = {
       type,
-      sortable: true,
-      filterable: true,
+      sortable: !isCustom,
+      filterable: !isCustom,
       resizable: true,
       align: 'left',
       nullable: false,
@@ -353,6 +357,14 @@ export class ColumnBuilder<TData = unknown, TValue = unknown, TId extends string
    */
   meta(meta: Record<string, unknown>): this {
     this.config.meta = { ...this.config.meta, ...meta };
+    return this;
+  }
+
+  /**
+   * Attach a server-derived column spec (plan 060 aggregates).
+   */
+  derived(spec: DerivedColumnSpec): this {
+    this.config.derived = spec;
     return this;
   }
 

--- a/packages/core/src/builders/index.ts
+++ b/packages/core/src/builders/index.ts
@@ -32,5 +32,9 @@ export { NumberColumnBuilder } from './number-column-builder';
 export { OptionColumnBuilder } from './option-column-builder';
 // Path-derived accessor walker (dot-notation, array-hop semantics) — shared
 // with the UI's relationship-path cell editing (plan 055).
-export { buildPathAccessor, type PathColumnFactory } from './path-builders';
+export {
+  type AggregateBuilderSpec,
+  buildPathAccessor,
+  type PathColumnFactory,
+} from './path-builders';
 export { TextColumnBuilder } from './text-column-builder';

--- a/packages/core/src/builders/path-builders.ts
+++ b/packages/core/src/builders/path-builders.ts
@@ -52,11 +52,14 @@ function assertAggregateField(spec: AggregateBuilderSpec): void {
 
 function derivedFromAggregate(spec: AggregateBuilderSpec): DerivedColumnSpec {
   assertAggregateField(spec);
+  if (spec.fn === 'count') {
+    return { kind: 'aggregate', relation: spec.relation, fn: 'count' };
+  }
   return {
     kind: 'aggregate',
     relation: spec.relation,
     fn: spec.fn,
-    ...(spec.fn !== 'count' && spec.field != null ? { field: spec.field } : {}),
+    field: spec.field as string,
   };
 }
 
@@ -360,6 +363,9 @@ export function createPathColumnFactory<TRow>(): PathColumnFactory<TRow> {
     },
 
     count(relation: string) {
+      if (relation == null || String(relation).trim() === '') {
+        throw new Error('t.count: relation must be a non-empty string (e.g. t.count("posts")).');
+      }
       const id = `${relation}Count` as const;
       return new NumberColumnBuilder<TRow, number, typeof id>()
         .id(id)
@@ -372,6 +378,9 @@ export function createPathColumnFactory<TRow>(): PathColumnFactory<TRow> {
     },
 
     aggregate<TId extends string>(id: TId, spec: AggregateBuilderSpec) {
+      if (spec.relation == null || String(spec.relation).trim() === '') {
+        throw new Error('t.aggregate: relation must be a non-empty string.');
+      }
       const derived = derivedFromAggregate(spec);
       return new NumberColumnBuilder<TRow, number, TId>()
         .id(id)

--- a/packages/core/src/builders/path-builders.ts
+++ b/packages/core/src/builders/path-builders.ts
@@ -18,14 +18,13 @@
  * object shape, because they ARE the same builder class underneath.
  *
  * See `plans/018-instance-api-runtime.md` Step 3 for the scope this file
- * implements, and its "Deferred OUT of this plan" list for what's
- * intentionally NOT here: `t.count()`/`t.sum()` (aggregate builders --
- * need adapter execution work), `t.json().path()`, and runtime enum
- * auto-OPTIONS metadata.
+ * implements. Aggregate builders (`t.count` / `t.aggregate`) ship in plan
+ * 060. Still deferred: `t.json().path()`, runtime enum auto-OPTIONS.
  */
 
 import { humanize, lastPathSegment } from '../lib/format-utils';
 import type { ColumnDefinition } from '../types/column';
+import type { AggregateFn, DerivedColumnSpec } from '../types/derived';
 import type { Paths, PathsOfType, PathValue } from '../types/paths';
 import { BooleanColumnBuilder } from './boolean-column-builder';
 import { ColumnBuilder } from './column-builder';
@@ -34,6 +33,32 @@ import { MultiOptionColumnBuilder } from './multi-option-column-builder';
 import { NumberColumnBuilder } from './number-column-builder';
 import { OptionColumnBuilder } from './option-column-builder';
 import { TextColumnBuilder } from './text-column-builder';
+
+/** Options for {@link PathColumnFactory.aggregate}. */
+export type AggregateBuilderSpec = {
+  relation: string;
+  fn: AggregateFn;
+  /** Required for sum/avg/min/max; ignored for count. */
+  field?: string;
+};
+
+function assertAggregateField(spec: AggregateBuilderSpec): void {
+  if (spec.fn !== 'count' && (spec.field == null || spec.field === '')) {
+    throw new Error(
+      `t.aggregate: fn '${spec.fn}' requires a 'field' (the numeric column on '${spec.relation}').`
+    );
+  }
+}
+
+function derivedFromAggregate(spec: AggregateBuilderSpec): DerivedColumnSpec {
+  assertAggregateField(spec);
+  return {
+    kind: 'aggregate',
+    relation: spec.relation,
+    fn: spec.fn,
+    ...(spec.fn !== 'count' && spec.field != null ? { field: spec.field } : {}),
+  };
+}
 
 /**
  * Walk a dot-notation path against a row, matching the RUNTIME accessor
@@ -150,11 +175,8 @@ export type ComputedBuilder<TData, TValue, TId extends string = string> = Column
 
 /**
  * The `t` builder factory bound to a specific table's row type `TRow`.
- * Implements plan 011 Step 3's required members
- * (`text/number/date/boolean/option/multiOption/computed/custom`).
- *
- * `t.count()`/`t.sum()` (aggregate builders) are deliberately NOT modeled --
- * deferred out of this plan (see module docblock).
+ * Implements plan 011 Step 3's required members plus plan 060 aggregates
+ * (`count` / `aggregate`).
  */
 export interface PathColumnFactory<TRow> {
   text<P extends PathsOfType<TRow, string | null>>(
@@ -221,6 +243,26 @@ export interface PathColumnFactory<TRow> {
    * entry.
    */
   auto(): ColumnDefinition<TRow, unknown>[];
+
+  /**
+   * Relation count column (plan 060). Id defaults to `` `${relation}Count` ``.
+   * Server-backed — filterable and sortable by default.
+   *
+   * @example
+   * ```ts
+   * t.count('posts').displayName('Posts')
+   * ```
+   */
+  count(relation: string): NumberColumnBuilder<TRow, number, `${string}Count`>;
+
+  /**
+   * General aggregate column (plan 060). Prefer {@link count} for counts.
+   * Non-count fns require `field`.
+   */
+  aggregate<TId extends string>(
+    id: TId,
+    spec: AggregateBuilderSpec
+  ): NumberColumnBuilder<TRow, number, TId>;
 }
 
 // ============================================================================
@@ -315,6 +357,30 @@ export function createPathColumnFactory<TRow>(): PathColumnFactory<TRow> {
 
     auto() {
       return [createAutoColumnsSentinel<TRow>()];
+    },
+
+    count(relation: string) {
+      const id = `${relation}Count` as const;
+      return new NumberColumnBuilder<TRow, number, typeof id>()
+        .id(id)
+        .accessor((row) => {
+          const value = (row as Record<string, unknown>)[id];
+          return typeof value === 'number' ? value : Number(value ?? 0);
+        })
+        .displayName(humanize(id))
+        .derived(derivedFromAggregate({ relation, fn: 'count' }));
+    },
+
+    aggregate<TId extends string>(id: TId, spec: AggregateBuilderSpec) {
+      const derived = derivedFromAggregate(spec);
+      return new NumberColumnBuilder<TRow, number, TId>()
+        .id(id)
+        .accessor((row) => {
+          const value = (row as Record<string, unknown>)[id];
+          return typeof value === 'number' ? value : Number(value ?? 0);
+        })
+        .displayName(humanize(id))
+        .derived(derived);
     },
   };
 }

--- a/packages/core/src/builders/path-builders.ts
+++ b/packages/core/src/builders/path-builders.ts
@@ -42,6 +42,14 @@ export type AggregateBuilderSpec = {
   field?: string;
 };
 
+function assertRelation(relation: string, caller: 't.count' | 't.aggregate'): void {
+  if (relation == null || String(relation).trim() === '') {
+    throw new Error(
+      `${caller}: relation must be a non-empty string (e.g. ${caller === 't.count' ? 't.count("posts")' : 't.aggregate("total", { relation: "orders", fn: "sum", field: "amount" })'}).`
+    );
+  }
+}
+
 function assertAggregateField(spec: AggregateBuilderSpec): void {
   if (spec.fn !== 'count' && (spec.field == null || spec.field === '')) {
     throw new Error(
@@ -51,6 +59,7 @@ function assertAggregateField(spec: AggregateBuilderSpec): void {
 }
 
 function derivedFromAggregate(spec: AggregateBuilderSpec): DerivedColumnSpec {
+  assertRelation(spec.relation, 't.aggregate');
   assertAggregateField(spec);
   if (spec.fn === 'count') {
     return { kind: 'aggregate', relation: spec.relation, fn: 'count' };
@@ -363,9 +372,7 @@ export function createPathColumnFactory<TRow>(): PathColumnFactory<TRow> {
     },
 
     count(relation: string) {
-      if (relation == null || String(relation).trim() === '') {
-        throw new Error('t.count: relation must be a non-empty string (e.g. t.count("posts")).');
-      }
+      assertRelation(relation, 't.count');
       const id = `${relation}Count` as const;
       return new NumberColumnBuilder<TRow, number, typeof id>()
         .id(id)
@@ -378,9 +385,6 @@ export function createPathColumnFactory<TRow>(): PathColumnFactory<TRow> {
     },
 
     aggregate<TId extends string>(id: TId, spec: AggregateBuilderSpec) {
-      if (spec.relation == null || String(spec.relation).trim() === '') {
-        throw new Error('t.aggregate: relation must be a non-empty string.');
-      }
       const derived = derivedFromAggregate(spec);
       return new NumberColumnBuilder<TRow, number, TId>()
         .id(id)

--- a/packages/core/src/factory.ts
+++ b/packages/core/src/factory.ts
@@ -48,6 +48,7 @@ import {
   type CellEditAction,
   type CellEditPolicy,
 } from './lib/cell-edit-core';
+import { withDerivedFetchParams } from './lib/derived-params';
 import type {
   FacetQueryParams,
   FetchDataParams,
@@ -141,6 +142,10 @@ export function betterTables<TAdapter extends object>(
         };
       }
     }
+
+    // Plan 060: attach derived specs from the table definition and enforce
+    // adapter aggregate capabilities before the adapter runs.
+    fetchParams = withDerivedFetchParams(table.columns, fetchParams, adapter.meta);
 
     let result = await adapter.fetchData(fetchParams);
     for (const plugin of plugins) {

--- a/packages/core/src/lib/derived-params.ts
+++ b/packages/core/src/lib/derived-params.ts
@@ -64,7 +64,8 @@ function collectFilterColumnIds(filters: FilterState[] | FilterGroupNode | undef
  */
 function collectDerivedScopeIds(
   columns: readonly ColumnDefinition[],
-  params: Pick<FetchDataParams, 'columns' | 'filters' | 'sorting'>
+  params: Pick<FetchDataParams, 'columns' | 'sorting'>,
+  filterColumnIds: Set<string>
 ): string[] | undefined {
   const requested = params.columns;
   if (requested == null || !Array.isArray(requested)) {
@@ -72,7 +73,7 @@ function collectDerivedScopeIds(
   }
 
   const scope = new Set(requested.map(String));
-  for (const id of collectFilterColumnIds(params.filters)) {
+  for (const id of filterColumnIds) {
     scope.add(id);
   }
   for (const sort of params.sorting ?? []) {
@@ -92,7 +93,9 @@ function collectDerivedScopeIds(
 export function assertAggregateCapabilities(
   adapterMeta: AdapterMeta,
   derived: readonly DerivedFetchSpec[],
-  params: Pick<FetchDataParams, 'filters' | 'sorting'>
+  params: Pick<FetchDataParams, 'filters' | 'sorting'>,
+  /** Precomputed filter column ids — avoids a second tree walk. */
+  filterColumnIds?: Set<string>
 ): void {
   if (derived.length === 0) return;
 
@@ -124,7 +127,7 @@ export function assertAggregateCapabilities(
   }
 
   const derivedIds = new Set(derived.map((d) => d.columnId));
-  const filterIds = collectFilterColumnIds(params.filters);
+  const filterIds = filterColumnIds ?? collectFilterColumnIds(params.filters);
   const needsFilter = [...filterIds].some((id) => derivedIds.has(id));
   if (needsFilter && !aggregates.filter) {
     throw new Error(
@@ -152,9 +155,10 @@ export function withDerivedFetchParams(
   if (columns == null || !Array.isArray(columns)) {
     return params;
   }
-  const scopeIds = collectDerivedScopeIds(columns, params);
+  const filterColumnIds = collectFilterColumnIds(params.filters);
+  const scopeIds = collectDerivedScopeIds(columns, params, filterColumnIds);
   const derived = collectDerivedFetchSpecs(columns, scopeIds);
-  assertAggregateCapabilities(adapterMeta, derived, params);
+  assertAggregateCapabilities(adapterMeta, derived, params, filterColumnIds);
   if (derived.length === 0) {
     return params;
   }

--- a/packages/core/src/lib/derived-params.ts
+++ b/packages/core/src/lib/derived-params.ts
@@ -1,0 +1,132 @@
+/**
+ * Collect derived column specs for fetch transport and enforce adapter
+ * aggregate capabilities (plan 060).
+ */
+
+import type { AdapterMeta, FetchDataParams } from '../types/adapter';
+import type { ColumnDefinition } from '../types/column';
+import type { DerivedFetchSpec } from '../types/derived';
+import type { FilterGroupNode, FilterNode, FilterState } from '../types/filter';
+import type { SortingParams } from '../types/sorting';
+import { isFilterGroupNode } from '../utils/type-guards';
+
+/** Collect derived specs from column defs, optionally scoped to requested ids. */
+export function collectDerivedFetchSpecs(
+  columns: readonly ColumnDefinition[] | null | undefined,
+  requestedColumnIds?: readonly string[]
+): DerivedFetchSpec[] {
+  if (columns == null || !Array.isArray(columns)) {
+    return [];
+  }
+  // Runtime-guard: callers may pass a non-array at the JS boundary (types
+  // only constrain `string[]`); treat non-arrays as "no column scope".
+  const allow =
+    requestedColumnIds == null || !Array.isArray(requestedColumnIds)
+      ? null
+      : new Set(requestedColumnIds.map(String));
+  const specs: DerivedFetchSpec[] = [];
+  for (const column of columns) {
+    if (!column.derived) continue;
+    if (allow != null && !allow.has(column.id)) continue;
+    specs.push({ columnId: column.id, ...column.derived });
+  }
+  return specs;
+}
+
+function collectFilterColumnIds(
+  filters: FilterState[] | FilterGroupNode | undefined
+): Set<string> {
+  const ids = new Set<string>();
+  if (filters == null) return ids;
+
+  const walkNode = (node: FilterNode) => {
+    if (isFilterGroupNode(node)) {
+      for (const child of node.children) {
+        walkNode(child);
+      }
+      return;
+    }
+    ids.add(node.columnId);
+  };
+
+  if (isFilterGroupNode(filters)) {
+    walkNode(filters);
+  } else {
+    for (const leaf of filters) {
+      walkNode(leaf);
+    }
+  }
+  return ids;
+}
+
+/**
+ * Throw if the adapter cannot satisfy the requested derived specs for the
+ * operations implied by the fetch params.
+ */
+export function assertAggregateCapabilities(
+  adapterMeta: AdapterMeta,
+  derived: readonly DerivedFetchSpec[],
+  params: Pick<FetchDataParams, 'filters' | 'sorting'>
+): void {
+  if (derived.length === 0) return;
+
+  const aggregates = adapterMeta.capabilities?.aggregates;
+  const adapterName = adapterMeta.name ?? 'adapter';
+
+  if (!aggregates) {
+    throw new Error(
+      `[better-tables] Adapter '${adapterName}' does not declare capabilities.aggregates, ` +
+        `but the table definition requests derived columns (${derived.map((d) => d.columnId).join(', ')}). ` +
+        `Use an adapter that supports aggregates (e.g. drizzleAdapter, memoryAdapter), or remove t.count/t.aggregate columns.`
+    );
+  }
+
+  if (!aggregates.render) {
+    throw new Error(
+      `[better-tables] Adapter '${adapterName}' declares aggregates.render=false; ` +
+        `cannot fetch derived columns (${derived.map((d) => d.columnId).join(', ')}).`
+    );
+  }
+
+  for (const spec of derived) {
+    if (!aggregates.fns.includes(spec.fn)) {
+      throw new Error(
+        `[better-tables] Adapter '${adapterName}' does not support aggregate fn '${spec.fn}' ` +
+          `(column '${spec.columnId}'). Supported: ${aggregates.fns.join(', ') || '(none)'}.`
+      );
+    }
+  }
+
+  const derivedIds = new Set(derived.map((d) => d.columnId));
+  const filterIds = collectFilterColumnIds(params.filters);
+  const needsFilter = [...filterIds].some((id) => derivedIds.has(id));
+  if (needsFilter && !aggregates.filter) {
+    throw new Error(
+      `[better-tables] Adapter '${adapterName}' declares aggregates.filter=false; ` +
+        `cannot filter on derived columns.`
+    );
+  }
+
+  const sorts: SortingParams[] = params.sorting ?? [];
+  const needsSort = sorts.some((s) => derivedIds.has(s.columnId));
+  if (needsSort && !aggregates.sort) {
+    throw new Error(
+      `[better-tables] Adapter '${adapterName}' declares aggregates.sort=false; ` +
+        `cannot sort on derived columns.`
+    );
+  }
+}
+
+/** Attach derived specs + enforce capabilities on fetch params. */
+export function withDerivedFetchParams(
+  columns: readonly ColumnDefinition[] | null | undefined,
+  params: FetchDataParams,
+  adapterMeta: AdapterMeta
+): FetchDataParams {
+  const derived = collectDerivedFetchSpecs(columns, params.columns);
+  assertAggregateCapabilities(adapterMeta, derived, params);
+  if (derived.length === 0) {
+    return params;
+  }
+  return { ...params, derived };
+}

--- a/packages/core/src/lib/derived-params.ts
+++ b/packages/core/src/lib/derived-params.ts
@@ -33,9 +33,7 @@ export function collectDerivedFetchSpecs(
   return specs;
 }
 
-function collectFilterColumnIds(
-  filters: FilterState[] | FilterGroupNode | undefined
-): Set<string> {
+function collectFilterColumnIds(filters: FilterState[] | FilterGroupNode | undefined): Set<string> {
   const ids = new Set<string>();
   if (filters == null) return ids;
 

--- a/packages/core/src/lib/derived-params.ts
+++ b/packages/core/src/lib/derived-params.ts
@@ -58,6 +58,34 @@ function collectFilterColumnIds(filters: FilterState[] | FilterGroupNode | undef
 }
 
 /**
+ * Column ids that should carry derived specs for this fetch: requested
+ * `params.columns`, plus any derived column referenced by filters/sorting
+ * (so a filter on `postsCount` still attaches the spec when `columns` omits it).
+ */
+function collectDerivedScopeIds(
+  columns: readonly ColumnDefinition[],
+  params: Pick<FetchDataParams, 'columns' | 'filters' | 'sorting'>
+): string[] | undefined {
+  const requested = params.columns;
+  if (requested == null || !Array.isArray(requested)) {
+    return undefined; // all derived columns
+  }
+
+  const scope = new Set(requested.map(String));
+  for (const id of collectFilterColumnIds(params.filters)) {
+    scope.add(id);
+  }
+  for (const sort of params.sorting ?? []) {
+    scope.add(sort.columnId);
+  }
+
+  // Only keep ids that actually have derived specs (unrelated filter columns
+  // must not widen the allow-set to "all columns").
+  const derivedIds = new Set(columns.filter((c) => c.derived != null).map((c) => c.id));
+  return [...scope].filter((id) => derivedIds.has(id));
+}
+
+/**
  * Throw if the adapter cannot satisfy the requested derived specs for the
  * operations implied by the fetch params.
  */
@@ -121,7 +149,11 @@ export function withDerivedFetchParams(
   params: FetchDataParams,
   adapterMeta: AdapterMeta
 ): FetchDataParams {
-  const derived = collectDerivedFetchSpecs(columns, params.columns);
+  if (columns == null || !Array.isArray(columns)) {
+    return params;
+  }
+  const scopeIds = collectDerivedScopeIds(columns, params);
+  const derived = collectDerivedFetchSpecs(columns, scopeIds);
   assertAggregateCapabilities(adapterMeta, derived, params);
   if (derived.length === 0) {
     return params;

--- a/packages/core/src/lib/index.ts
+++ b/packages/core/src/lib/index.ts
@@ -1,6 +1,7 @@
 export * from './cell-edit-core';
 export * from './date-presets';
 export * from './date-utils';
+export * from './derived-params';
 export * from './export-format';
 export * from './filter-value-utils';
 export * from './format-utils';

--- a/packages/core/src/types/adapter.ts
+++ b/packages/core/src/types/adapter.ts
@@ -9,6 +9,7 @@
 
 import type { ColumnType } from './column';
 import type { DataEvent } from './common';
+import type { AdapterCapabilities, DerivedFetchSpec } from './derived';
 import type { FilterGroupNode, FilterOperator, FilterOption, FilterState } from './filter';
 import type { PaginationParams } from './pagination';
 import type { SortingParams } from './sorting';
@@ -56,6 +57,13 @@ export interface FetchDataParams {
 
   /** Specific columns to include in the result */
   columns?: string[];
+
+  /**
+   * Server-derived column specs (plan 060). Attached by the instance fetch
+   * path / UI from column definitions — not adapter-constructor config.
+   * Adapters validate each spec against schema/relationships.
+   */
+  derived?: DerivedFetchSpec[];
 
   /**
    * Explicit primary table specification.
@@ -640,6 +648,12 @@ export interface AdapterMeta {
    * plan 011's `Paths<T>` depth cap).
    */
   maxGroupDepth?: number;
+
+  /**
+   * Optional capability contributions (plan 060). Adapters that support
+   * server-derived aggregates declare `capabilities.aggregates`.
+   */
+  capabilities?: AdapterCapabilities;
 }
 
 /**

--- a/packages/core/src/types/column.ts
+++ b/packages/core/src/types/column.ts
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import type { ColumnMeta } from './column-meta';
 import type { IconComponent, RenderProps } from './common';
+import type { DerivedColumnSpec } from './derived';
 import type { FilterConfig } from './filter';
 
 /**
@@ -94,6 +95,13 @@ export interface ColumnDefinition<TData = unknown, TValue = unknown, TId extends
 
   /** Whether column supports null/undefined values */
   nullable?: boolean;
+
+  /**
+   * Server-derived column spec (plan 060). When set, adapters evaluate the
+   * value (e.g. relation `count`) instead of reading a physical column.
+   * Serializable — never functions or SQL strings.
+   */
+  derived?: DerivedColumnSpec;
 
   /** Column metadata - strongly typed */
   meta?: ColumnMeta;

--- a/packages/core/src/types/derived.ts
+++ b/packages/core/src/types/derived.ts
@@ -10,8 +10,13 @@
 /** Aggregate functions supported by derived columns. `distinct` is deferred. */
 export type AggregateFn = 'count' | 'sum' | 'avg' | 'min' | 'max';
 
+/** Field-requiring aggregate fns (everything except `count`). */
+export type AggregateFnWithField = Exclude<AggregateFn, 'count'>;
+
 /**
  * Declarative aggregate over a single-hop many-relation on the primary table.
+ *
+ * Discriminated on `fn`: `count` has no field; sum/avg/min/max require `field`.
  *
  * @example
  * ```ts
@@ -19,14 +24,21 @@ export type AggregateFn = 'count' | 'sum' | 'avg' | 'min' | 'max';
  * { kind: 'aggregate', relation: 'orders', fn: 'sum', field: 'amount' }
  * ```
  */
-export interface DerivedColumnSpec {
-  kind: 'aggregate';
-  /** Relation name on the primary table (e.g. `'posts'`). Single hop. */
-  relation: string;
-  fn: AggregateFn;
-  /** Required for sum/avg/min/max; ignored for count. */
-  field?: string;
-}
+export type DerivedColumnSpec =
+  | {
+      kind: 'aggregate';
+      /** Relation name on the primary table (e.g. `'posts'`). Single hop. */
+      relation: string;
+      fn: 'count';
+      field?: undefined;
+    }
+  | {
+      kind: 'aggregate';
+      relation: string;
+      fn: AggregateFnWithField;
+      /** Numeric column on the related table. */
+      field: string;
+    };
 
 /** A derived spec bound to its column id for fetch transport. */
 export type DerivedFetchSpec = { columnId: string } & DerivedColumnSpec;

--- a/packages/core/src/types/derived.ts
+++ b/packages/core/src/types/derived.ts
@@ -1,0 +1,48 @@
+/**
+ * Serializable server-derived column specs (plan 060).
+ *
+ * Specs ride `FetchDataParams.derived` and must never carry functions or SQL
+ * strings — adapters validate identifiers against their schema.
+ *
+ * @see plans/design/derived-columns.md
+ */
+
+/** Aggregate functions supported by derived columns. `distinct` is deferred. */
+export type AggregateFn = 'count' | 'sum' | 'avg' | 'min' | 'max';
+
+/**
+ * Declarative aggregate over a single-hop many-relation on the primary table.
+ *
+ * @example
+ * ```ts
+ * { kind: 'aggregate', relation: 'posts', fn: 'count' }
+ * { kind: 'aggregate', relation: 'orders', fn: 'sum', field: 'amount' }
+ * ```
+ */
+export interface DerivedColumnSpec {
+  kind: 'aggregate';
+  /** Relation name on the primary table (e.g. `'posts'`). Single hop. */
+  relation: string;
+  fn: AggregateFn;
+  /** Required for sum/avg/min/max; ignored for count. */
+  field?: string;
+}
+
+/** A derived spec bound to its column id for fetch transport. */
+export type DerivedFetchSpec = { columnId: string } & DerivedColumnSpec;
+
+/**
+ * Per-operation aggregate capability (Prisma can render/sort relation counts
+ * but not filter by them — a flat fn list cannot express that).
+ */
+export interface AggregateCapabilities {
+  fns: AggregateFn[];
+  render: boolean;
+  filter: boolean;
+  sort: boolean;
+}
+
+/** Optional adapter capability contributions. */
+export interface AdapterCapabilities {
+  aggregates?: AggregateCapabilities;
+}

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -3,6 +3,7 @@ export * from './adapter';
 export * from './column';
 export * from './column-meta';
 export * from './common';
+export * from './derived';
 export * from './factory';
 export * from './filter';
 export * from './filter-operators';

--- a/packages/core/tests/adapters/memory-adapter.test.ts
+++ b/packages/core/tests/adapters/memory-adapter.test.ts
@@ -415,7 +415,14 @@ describe('memoryAdapter', () => {
     }
 
     const users: UserWithPosts[] = [
-      { id: '1', name: 'Ada', posts: [{ title: 'a', views: 10 }, { title: 'b', views: 20 }] },
+      {
+        id: '1',
+        name: 'Ada',
+        posts: [
+          { title: 'a', views: 10 },
+          { title: 'b', views: 20 },
+        ],
+      },
       { id: '2', name: 'Grace', posts: [{ title: 'c', views: 5 }] },
       { id: '3', name: 'Alan', posts: [] },
     ];
@@ -435,7 +442,10 @@ describe('memoryAdapter', () => {
         ],
       });
       const byId = Object.fromEntries(
-        result.data.map((row) => [row.id, row as UserWithPosts & { postsCount: number; viewsSum: number }])
+        result.data.map((row) => [
+          row.id,
+          row as UserWithPosts & { postsCount: number; viewsSum: number },
+        ])
       );
       expect(byId['1']?.postsCount).toBe(2);
       expect(byId['1']?.viewsSum).toBe(30);

--- a/packages/core/tests/adapters/memory-adapter.test.ts
+++ b/packages/core/tests/adapters/memory-adapter.test.ts
@@ -399,5 +399,84 @@ describe('memoryAdapter', () => {
       delete: false,
     });
     expect(adapter.meta.supportsFilterGroups).toBe(true);
+    expect(adapter.meta.capabilities?.aggregates).toMatchObject({
+      render: true,
+      filter: true,
+      sort: true,
+      fns: expect.arrayContaining(['count', 'sum']),
+    });
+  });
+
+  describe('derived aggregates (plan 060)', () => {
+    interface UserWithPosts {
+      id: string;
+      name: string;
+      posts: { title: string; views: number }[];
+    }
+
+    const users: UserWithPosts[] = [
+      { id: '1', name: 'Ada', posts: [{ title: 'a', views: 10 }, { title: 'b', views: 20 }] },
+      { id: '2', name: 'Grace', posts: [{ title: 'c', views: 5 }] },
+      { id: '3', name: 'Alan', posts: [] },
+    ];
+
+    it('renders count and sum over nested arrays', async () => {
+      const adapter = memoryAdapter(users);
+      const result = await adapter.fetchData({
+        derived: [
+          { columnId: 'postsCount', kind: 'aggregate', relation: 'posts', fn: 'count' },
+          {
+            columnId: 'viewsSum',
+            kind: 'aggregate',
+            relation: 'posts',
+            fn: 'sum',
+            field: 'views',
+          },
+        ],
+      });
+      const byId = Object.fromEntries(
+        result.data.map((row) => [row.id, row as UserWithPosts & { postsCount: number; viewsSum: number }])
+      );
+      expect(byId['1']?.postsCount).toBe(2);
+      expect(byId['1']?.viewsSum).toBe(30);
+      expect(byId['2']?.postsCount).toBe(1);
+      expect(byId['3']?.postsCount).toBe(0);
+    });
+
+    it('filters on count inside an OR group', async () => {
+      const adapter = memoryAdapter(users);
+      const filters: FilterGroupNode = {
+        kind: 'group',
+        logic: 'or',
+        children: [
+          {
+            columnId: 'postsCount',
+            type: 'number',
+            operator: 'greaterThan',
+            values: [1],
+          },
+          {
+            columnId: 'name',
+            type: 'text',
+            operator: 'equals',
+            values: ['Alan'],
+          },
+        ],
+      };
+      const result = await adapter.fetchData({
+        filters,
+        derived: [{ columnId: 'postsCount', kind: 'aggregate', relation: 'posts', fn: 'count' }],
+      });
+      expect(result.data.map((r) => r.id).sort()).toEqual(['1', '3']);
+    });
+
+    it('sorts by derived count', async () => {
+      const adapter = memoryAdapter(users);
+      const result = await adapter.fetchData({
+        sorting: [{ columnId: 'postsCount', direction: 'desc' }],
+        derived: [{ columnId: 'postsCount', kind: 'aggregate', relation: 'posts', fn: 'count' }],
+      });
+      expect(result.data.map((r) => r.id)).toEqual(['1', '2', '3']);
+    });
   });
 });

--- a/packages/core/tests/adapters/memory-adapter.test.ts
+++ b/packages/core/tests/adapters/memory-adapter.test.ts
@@ -488,5 +488,11 @@ describe('memoryAdapter', () => {
       });
       expect(result.data.map((r) => r.id)).toEqual(['1', '2', '3']);
     });
+
+    it('rejects facets and min/max on derived aggregate columns', async () => {
+      const adapter = memoryAdapter(users, { derivedColumnIds: ['postsCount'] });
+      await expect(adapter.getFacetedValues('postsCount')).rejects.toThrow(/derived aggregate/);
+      await expect(adapter.getMinMaxValues('postsCount')).rejects.toThrow(/derived aggregate/);
+    });
   });
 });

--- a/packages/core/tests/builders/path-builders.test.ts
+++ b/packages/core/tests/builders/path-builders.test.ts
@@ -213,6 +213,8 @@ describe('path builders (plan 018)', () => {
 
       expect(def.type).toBe('custom');
       expect(def.id).toBe('custom');
+      expect(def.filterable).toBe(false);
+      expect(def.sortable).toBe(false);
     });
 
     it('t.computed() infers the value type from the accessor and humanizes the id for the default label', () => {
@@ -222,7 +224,45 @@ describe('path builders (plan 018)', () => {
       expect(def.id).toBe('fullName');
       expect(def.displayName).toBe('Full Name');
       expect(def.type).toBe('custom');
+      expect(def.filterable).toBe(false);
+      expect(def.sortable).toBe(false);
       expect(def.accessor({ name: 'Ada', age: 30, posts: [] })).toBe('Ada!!');
+    });
+  });
+
+  describe('t.count() / t.aggregate() (plan 060)', () => {
+    it('t.count(relation) defaults id to `${relation}Count` with a count derived spec', () => {
+      const t = createPathColumnFactory<User>();
+      const def = t.count('posts').build();
+
+      expect(def.id).toBe('postsCount');
+      expect(def.type).toBe('number');
+      expect(def.filterable).toBe(true);
+      expect(def.sortable).toBe(true);
+      expect(def.derived).toEqual({ kind: 'aggregate', relation: 'posts', fn: 'count' });
+      expect(
+        def.accessor({ name: 'Ada', age: 30, posts: [], postsCount: 3 } as User & {
+          postsCount: number;
+        })
+      ).toBe(3);
+    });
+
+    it('t.aggregate requires field for non-count fns', () => {
+      const t = createPathColumnFactory<User>();
+      expect(() => t.aggregate('total', { relation: 'posts', fn: 'sum' })).toThrow(/field/);
+    });
+
+    it('t.aggregate(id, spec) carries the general derived shape', () => {
+      const t = createPathColumnFactory<User>();
+      const def = t.aggregate('postTitles', { relation: 'posts', fn: 'sum', field: 'age' }).build();
+
+      expect(def.id).toBe('postTitles');
+      expect(def.derived).toEqual({
+        kind: 'aggregate',
+        relation: 'posts',
+        fn: 'sum',
+        field: 'age',
+      });
     });
   });
 });

--- a/packages/core/tests/builders/path-builders.test.ts
+++ b/packages/core/tests/builders/path-builders.test.ts
@@ -231,7 +231,7 @@ describe('path builders (plan 018)', () => {
   });
 
   describe('t.count() / t.aggregate() (plan 060)', () => {
-    it('t.count(relation) defaults id to `${relation}Count` with a count derived spec', () => {
+    it('t.count(relation) defaults id to relationCount with a count derived spec', () => {
       const t = createPathColumnFactory<User>();
       const def = t.count('posts').build();
 

--- a/packages/core/tests/builders/path-builders.test.ts
+++ b/packages/core/tests/builders/path-builders.test.ts
@@ -247,6 +247,12 @@ describe('path builders (plan 018)', () => {
       ).toBe(3);
     });
 
+    it('t.count rejects an empty relation', () => {
+      const t = createPathColumnFactory<User>();
+      expect(() => t.count('')).toThrow(/non-empty/);
+      expect(() => t.count('   ')).toThrow(/non-empty/);
+    });
+
     it('t.aggregate requires field for non-count fns', () => {
       const t = createPathColumnFactory<User>();
       expect(() => t.aggregate('total', { relation: 'posts', fn: 'sum' })).toThrow(/field/);

--- a/packages/core/tests/builders/path-builders.test.ts
+++ b/packages/core/tests/builders/path-builders.test.ts
@@ -249,8 +249,18 @@ describe('path builders (plan 018)', () => {
 
     it('t.count rejects an empty relation', () => {
       const t = createPathColumnFactory<User>();
-      expect(() => t.count('')).toThrow(/non-empty/);
-      expect(() => t.count('   ')).toThrow(/non-empty/);
+      expect(() => t.count('')).toThrow(/t\.count.*non-empty/);
+      expect(() => t.count('   ')).toThrow(/t\.count.*non-empty/);
+    });
+
+    it('t.aggregate rejects an empty relation', () => {
+      const t = createPathColumnFactory<User>();
+      expect(() => t.aggregate('total', { relation: '', fn: 'count' })).toThrow(
+        /t\.aggregate.*non-empty/
+      );
+      expect(() => t.aggregate('total', { relation: '   ', fn: 'sum', field: 'amount' })).toThrow(
+        /t\.aggregate.*non-empty/
+      );
     });
 
     it('t.aggregate requires field for non-count fns', () => {

--- a/packages/core/tests/factory.test.ts
+++ b/packages/core/tests/factory.test.ts
@@ -288,6 +288,52 @@ describe('betterTables() instance', () => {
       });
       expect(true).toBe(true);
     });
+
+    it('attaches derived specs from the table definition (plan 060)', async () => {
+      let capturedParams: FetchDataParams | undefined;
+      const adapter = createMockAdapter();
+      adapter.meta = {
+        ...adapter.meta,
+        capabilities: {
+          aggregates: {
+            fns: ['count', 'sum', 'avg', 'min', 'max'],
+            render: true,
+            filter: true,
+            sort: true,
+          },
+        },
+      };
+      adapter.fetchData = async (params) => {
+        capturedParams = params;
+        return {
+          data: [],
+          total: 0,
+          pagination: { page: 1, limit: 20, totalPages: 0, hasNext: false, hasPrev: false },
+        };
+      };
+      const tables = betterTables({ database: adapter });
+      const usersTable = defineTable<typeof tables>()('users', (t) => ({
+        columns: [t.text('name'), t.count('posts')],
+      }));
+
+      await tables.fetchData(usersTable, { columns: ['name', 'postsCount'] });
+
+      expect(capturedParams?.derived).toEqual([
+        { columnId: 'postsCount', kind: 'aggregate', relation: 'posts', fn: 'count' },
+      ]);
+    });
+
+    it('throws when derived columns are present but the adapter lacks capabilities.aggregates', async () => {
+      const adapter = createMockAdapter();
+      const tables = betterTables({ database: adapter });
+      const usersTable = defineTable<typeof tables>()('users', (t) => ({
+        columns: [t.text('name'), t.count('posts')],
+      }));
+
+      await expect(tables.fetchData(usersTable, { columns: ['postsCount'] })).rejects.toThrow(
+        /capabilities\.aggregates/
+      );
+    });
   });
 
   describe('tables.createRecord/updateRecord/deleteRecord -- table-scoped writes (plan 047)', () => {

--- a/packages/core/tests/lib/derived-params.test.ts
+++ b/packages/core/tests/lib/derived-params.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  assertAggregateCapabilities,
+  collectDerivedFetchSpecs,
+  withDerivedFetchParams,
+} from '../../src/lib/derived-params';
+import type { AdapterMeta } from '../../src/types/adapter';
+import type { ColumnDefinition } from '../../src/types/column';
+
+const baseMeta: AdapterMeta = {
+  name: 'stub',
+  version: '1.0.0',
+  features: {
+    create: false,
+    read: true,
+    update: false,
+    delete: false,
+    bulkOperations: false,
+    realTimeUpdates: false,
+    export: false,
+    transactions: false,
+  },
+  supportedColumnTypes: ['number'],
+  supportedOperators: {
+    text: [],
+    number: ['greaterThan'],
+    date: [],
+    boolean: [],
+    option: [],
+    multiOption: [],
+    currency: [],
+    percentage: [],
+    url: [],
+    email: [],
+    phone: [],
+    json: [],
+    custom: [],
+  },
+};
+
+const columns = [
+  {
+    id: 'name',
+    displayName: 'Name',
+    type: 'text',
+    accessor: (r: { name: string }) => r.name,
+  },
+  {
+    id: 'postsCount',
+    displayName: 'Posts',
+    type: 'number',
+    accessor: (r: { postsCount?: number }) => r.postsCount ?? 0,
+    derived: { kind: 'aggregate', relation: 'posts', fn: 'count' },
+  },
+] as ColumnDefinition[];
+
+describe('derived-params (plan 060)', () => {
+  it('collectDerivedFetchSpecs scopes to requested column ids', () => {
+    expect(collectDerivedFetchSpecs(columns, ['name'])).toEqual([]);
+    expect(collectDerivedFetchSpecs(columns, ['postsCount'])).toEqual([
+      { columnId: 'postsCount', kind: 'aggregate', relation: 'posts', fn: 'count' },
+    ]);
+    expect(collectDerivedFetchSpecs(columns)).toHaveLength(1);
+  });
+
+  it('assertAggregateCapabilities rejects missing capability block', () => {
+    expect(() =>
+      assertAggregateCapabilities(
+        baseMeta,
+        [{ columnId: 'postsCount', kind: 'aggregate', relation: 'posts', fn: 'count' }],
+        {}
+      )
+    ).toThrow(/capabilities\.aggregates/);
+  });
+
+  it('withDerivedFetchParams attaches specs when capable', () => {
+    const meta: AdapterMeta = {
+      ...baseMeta,
+      capabilities: {
+        aggregates: {
+          fns: ['count', 'sum', 'avg', 'min', 'max'],
+          render: true,
+          filter: true,
+          sort: true,
+        },
+      },
+    };
+    const params = withDerivedFetchParams(columns, { columns: ['postsCount'] }, meta);
+    expect(params.derived).toEqual([
+      { columnId: 'postsCount', kind: 'aggregate', relation: 'posts', fn: 'count' },
+    ]);
+  });
+});

--- a/packages/core/tests/lib/derived-params.test.ts
+++ b/packages/core/tests/lib/derived-params.test.ts
@@ -6,6 +6,7 @@ import {
 } from '../../src/lib/derived-params';
 import type { AdapterMeta } from '../../src/types/adapter';
 import type { ColumnDefinition } from '../../src/types/column';
+import type { AggregateCapabilities } from '../../src/types/derived';
 
 const baseMeta: AdapterMeta = {
   name: 'stub',
@@ -38,6 +39,13 @@ const baseMeta: AdapterMeta = {
   },
 };
 
+const fullAggregates: AggregateCapabilities = {
+  fns: ['count', 'sum', 'avg', 'min', 'max'],
+  render: true,
+  filter: true,
+  sort: true,
+};
+
 const columns = [
   {
     id: 'name',
@@ -54,40 +62,109 @@ const columns = [
   },
 ] as ColumnDefinition[];
 
+const postsCountSpec = {
+  columnId: 'postsCount',
+  kind: 'aggregate' as const,
+  relation: 'posts',
+  fn: 'count' as const,
+};
+
 describe('derived-params (plan 060)', () => {
   it('collectDerivedFetchSpecs scopes to requested column ids', () => {
     expect(collectDerivedFetchSpecs(columns, ['name'])).toEqual([]);
-    expect(collectDerivedFetchSpecs(columns, ['postsCount'])).toEqual([
-      { columnId: 'postsCount', kind: 'aggregate', relation: 'posts', fn: 'count' },
-    ]);
+    expect(collectDerivedFetchSpecs(columns, ['postsCount'])).toEqual([postsCountSpec]);
     expect(collectDerivedFetchSpecs(columns)).toHaveLength(1);
   });
 
   it('assertAggregateCapabilities rejects missing capability block', () => {
+    expect(() => assertAggregateCapabilities(baseMeta, [postsCountSpec], {})).toThrow(
+      /capabilities\.aggregates/
+    );
+  });
+
+  it('assertAggregateCapabilities rejects aggregates.render=false', () => {
+    const meta: AdapterMeta = {
+      ...baseMeta,
+      capabilities: { aggregates: { ...fullAggregates, render: false } },
+    };
+    expect(() => assertAggregateCapabilities(meta, [postsCountSpec], {})).toThrow(
+      /aggregates\.render=false/
+    );
+  });
+
+  it('assertAggregateCapabilities rejects unsupported aggregate fn', () => {
+    const meta: AdapterMeta = {
+      ...baseMeta,
+      capabilities: {
+        aggregates: { fns: ['count'], render: true, filter: true, sort: true },
+      },
+    };
     expect(() =>
       assertAggregateCapabilities(
-        baseMeta,
-        [{ columnId: 'postsCount', kind: 'aggregate', relation: 'posts', fn: 'count' }],
+        meta,
+        [{ columnId: 'total', kind: 'aggregate', relation: 'orders', fn: 'sum', field: 'amount' }],
         {}
       )
-    ).toThrow(/capabilities\.aggregates/);
+    ).toThrow(/does not support aggregate fn 'sum'/);
+  });
+
+  it('assertAggregateCapabilities rejects aggregates.filter=false when filtering derived', () => {
+    const meta: AdapterMeta = {
+      ...baseMeta,
+      capabilities: { aggregates: { ...fullAggregates, filter: false } },
+    };
+    expect(() =>
+      assertAggregateCapabilities(meta, [postsCountSpec], {
+        filters: [{ columnId: 'postsCount', type: 'number', operator: 'greaterThan', values: [1] }],
+      })
+    ).toThrow(/aggregates\.filter=false/);
+  });
+
+  it('assertAggregateCapabilities rejects aggregates.sort=false when sorting derived', () => {
+    const meta: AdapterMeta = {
+      ...baseMeta,
+      capabilities: { aggregates: { ...fullAggregates, sort: false } },
+    };
+    expect(() =>
+      assertAggregateCapabilities(meta, [postsCountSpec], {
+        sorting: [{ columnId: 'postsCount', direction: 'asc' }],
+      })
+    ).toThrow(/aggregates\.sort=false/);
   });
 
   it('withDerivedFetchParams attaches specs when capable', () => {
     const meta: AdapterMeta = {
       ...baseMeta,
-      capabilities: {
-        aggregates: {
-          fns: ['count', 'sum', 'avg', 'min', 'max'],
-          render: true,
-          filter: true,
-          sort: true,
-        },
-      },
+      capabilities: { aggregates: { ...fullAggregates } },
     };
     const params = withDerivedFetchParams(columns, { columns: ['postsCount'] }, meta);
-    expect(params.derived).toEqual([
-      { columnId: 'postsCount', kind: 'aggregate', relation: 'posts', fn: 'count' },
-    ]);
+    expect(params.derived).toEqual([postsCountSpec]);
+  });
+
+  it('withDerivedFetchParams returns params unchanged when no derived columns apply', () => {
+    const meta: AdapterMeta = {
+      ...baseMeta,
+      capabilities: { aggregates: { ...fullAggregates } },
+    };
+    const input = { columns: ['name'] as string[] };
+    const params = withDerivedFetchParams(columns, input, meta);
+    expect(params).toBe(input);
+    expect(params.derived).toBeUndefined();
+  });
+
+  it('withDerivedFetchParams includes derived columns referenced by filters even if omitted from columns', () => {
+    const meta: AdapterMeta = {
+      ...baseMeta,
+      capabilities: { aggregates: { ...fullAggregates } },
+    };
+    const params = withDerivedFetchParams(
+      columns,
+      {
+        columns: ['name'],
+        filters: [{ columnId: 'postsCount', type: 'number', operator: 'greaterThan', values: [2] }],
+      },
+      meta
+    );
+    expect(params.derived).toEqual([postsCountSpec]);
   });
 });

--- a/packages/ui/src/hooks/use-table-data.ts
+++ b/packages/ui/src/hooks/use-table-data.ts
@@ -1,12 +1,14 @@
 'use client';
 
 import type {
+  ColumnDefinition,
   FetchDataParams,
   FetchDataResult,
   FilterState,
   PaginationState,
   TableAdapter,
 } from '@better-tables/core';
+import { collectDerivedFetchSpecs } from '@better-tables/core';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 // Stable defaults so omitted `filters`/`params` don't recreate `fetchData`'s
@@ -34,6 +36,12 @@ export interface UseTableDataOptions<TData = unknown> {
    * Pass a referentially stable object when possible.
    */
   params?: Record<string, unknown>;
+
+  /**
+   * Column definitions — used to attach plan-060 `derived` specs onto fetch
+   * params (same seam as the instance `fetchData` path).
+   */
+  columns?: ColumnDefinition[];
 
   /** Whether to fetch data automatically */
   enabled?: boolean;
@@ -93,6 +101,7 @@ export function useTableData<TData = unknown>({
   filters = EMPTY_FILTERS,
   pagination,
   params = EMPTY_PARAMS,
+  columns,
   enabled = true,
 }: UseTableDataOptions<TData>): UseTableDataResult<TData> {
   const [data, setData] = useState<TData[]>([]);
@@ -132,6 +141,13 @@ export function useTableData<TData = unknown>({
         };
       }
 
+      if (columns && columns.length > 0) {
+        const derived = collectDerivedFetchSpecs(columns, fetchParams.columns);
+        if (derived.length > 0) {
+          fetchParams.derived = derived;
+        }
+      }
+
       const result = await adapter.fetchData(fetchParams);
 
       if (requestId !== requestIdRef.current || abortController.signal.aborted) {
@@ -152,7 +168,7 @@ export function useTableData<TData = unknown>({
         setLoading(false);
       }
     }
-  }, [adapter, filters, pagination, params, enabled]);
+  }, [adapter, filters, pagination, params, columns, enabled]);
 
   const refetch = useCallback(async () => {
     await fetchData();

--- a/packages/ui/src/hooks/use-table-data.ts
+++ b/packages/ui/src/hooks/use-table-data.ts
@@ -8,15 +8,16 @@ import type {
   PaginationState,
   TableAdapter,
 } from '@better-tables/core';
-import { collectDerivedFetchSpecs } from '@better-tables/core';
+import { withDerivedFetchParams } from '@better-tables/core';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-// Stable defaults so omitted `filters`/`params` don't recreate `fetchData`'s
-// identity (and retrigger the fetch effect) on every render the way inline
-// `= []` / `= {}` default-parameter literals would. Frozen so a shared
-// constant can't be mutated via fetchParams (e.g. filters.push).
+// Stable defaults so omitted `filters`/`params`/`columns` don't recreate
+// `fetchData`'s identity (and retrigger the fetch effect) on every render
+// the way inline `= []` / `= {}` default-parameter literals would. Frozen so
+// a shared constant can't be mutated via fetchParams (e.g. filters.push).
 const EMPTY_FILTERS = Object.freeze([] as FilterState[]) as FilterState[];
 const EMPTY_PARAMS = Object.freeze({}) as Record<string, unknown>;
+const EMPTY_COLUMNS = Object.freeze([] as ColumnDefinition[]) as ColumnDefinition[];
 
 export interface UseTableDataOptions<TData = unknown> {
   /** Table adapter for data fetching */
@@ -38,8 +39,10 @@ export interface UseTableDataOptions<TData = unknown> {
   params?: Record<string, unknown>;
 
   /**
-   * Column definitions — used to attach plan-060 `derived` specs onto fetch
-   * params (same seam as the instance `fetchData` path).
+   * Column definitions — used to attach `derived` aggregate specs onto fetch
+   * params (same seam as instance `fetchData` / {@link withDerivedFetchParams}).
+   * Pass a referentially stable array when possible; an inline `columns={[...]}`
+   * literal recreates `fetchData` every render and can loop refetches.
    */
   columns?: ColumnDefinition[];
 
@@ -101,7 +104,7 @@ export function useTableData<TData = unknown>({
   filters = EMPTY_FILTERS,
   pagination,
   params = EMPTY_PARAMS,
-  columns,
+  columns = EMPTY_COLUMNS,
   enabled = true,
 }: UseTableDataOptions<TData>): UseTableDataResult<TData> {
   const [data, setData] = useState<TData[]>([]);
@@ -141,14 +144,12 @@ export function useTableData<TData = unknown>({
         };
       }
 
-      if (columns && columns.length > 0) {
-        const derived = collectDerivedFetchSpecs(columns, fetchParams.columns);
-        if (derived.length > 0) {
-          fetchParams.derived = derived;
-        }
-      }
+      const withDerived =
+        columns.length > 0
+          ? withDerivedFetchParams(columns, fetchParams, adapter.meta)
+          : fetchParams;
 
-      const result = await adapter.fetchData(fetchParams);
+      const result = await adapter.fetchData(withDerived);
 
       if (requestId !== requestIdRef.current || abortController.signal.aborted) {
         return;

--- a/plans/README.md
+++ b/plans/README.md
@@ -33,7 +33,7 @@ loose backlog. Deferred items are at the bottom.
 ## Where we are (2026-07-22)
 
 **0.6 is shippable.** Waves A–D are merged to `main`. Open work is Wave E
-plus two leftovers (048, 060). 058 stays deferred.
+plus leftover 048. 058 stays deferred; **060 landed**.
 
 | Wave | Plans | Outcome |
 |------|-------|---------|
@@ -41,7 +41,7 @@ plus two leftovers (048, 060). 058 stays deferred.
 | A — pre-0.6 | 033–036, 040, 046, 047 | [PR #83](https://github.com/Better-Tables/better-tables/pull/83) |
 | B — quality | 037–039, 041–045, 051, 052 | [PR #85](https://github.com/Better-Tables/better-tables/pull/85); reconcile audit at `7b58ed8` verified all 17 criteria |
 | C — features | 053–055, 049, 050 | Editable cells / auto columns / direct save ([PR #86](https://github.com/Better-Tables/better-tables/pull/86)); plugins ([PR #101](https://github.com/Better-Tables/better-tables/pull/101)); export UI ([PR #102](https://github.com/Better-Tables/better-tables/pull/102)). **048 still open** |
-| D — hygiene + modules | 056, 057, 059 | Typecheck order + contract cleanup ([PR #99](https://github.com/Better-Tables/better-tables/pull/99)); UI modules + actions opt-in ([PR #100](https://github.com/Better-Tables/better-tables/pull/100)). **058 deferred; 060 open** |
+| D — hygiene + modules | 056, 057, 059, 060 | Typecheck order + contract cleanup ([PR #99](https://github.com/Better-Tables/better-tables/pull/99)); UI modules + actions opt-in ([PR #100](https://github.com/Better-Tables/better-tables/pull/100)); derived aggregates (`t.count`). **058 deferred** |
 | Docs / demo | — | Handbook overhaul + `memoryAdapter` in core ([PR #88](https://github.com/Better-Tables/better-tables/pull/88)); marketing redesign ([PR #87](https://github.com/Better-Tables/better-tables/pull/87)) |
 
 ---
@@ -58,31 +58,36 @@ plus two leftovers (048, 060). 058 stays deferred.
 
 | Plan | What | Depends on | Status |
 |------|------|------------|--------|
-| [060](060-derived-aggregate-columns.md) | Server-derived aggregates: `t.count('posts')` render/filter/sort via drizzle computed-fields + memoryAdapter nested arrays; honest `filterable`/`sortable` defaults for `t.computed` | none | **TODO** (P2) |
 | [058](058-global-search.md) | Global search as filter sugar over `.searchable()` columns | none | **DEFERRED** (2026-07-21) — plan intact; `FetchDataParams.search` stays declared-but-unconsumed |
 
 ### Wave E — adapter expansion
 
 | Plan | What | Depends on | Status |
 |------|------|------------|--------|
-| [061](061-prisma-adapter-full-parity.md) | Prisma at full Drizzle parity. Phase 1 = shared conformance suite (memory + drizzle). Later phases: reads, facets, schema, writes, export, aggregates | Phase 7 needs 060 (skip cleanly if not landed) | **TODO** (P2) |
-| [062](062-kysely-adapter.md) | Kysely adapter (SQL-native composition; full aggregate parity) | 061 Phases 1 + 6; aggregates need 060 | **TODO** |
+| [061](061-prisma-adapter-full-parity.md) | Prisma at full Drizzle parity. Phase 1 = shared conformance suite (memory + drizzle). Later phases: reads, facets, schema, writes, export, aggregates | Phase 7 can use 060 (landed) | **TODO** (P2) |
+| [062](062-kysely-adapter.md) | Kysely adapter (SQL-native composition; full aggregate parity) | 061 Phases 1 + 6; aggregates need 060 (done) | **TODO** |
 
 008 is superseded by 061 — do not execute 008.
+
+**060 DONE** (2026-07-22): `t.count` / `t.aggregate`, `FetchDataParams.derived`,
+Drizzle correlated-subquery lowering + `FilterGroupNode` walk for
+`filterSql`/derived specs (051 computed-TREE gap closed for that path;
+legacy callback-`filter` still throws), memoryAdapter nested-array eval,
+homepage `postsCount` dogfood. Design record: `plans/design/derived-columns.md`.
 
 ---
 
 ## Order notes (open plans only)
 
-- **060 first** if DX is the priority — unblocks honest derived columns and
-  Wave E aggregates. No hard deps; 058 is deferred so no `factory.ts` race.
 - **061 Phase 1** anytime — conformance suite is valuable alone and required
-  for 062. Phases merge independently; skip Phase 7 until 060 lands.
-- **048** anytime after 0.6 — no file overlap with 060/061; follow plan 041
+  for 062. Phases merge independently; Phase 7 can implement aggregates against
+  the 060 capability shape.
+- **048** anytime after 0.6 — no file overlap with 061; follow plan 041
   handler idioms and plan 042 input-test patterns.
 - **062** only after 061 Phases 1 + 6.
-- Capability asymmetry to design for in 060: Prisma can sort-by-count but
-  not filter-by-count; Kysely/Drizzle do both.
+- Capability asymmetry (from 060 design): Prisma can sort-by-count but
+  not filter-by-count; Kysely/Drizzle do both — declare honestly in
+  `AdapterMeta.capabilities.aggregates`.
 
 Standing product decisions that still constrain open work:
 
@@ -189,7 +194,7 @@ Details and criteria live in each plan file. One line per plan.
 | 043 | Cross-package integration harness (Playwright E2E deferred) |
 | 044 | Drizzle module decomposition |
 | 045 | Column-builder dedup |
-| 051 | Robustness sweep (detectDriver + computed-TREE documented/deferred) |
+| 051 | Robustness sweep (detectDriver + computed-TREE documented/deferred; TREE closed for `filterSql`/derived in 060) |
 | 052 | CI/toolchain hygiene; blocking lint |
 
 ### Wave C — [PR #86](https://github.com/Better-Tables/better-tables/pull/86), [#101](https://github.com/Better-Tables/better-tables/pull/101), [#102](https://github.com/Better-Tables/better-tables/pull/102)
@@ -202,13 +207,14 @@ Details and criteria live in each plan file. One line per plan.
 | 049 | Plugin hooks `beforeFetch`/`afterFetch` + `logPlugin()` |
 | 050 | Export UI (`ExportButton`, `csvExport()`, 50k row cap) |
 
-### Wave D — [PR #99](https://github.com/Better-Tables/better-tables/pull/99), [#100](https://github.com/Better-Tables/better-tables/pull/100)
+### Wave D — [PR #99](https://github.com/Better-Tables/better-tables/pull/99), [#100](https://github.com/Better-Tables/better-tables/pull/100), 060
 
 | Plan | What |
 |------|------|
 | 056 | Deterministic typecheck (`dependsOn` build; site override) |
 | 057 | Dead contract surface removed (reserved flags/types) |
 | 059 | UI modules tier + actions as first opt-in module |
+| 060 | Derived aggregates (`t.count` / `t.aggregate`); honest custom defaults |
 
 ### Notable non-plan merges
 
@@ -232,7 +238,7 @@ DX-10, `"use client"` unbundle, bun hoisted linker). Do not re-file.
   flag + feature together.
 - **Realtime UI** — UI flag removed; drizzle `subscribe` is real. Future
   059-style module (+ optional plugin).
-- **Facets on derived columns** — fast-follow after 060.
+- **Facets on derived columns** — fast-follow after 060 (landed).
 - **Saved/named views** (`savedFilters()` plugin) — after plugin seam has
   a second real plugin; sketch in `table-definition-dx.md`.
 - **Data import** — other half of export; large design, not near-term.

--- a/plans/design/derived-columns.md
+++ b/plans/design/derived-columns.md
@@ -1,0 +1,137 @@
+# Design: Server-derived columns (aggregates)
+
+> Design deliverable for **Step 1** of `plans/060-derived-aggregate-columns.md`.
+> Decides the serializable spec shape, transport, capability declaration,
+> honest builder defaults, and SQL lowering strategy. Prisma (061) and Kysely
+> (062) declare against the capability shape chosen here.
+
+---
+
+## 1. Spec shape (declarative, serializable)
+
+```ts
+interface DerivedColumnSpec {
+  kind: 'aggregate';
+  /** Relation name on the primary table (e.g. `'posts'`). Single hop. */
+  relation: string;
+  fn: 'count' | 'sum' | 'avg' | 'min' | 'max';
+  /** Required for sum/avg/min/max; ignored for count. */
+  field?: string;
+}
+```
+
+**Why no functions or SQL strings:** specs cross the HTTP wire and must be
+validated server-side against the schema. The server builds SQL from an enum
++ schema-validated identifiers.
+
+| `fn` | Result type | `field` |
+|------|-------------|---------|
+| `count` | `number` | ignored |
+| `sum` / `avg` / `min` / `max` | follows target field (numeric) | required |
+
+`distinct` (present on toolkit `AggregateColumn`) is **deferred** — not in
+this union. Nested-relation paths (`posts.comments`) are deferred; `relation`
+is a single hop by design.
+
+---
+
+## 2. Transport: `FetchDataParams.derived`
+
+```ts
+FetchDataParams.derived?: Array<{ columnId: string } & DerivedColumnSpec>
+```
+
+Attached by the two layers that own column definitions:
+
+1. Core instance `fetchData` (`factory.ts`) — from `table.columns`
+2. UI `use-table-data` — from its columns prop
+
+**Not** adapter-constructor config. Rationale: stateless per-request, works
+over HTTP unchanged, multi-table safe, keeps `defineTable` the single source
+of truth. The adapter validates every spec against schema/relationships and
+throws `SchemaError` on unknown relation/field or non-`many` cardinality.
+
+When `params.columns` is set, only derived specs for requested column ids are
+attached. When omitted, all derived columns on the table definition are
+attached.
+
+---
+
+## 3. Security
+
+Declarative-only is the injection boundary. A malicious client can at worst
+request an aggregate over data the endpoint already serves. HTTP allow-lists
+(docs `adapters/http.mdx`) apply to derived `columnId`s like any other id.
+Adapters MUST build identifiers from relationship metadata, never from raw
+client strings for table/column names (only enum `fn` + validated keys).
+
+---
+
+## 4. Honest defaults
+
+| Builder | `filterable` / `sortable` default | Notes |
+|---------|-----------------------------------|--------|
+| `t.computed` / `t.custom` (`type: 'custom'`) | **false** / **false** | Client-only display; no DB column. Explicit `.filterable(true)` still works. |
+| `t.count` / `t.aggregate` | **true** / **true** | Server-backed via `derived`; number operators work. |
+
+---
+
+## 5. Capability declaration (per-operation granularity)
+
+Plan 061: Prisma can SELECT and ORDER BY a relation count but cannot
+WHERE-by-count. A flat `fns: string[]` cannot describe that. Shape:
+
+```ts
+AdapterMeta.capabilities?: {
+  aggregates?: {
+    fns: Array<'count' | 'sum' | 'avg' | 'min' | 'max'>;
+    render: boolean;
+    filter: boolean;
+    sort: boolean;
+  };
+}
+```
+
+- **Drizzle + memoryAdapter (this plan):** all fns; `render/filter/sort: true`.
+- **Prisma (061 Phase 7):** likely `filter: false` with count still in `fns`.
+- Core instance fetch throws early when specs are present and the adapter
+  lacks a sufficient capability (missing block, missing `fn`, or
+  `render === false`). Filter/sort requests are enforced at the adapter when
+  those flags are false (or core can preflight when filters/sorts reference
+  derived ids — prefer clear errors).
+
+Vocabulary: use **capabilities** and the key **aggregates** (from
+`table-definition-dx.md`).
+
+---
+
+## 6. SQL strategy
+
+Correlated subqueries, lowered into the existing drizzle `ComputedFieldConfig`
+pipeline (`filterSql` / `sortSql` / SELECT alias). No parallel pipeline. No
+`GROUP BY`/`HAVING` (preserves pagination `total` and plan 003's
+count-inflation hardening).
+
+Example:
+
+```sql
+(SELECT count(*) FROM posts WHERE posts.user_id = users.id) AS "postsCount"
+```
+
+`FilterGroupNode` trees: substitute derived/`filterSql` leaves in place,
+preserving AND/OR. Legacy callback-`filter` computed fields still reject
+trees (with advice that does **not** recommend unconditional flattening).
+
+---
+
+## 7. Builder API
+
+```ts
+t.count('posts')                          // id postsCount, fn count
+t.aggregate('revenue', { relation: 'orders', fn: 'sum', field: 'amount' })
+t.count('posts').displayName('Posts')     // NumberColumnBuilder chain
+```
+
+Relation name is a runtime-validated string (schema check in the adapter).
+Type-level relation autocomplete is a stretch — ship runtime validation as
+the contract.


### PR DESCRIPTION
## Summary
- Add declarative `t.count` / `t.aggregate` derived columns with serializable `DerivedColumnSpec` transport on `FetchDataParams.derived`, plus `AdapterMeta.capabilities.aggregates` checks on instance fetch / `useTableData`.
- Lower specs in Drizzle to correlated subqueries via the computed-fields pipeline; walk `FilterGroupNode` trees for `filterSql`/derived leaves (OR semantics preserved); keep throwing for legacy callback-`filter` computed fields.
- `memoryAdapter` evaluates nested-array aggregates; homepage dogfoods `postsCount`; docs + core/drizzle minor changesets; ledger marks 060 DONE (051 computed-TREE closed for `filterSql`/derived).

## Test plan
- [x] `cd packages/core && bun test`
- [x] `cd packages/adapters/drizzle && bun test` (sqlite always; pg/mysql env-gated)
- [x] `cd packages/ui && bun test`
- [x] `cd apps/marketing && bun test`
- [x] `bun run typecheck`
- [x] Grep: no “flatten the tree” in drizzle src; `t.count(` in ≥2 doc pages
- [ ] Manual: marketing `/` — Posts column counts, `> 5` filter, sort, combined filter + pagination `total`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds server-derived aggregate columns with `t.count` / `t.aggregate` that adapters can render, filter, and sort. Drizzle compiles them to correlated subqueries with filter-tree support; the core `memoryAdapter` evaluates nested arrays; client-only `t.computed`/`t.custom` now default to not filterable/sortable.

- New Features
  - Core: Declarative derived specs on columns, transported via `FetchDataParams.derived`; instance `fetchData` and `useTableData` attach specs and enforce `AdapterMeta.capabilities.aggregates`.
  - `@better-tables/adapters-drizzle`: Lowers derived specs to correlated subqueries for SELECT/WHERE/ORDER BY; walks `FilterGroupNode` trees for `filterSql`/derived leaves; exposes `capabilities.aggregates` with `count/sum/avg/min/max`.
  - Core `memoryAdapter`: Materializes aggregates from nested arrays before filter/sort; declares full aggregate capabilities.
  - DX: `t.count('posts')` yields `postsCount` (number, filterable, sortable). Docs and homepage demo updated; `apps/marketing` typecheck now runs `fumadocs-mdx` before `tsc`.

- Bug Fixes
  - Gate tree compilation to `filterSql`/derived leaves; legacy callback-`filter` computed fields in trees throw `QueryError`.
  - Share join-planning leaf resolution across data/count queries and use `filterJoinLeaves` when filters are compiled away.
  - Harden validation: reject array-FK aggregates and NaN filter values; align `useTableData` with `withDerivedFetchParams`; `memoryAdapter` facets on derived columns require explicit `derivedColumnIds`.

<sup>Written for commit ed08ba0ccb1c1eb7230e8eecc6f60f52c55c66ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Better-Tables/better-tables/pull/103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

