### PR TITLE
Bound page size and eliminate wasteful RSC round-trips on table interactions

### DIFF
--- a/.changeset/adapter-max-page-size.md
+++ b/.changeset/adapter-max-page-size.md
@@ -1,0 +1,14 @@
+---
+"@better-tables/core": minor
+"@better-tables/adapters-drizzle": minor
+---
+
+Guard against unbounded page sizes: the Drizzle adapter now clamps an incoming
+`pagination.limit` to a configurable `maxPageSize` (new adapter option, default
+`DEFAULT_MAX_PAGE_SIZE` = 200) before querying. Because `limit` is commonly
+URL-driven (`?limit=…`), an oversized value previously flowed straight to the
+database and forced the client to render tens of thousands of rows; it is now
+capped, and the clamped value is reflected in the returned pagination metadata.
+Raise `options.maxPageSize` for deliberately larger pages, or set it to a
+non-positive value to disable the clamp. `DEFAULT_MAX_PAGE_SIZE` is exported
+from `@better-tables/core`.

--- a/apps/marketing/src/lib/nextjs-url-adapter.ts
+++ b/apps/marketing/src/lib/nextjs-url-adapter.ts
@@ -1,42 +1,82 @@
 'use client';
 
 import type { UrlSyncAdapter } from '@better-tables/core';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useMemo } from 'react';
 
 /**
- * Next.js App Router URL sync adapter
- * Provides URL synchronization for Next.js applications
+ * URL params the server (the `LiveDemo` RSC) reads to build its query. A change
+ * to any of these must re-run the server component, so it goes through the
+ * router. Every other synced param — column visibility, column order — is a
+ * client-only view preference the server ignores.
+ */
+const SERVER_AFFECTING_PARAMS = ['page', 'limit', 'filters', 'sorting'] as const;
+
+/**
+ * Next.js App Router URL sync adapter.
+ *
+ * The table's URL-sync writes state out on *every* store change (including ones
+ * that don't touch any synced URL param, e.g. row selection). A naive
+ * `router.push` on each write therefore fired a full RSC round-trip — refetch +
+ * re-render of the whole page — even to tick a checkbox or toggle a column. To
+ * avoid that, `setParams`:
+ *
+ *  - does nothing when the resulting query string is identical to the current
+ *    one (selection changes, redundant writes) — no navigation at all;
+ *  - uses `router.replace` (not `push`, so an interaction isn't a back-button
+ *    stop) only when a *server-affecting* param actually changed value, since
+ *    only then does the server need to refetch;
+ *  - otherwise updates the URL with a shallow `history.replaceState`, keeping
+ *    client-only view state (column visibility/order) shareable in the URL
+ *    without paying a server round-trip the server would ignore.
  */
 export function useNextjsUrlAdapter(): UrlSyncAdapter {
   const router = useRouter();
+  const pathname = usePathname();
   const searchParams = useSearchParams();
 
   return useMemo(
     () => ({
-      getParam: (key: string) => {
-        return searchParams.get(key);
-      },
+      getParam: (key: string) => searchParams.get(key),
 
       setParams: (updates: Record<string, string | null>) => {
-        const params = new URLSearchParams(searchParams);
-
+        const nextParams = new URLSearchParams(searchParams);
         for (const [key, value] of Object.entries(updates)) {
           if (value === null) {
-            params.delete(key);
+            nextParams.delete(key);
           } else {
-            params.set(key, value);
+            nextParams.set(key, value);
           }
         }
 
-        // Preserve hash fragment when updating URL
-        const hash = typeof window !== 'undefined' ? window.location.hash : '';
-        const newUrl = `?${params.toString()}${hash}`;
+        // Nothing the URL cares about changed (e.g. a row-selection write):
+        // don't navigate at all.
+        const nextQuery = nextParams.toString();
+        if (nextQuery === searchParams.toString()) {
+          return;
+        }
 
-        // Push the new URL to trigger server re-fetch
-        router.push(newUrl, { scroll: false });
+        // Did any param that the server reads change value? Compare against the
+        // current URL rather than trusting `updates` keys — the write-out always
+        // includes the (often unchanged) page/limit, so key presence alone would
+        // always look server-affecting.
+        const serverChanged = SERVER_AFFECTING_PARAMS.some(
+          (key) => (searchParams.get(key) ?? '') !== (nextParams.get(key) ?? '')
+        );
+
+        const hash = typeof window !== 'undefined' ? window.location.hash : '';
+        const newUrl = `${pathname}${nextQuery ? `?${nextQuery}` : ''}${hash}`;
+
+        if (serverChanged) {
+          router.replace(newUrl, { scroll: false });
+        } else if (typeof window !== 'undefined') {
+          // Client-only view state: keep it in the URL without a server
+          // round-trip. Preserve Next's history state so routing stays intact;
+          // Next syncs `useSearchParams` from this entry.
+          window.history.replaceState(window.history.state, '', newUrl);
+        }
       },
     }),
-    [router, searchParams]
+    [router, pathname, searchParams]
   );
 }

--- a/packages/adapters/drizzle/src/drizzle-adapter.ts
+++ b/packages/adapters/drizzle/src/drizzle-adapter.ts
@@ -412,13 +412,21 @@ export class DrizzleAdapter<TSchema extends Record<string, unknown>, TDriver ext
    * `maxPageSize` (default {@link DEFAULT_MAX_PAGE_SIZE}). Never mutates the
    * caller's object. A non-positive or non-finite cap disables the clamp; a
    * non-finite incoming `limit` is left untouched (other code validates it).
+   * The cap is floored to a whole number so a fractional `maxPageSize` (e.g.
+   * `2.5`) can't produce a non-integral `LIMIT`/`OFFSET` or paging metadata.
+   *
+   * The `export` path (`exportData`) opts out via `clampPageSize: false`: its
+   * page size is its own, separately-bounded row cap (`maxRows` /
+   * {@link DEFAULT_EXPORT_ROW_CAP}), not a URL-driven interactive limit, so the
+   * interactive cap must not silently truncate an export.
    */
   private withClampedPageSize(params: FetchDataParams): FetchDataParams {
     const { pagination } = params;
     if (!pagination) return params;
 
-    const cap = this.options?.maxPageSize ?? DEFAULT_MAX_PAGE_SIZE;
-    if (!Number.isFinite(cap) || cap <= 0) return params;
+    const rawCap = this.options?.maxPageSize ?? DEFAULT_MAX_PAGE_SIZE;
+    if (!Number.isFinite(rawCap) || rawCap <= 0) return params;
+    const cap = Math.floor(rawCap);
     if (!Number.isFinite(pagination.limit) || pagination.limit <= cap) return params;
 
     return { ...params, pagination: { ...pagination, limit: cap } };
@@ -472,7 +480,12 @@ export class DrizzleAdapter<TSchema extends Record<string, unknown>, TDriver ext
    * @since 1.0.0
    */
   async fetchData(
-    params: FetchDataParams
+    params: FetchDataParams,
+    // Internal-only: `exportData` passes `clampPageSize: false` because an
+    // export's page size is its own separately-bounded row cap, not an
+    // interactive limit (see `withClampedPageSize`). External callers use the
+    // public single-arg signature and always get the clamp.
+    options?: { clampPageSize?: boolean }
   ): Promise<FetchDataResult<InferSelectModelFromFilteredSchema<TSchema>>> {
     const startTime = Date.now();
 
@@ -481,7 +494,9 @@ export class DrizzleAdapter<TSchema extends Record<string, unknown>, TDriver ext
     // result set or force the client to render tens of thousands of rows. The
     // clamped value flows through to both the query and the returned pagination
     // metadata below, since everything downstream reads `params.pagination`.
-    params = this.withClampedPageSize(params);
+    if (options?.clampPageSize !== false) {
+      params = this.withClampedPageSize(params);
+    }
 
     // Resolved before the try block so a multi-table-ambiguity SchemaError
     // surfaces to the caller as-is, rather than being wrapped in a
@@ -1439,7 +1454,10 @@ export class DrizzleAdapter<TSchema extends Record<string, unknown>, TDriver ext
         pagination: { page: 1, limit },
       };
 
-      const result = await this.fetchData(fetchParams);
+      // Opt out of the interactive page-size clamp: the export cap above IS the
+      // bound here, so clamping to `maxPageSize` would silently truncate exports
+      // of more than `maxPageSize` rows.
+      const result = await this.fetchData(fetchParams, { clampPageSize: false });
 
       // Convert to export format
       const exportData = convertToExportFormat(

--- a/packages/adapters/drizzle/src/drizzle-adapter.ts
+++ b/packages/adapters/drizzle/src/drizzle-adapter.ts
@@ -69,6 +69,7 @@ import type {
 } from '@better-tables/core';
 import {
   DEFAULT_EXPORT_ROW_CAP,
+  DEFAULT_MAX_PAGE_SIZE,
   isFilterGroupNode,
   normalizeFilterNode,
 } from '@better-tables/core';
@@ -407,6 +408,23 @@ export class DrizzleAdapter<TSchema extends Record<string, unknown>, TDriver ext
   }
 
   /**
+   * Return `params` with `pagination.limit` clamped to the configured
+   * `maxPageSize` (default {@link DEFAULT_MAX_PAGE_SIZE}). Never mutates the
+   * caller's object. A non-positive or non-finite cap disables the clamp; a
+   * non-finite incoming `limit` is left untouched (other code validates it).
+   */
+  private withClampedPageSize(params: FetchDataParams): FetchDataParams {
+    const { pagination } = params;
+    if (!pagination) return params;
+
+    const cap = this.options?.maxPageSize ?? DEFAULT_MAX_PAGE_SIZE;
+    if (!Number.isFinite(cap) || cap <= 0) return params;
+    if (!Number.isFinite(pagination.limit) || pagination.limit <= cap) return params;
+
+    return { ...params, pagination: { ...pagination, limit: cap } };
+  }
+
+  /**
    * Fetch data with filtering, sorting, and pagination.
    *
    * This is the main method for retrieving data from the database. It handles:
@@ -457,6 +475,13 @@ export class DrizzleAdapter<TSchema extends Record<string, unknown>, TDriver ext
     params: FetchDataParams
   ): Promise<FetchDataResult<InferSelectModelFromFilteredSchema<TSchema>>> {
     const startTime = Date.now();
+
+    // Clamp an oversized page size (commonly URL-driven via `?limit=…`) before
+    // it reaches the database, so a crafted request can't pull an unbounded
+    // result set or force the client to render tens of thousands of rows. The
+    // clamped value flows through to both the query and the returned pagination
+    // metadata below, since everything downstream reads `params.pagination`.
+    params = this.withClampedPageSize(params);
 
     // Resolved before the try block so a multi-table-ambiguity SchemaError
     // surfaces to the caller as-is, rather than being wrapped in a

--- a/packages/adapters/drizzle/src/types/operations.ts
+++ b/packages/adapters/drizzle/src/types/operations.ts
@@ -328,6 +328,27 @@ export interface DrizzleAdapterOptions {
    * ```
    */
   onInvalidFilter?: InvalidFilterBehavior;
+
+  /**
+   * Upper bound on a single page's `limit` (rows per page). An incoming
+   * `pagination.limit` larger than this is clamped down to it before the query
+   * runs. Because `limit` is commonly URL-driven, this guards against a crafted
+   * `?limit=…` pulling an unbounded result set from the database and forcing the
+   * client to render tens of thousands of rows.
+   *
+   * Defaults to {@link DEFAULT_MAX_PAGE_SIZE} (200). Raise it for a deliberately
+   * large page (e.g. a virtualized "load everything" view); a non-positive or
+   * non-finite value disables the clamp.
+   *
+   * @default 200
+   * @example
+   * ```typescript
+   * const adapter = drizzleAdapter(db, {
+   *   options: { maxPageSize: 500 }
+   * });
+   * ```
+   */
+  maxPageSize?: number;
 }
 
 /**

--- a/packages/adapters/drizzle/tests/page-size-clamp.test.ts
+++ b/packages/adapters/drizzle/tests/page-size-clamp.test.ts
@@ -13,12 +13,21 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { DEFAULT_MAX_PAGE_SIZE } from '@better-tables/core';
 import { DrizzleAdapter } from '../src/drizzle-adapter';
 import type { DrizzleAdapterConfig, DrizzleDatabase } from '../src/types';
-import {
-  closeDatabase,
-  createTestDatabase,
-  setupTestDatabase,
-} from './helpers/test-fixtures';
-import { relationsSchema, schema } from './helpers/test-schema';
+import { closeDatabase, createTestDatabase, setupTestDatabase } from './helpers/test-fixtures';
+import { relationsSchema, schema, users } from './helpers/test-schema';
+
+/** Insert `count` extra users so a page cap can actually bite the row set. */
+async function seedManyUsers(
+  db: ReturnType<typeof createTestDatabase>['db'],
+  count: number
+): Promise<void> {
+  const rows = Array.from({ length: count }, (_, i) => ({
+    id: 1000 + i,
+    name: `User ${i}`,
+    email: `user${i}@example.com`,
+  }));
+  await db.insert(users).values(rows);
+}
 
 function makeAdapter(
   db: ReturnType<typeof createTestDatabase>['db'],
@@ -86,5 +95,36 @@ describe('DrizzleAdapter - page-size clamp', () => {
 
     // No clamp: the requested (absurd) limit is echoed back unchanged.
     expect(result.pagination?.limit).toBe(100_000);
+  });
+
+  it('actually limits the SQL result set to the default cap (not just metadata)', async () => {
+    // Seed well past the cap so an unclamped query would return far more rows.
+    await seedManyUsers(db, 250);
+    const adapter = makeAdapter(db);
+    const result = await adapter.fetchData({ pagination: { page: 1, limit: 100_000 } });
+
+    expect(result.data.length).toBe(DEFAULT_MAX_PAGE_SIZE);
+  });
+
+  it('floors a fractional maxPageSize to a whole page size', async () => {
+    const adapter = makeAdapter(db, 2.5);
+    const result = await adapter.fetchData({ pagination: { page: 1, limit: 1000 } });
+
+    // 2.5 -> 2 so LIMIT/OFFSET and metadata stay integral.
+    expect(result.pagination?.limit).toBe(2);
+    expect(result.data.length).toBe(2);
+    expect(Number.isInteger(result.pagination?.limit)).toBe(true);
+  });
+
+  it('does NOT clamp exports (export keeps its own row cap)', async () => {
+    // Seed past the interactive cap; the export must still return every row up
+    // to its own maxRows bound, not be truncated to maxPageSize.
+    await seedManyUsers(db, 250);
+    const adapter = makeAdapter(db, 200);
+    const result = await adapter.exportData({ format: 'json', maxRows: 10_000 });
+
+    const rows = JSON.parse(result.data as string) as unknown[];
+    // 250 seeded + 3 fixture users = 253, all well over the 200 page cap.
+    expect(rows.length).toBeGreaterThan(DEFAULT_MAX_PAGE_SIZE);
   });
 });

--- a/packages/adapters/drizzle/tests/page-size-clamp.test.ts
+++ b/packages/adapters/drizzle/tests/page-size-clamp.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Page-size clamp tests for DrizzleAdapter.
+ *
+ * `pagination.limit` is frequently URL-driven (`?limit=…`), so `fetchData`
+ * clamps an oversized limit down to `options.maxPageSize` (default
+ * `DEFAULT_MAX_PAGE_SIZE`) before the query runs. This keeps a crafted request
+ * from pulling an unbounded result set out of the database and forcing the
+ * client to render tens of thousands of rows. The clamped value is reflected in
+ * the returned `pagination.limit` too, so paging math stays consistent.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { DEFAULT_MAX_PAGE_SIZE } from '@better-tables/core';
+import { DrizzleAdapter } from '../src/drizzle-adapter';
+import type { DrizzleAdapterConfig, DrizzleDatabase } from '../src/types';
+import {
+  closeDatabase,
+  createTestDatabase,
+  setupTestDatabase,
+} from './helpers/test-fixtures';
+import { relationsSchema, schema } from './helpers/test-schema';
+
+function makeAdapter(
+  db: ReturnType<typeof createTestDatabase>['db'],
+  maxPageSize?: number
+): DrizzleAdapter<typeof schema, 'sqlite'> {
+  const config: DrizzleAdapterConfig<typeof schema, 'sqlite'> = {
+    db: db as unknown as DrizzleDatabase<'sqlite'>,
+    schema,
+    driver: 'sqlite',
+    autoDetectRelationships: true,
+    relations: relationsSchema,
+    options: {
+      defaultPrimaryTable: 'users',
+      ...(maxPageSize !== undefined && { maxPageSize }),
+    },
+  };
+  return new DrizzleAdapter(config);
+}
+
+describe('DrizzleAdapter - page-size clamp', () => {
+  let db: ReturnType<typeof createTestDatabase>['db'];
+  let sqlite: ReturnType<typeof createTestDatabase>['sqlite'];
+
+  beforeEach(async () => {
+    const created = createTestDatabase();
+    db = created.db;
+    sqlite = created.sqlite;
+    await setupTestDatabase(db);
+  });
+
+  afterEach(() => {
+    closeDatabase(sqlite);
+  });
+
+  it('clamps an oversized limit to the default max page size', async () => {
+    const adapter = makeAdapter(db);
+    const result = await adapter.fetchData({ pagination: { page: 1, limit: 100_000 } });
+
+    // The returned metadata reflects the clamp even when fewer rows exist, so
+    // totalPages/hasNext are computed against the real cap, not the request.
+    expect(result.pagination?.limit).toBe(DEFAULT_MAX_PAGE_SIZE);
+    // Never returns more rows than the cap (the fixture seeds only a few).
+    expect(result.data.length).toBeLessThanOrEqual(DEFAULT_MAX_PAGE_SIZE);
+  });
+
+  it('clamps to a custom maxPageSize option', async () => {
+    const adapter = makeAdapter(db, 2);
+    const result = await adapter.fetchData({ pagination: { page: 1, limit: 1000 } });
+
+    expect(result.pagination?.limit).toBe(2);
+    expect(result.data.length).toBe(2);
+  });
+
+  it('leaves an at-or-under-cap limit untouched', async () => {
+    const adapter = makeAdapter(db, 200);
+    const result = await adapter.fetchData({ pagination: { page: 1, limit: 2 } });
+
+    expect(result.pagination?.limit).toBe(2);
+    expect(result.data.length).toBe(2);
+  });
+
+  it('disables the clamp when maxPageSize is non-positive', async () => {
+    const adapter = makeAdapter(db, 0);
+    const result = await adapter.fetchData({ pagination: { page: 1, limit: 100_000 } });
+
+    // No clamp: the requested (absurd) limit is echoed back unchanged.
+    expect(result.pagination?.limit).toBe(100_000);
+  });
+});

--- a/packages/core/src/types/adapter.ts
+++ b/packages/core/src/types/adapter.ts
@@ -342,6 +342,17 @@ export interface ExportParams {
 export const DEFAULT_EXPORT_ROW_CAP = 50_000;
 
 /**
+ * Default upper bound on a single page's `limit` (rows per page). Adapters
+ * clamp an incoming `pagination.limit` to this when a larger value arrives —
+ * pagination `limit` is frequently URL-driven (e.g. `?limit=…`), so without a
+ * cap a crafted request can ask the database for an unbounded result set and
+ * force the client to render tens of thousands of rows. `200` is a safe
+ * default for interactive tables; override per-adapter for genuinely larger
+ * pages (e.g. a virtualized "load everything" view).
+ */
+export const DEFAULT_MAX_PAGE_SIZE = 200;
+
+/**
  * Result from data export operation.
  *
  * Contains the exported data as a blob or string along with

--- a/packages/ui/src/components/table/table.tsx
+++ b/packages/ui/src/components/table/table.tsx
@@ -1014,7 +1014,8 @@ function BetterTableInner<TData = unknown>({
     // writes. Depending on `columnVisibility` here previously made this
     // effect re-fire on its own `setColumnVisibility` call.
     if (newlyFilteredColumns.length > 0 || unfilteredColumns.length > 0) {
-      const newVisibility = { ...store.getState().columnVisibility };
+      const currentVisibility = store.getState().columnVisibility;
+      const newVisibility = { ...currentVisibility };
       for (const columnId of newlyFilteredColumns) {
         newVisibility[columnId] = true;
       }
@@ -1025,7 +1026,15 @@ function BetterTableInner<TData = unknown>({
           }
         }
       }
-      setColumnVisibility(newVisibility);
+      // Only write when visibility actually changed. The common case — filtering
+      // a column that's already visible — otherwise pushes a new-but-equal object
+      // into the store and re-renders the whole table for nothing.
+      const changed = Object.keys(newVisibility).some(
+        (key) => newVisibility[key] !== currentVisibility[key]
+      );
+      if (changed) {
+        setColumnVisibility(newVisibility);
+      }
     }
 
     // Update ref for next comparison

--- a/packages/ui/src/hooks/use-table-url-sync.ts
+++ b/packages/ui/src/hooks/use-table-url-sync.ts
@@ -177,6 +177,34 @@ function hydrateFromUrl(
 }
 
 /**
+ * Whether writing `urlParams` would actually change any synced URL param.
+ *
+ * The table manager emits `state_changed` for mutations that touch no synced
+ * URL param at all — row selection is the common one — and the write-out below
+ * serializes the *current* value of every configured field, not a diff. Without
+ * this check every such change would call `adapter.setParams` with values
+ * identical to the URL; harmless for a history-only adapter, but with an adapter
+ * that navigates on `setParams` (e.g. a Next.js router adapter) it forces a
+ * needless refetch / full RSC round-trip (e.g. re-fetching the page just to tick
+ * a checkbox).
+ *
+ * Each entry is compared against the adapter's current value. A `null` value
+ * means "this param should be absent", which matches an absent (`null`) current
+ * value; `undefined` from the adapter is normalized to `null`.
+ */
+function serializedParamsDifferFromUrl(
+  urlParams: Record<string, string | null>,
+  adapter: UrlSyncAdapter
+): boolean {
+  for (const [key, value] of Object.entries(urlParams)) {
+    if ((adapter.getParam(key) ?? null) !== (value ?? null)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
  * Build a signature string from the URL param values relevant to `config`.
  * Used as a render-time effect dependency so the hydration effect re-runs
  * whenever the underlying URL values change -- even if the `adapter`
@@ -295,6 +323,12 @@ export function useTableUrlSync(
     const manager = store.getState().manager;
     const { fn: debouncedUrlUpdate, cancel: cancelDebouncedUrlUpdate } = debounce((tableState) => {
       const urlParams = serializeTableStateToUrl(tableState);
+      // Skip writes that wouldn't change the URL (e.g. a row-selection change,
+      // which emits `state_changed` but touches no synced param) so adapters
+      // that navigate on `setParams` don't refetch for nothing.
+      if (!serializedParamsDifferFromUrl(urlParams, adapter)) {
+        return;
+      }
       adapter.setParams(urlParams);
     }, 150);
 

--- a/packages/ui/src/hooks/use-table-url-sync.ts
+++ b/packages/ui/src/hooks/use-table-url-sync.ts
@@ -177,6 +177,52 @@ function hydrateFromUrl(
 }
 
 /**
+ * Capture the table's starting pagination once (its app-configured / SSR-seeded
+ * default) so later writes can keep default `page`/`limit` out of a URL that
+ * doesn't already carry them. Called before the first hydration, while the
+ * store still holds its initial pagination.
+ */
+function captureDefaultPagination(
+  store: TableStore,
+  ref: { current: { page: number; limit: number } | null }
+): void {
+  if (ref.current) return;
+  const p = store.getState().manager.getPagination();
+  ref.current = { page: p.page, limit: p.limit };
+}
+
+/**
+ * Drop `page`/`limit` from a params write when they're at the captured default
+ * AND absent from the current URL, so a change that doesn't touch pagination
+ * (row selection, a column toggle) on a clean URL doesn't introduce
+ * `?page=1&limit=<default>` and trigger a navigation/refetch. Mutates
+ * `urlParams`. Never removes a param the URL already carries — only skips
+ * adding a redundant default one.
+ */
+function stripDefaultPaginationFromWrite(
+  urlParams: Record<string, string | null>,
+  pagination: { page: number; limit: number } | undefined,
+  defaults: { page: number; limit: number } | null,
+  adapter: UrlSyncAdapter
+): void {
+  if (!defaults || !pagination) return;
+  if (
+    urlParams.page != null &&
+    pagination.page === defaults.page &&
+    adapter.getParam('page') === null
+  ) {
+    delete urlParams.page;
+  }
+  if (
+    urlParams.limit != null &&
+    pagination.limit === defaults.limit &&
+    adapter.getParam('limit') === null
+  ) {
+    delete urlParams.limit;
+  }
+}
+
+/**
  * Whether writing `urlParams` would actually change any synced URL param.
  *
  * The table manager emits `state_changed` for mutations that touch no synced
@@ -262,6 +308,11 @@ export function useTableUrlSync(
 ): void {
   const stableConfig = useStableUrlSyncConfig(config);
   const hasHydratedFromUrl = useRef(false);
+  // The pagination the table starts at (its app-configured / SSR-seeded
+  // default), captured once before the first user interaction. Used to keep
+  // default `page`/`limit` out of a URL that doesn't already carry them — see
+  // the write-out effect below.
+  const defaultPaginationRef = useRef<{ page: number; limit: number } | null>(null);
   const [storeReady, setStoreReady] = useState(() => Boolean(getTableStore(tableId)));
   // Recomputed every render (cheap: a handful of adapter.getParam reads) so
   // it changes whenever the URL's relevant params change, even for adapters
@@ -279,6 +330,7 @@ export function useTableUrlSync(
     // from looping with the store->URL write-out effect below.
     const store = getTableStore(tableId);
     if (store) {
+      captureDefaultPagination(store, defaultPaginationRef);
       // First hydration must not clear SSR-seeded initialFilters; later ones
       // (soft navs) may clear (finding 15).
       hydrateFromUrl(store, stableConfig, adapter, hasHydratedFromUrl.current);
@@ -296,6 +348,7 @@ export function useTableUrlSync(
       attempts += 1;
       const lateStore = getTableStore(tableId);
       if (lateStore) {
+        captureDefaultPagination(lateStore, defaultPaginationRef);
         hydrateFromUrl(lateStore, stableConfig, adapter, hasHydratedFromUrl.current);
         hasHydratedFromUrl.current = true;
         setStoreReady(true);
@@ -323,6 +376,15 @@ export function useTableUrlSync(
     const manager = store.getState().manager;
     const { fn: debouncedUrlUpdate, cancel: cancelDebouncedUrlUpdate } = debounce((tableState) => {
       const urlParams = serializeTableStateToUrl(tableState);
+      // Keep default page/limit out of a URL that doesn't already carry them,
+      // so a change that doesn't touch pagination (selection, column toggle)
+      // doesn't introduce `?page=1&limit=<default>`.
+      stripDefaultPaginationFromWrite(
+        urlParams,
+        tableState.pagination,
+        defaultPaginationRef.current,
+        adapter
+      );
       // Skip writes that wouldn't change the URL (e.g. a row-selection change,
       // which emits `state_changed` but touches no synced param) so adapters
       // that navigate on `setParams` don't refetch for nothing.

--- a/packages/ui/src/hooks/use-table-url-sync.ts
+++ b/packages/ui/src/hooks/use-table-url-sync.ts
@@ -313,6 +313,13 @@ export function useTableUrlSync(
   // default `page`/`limit` out of a URL that doesn't already carry them — see
   // the write-out effect below.
   const defaultPaginationRef = useRef<{ page: number; limit: number } | null>(null);
+  // Re-capture the default pagination when this hook is pointed at a different
+  // table, so table B's writes aren't measured against table A's defaults.
+  const capturedForTableIdRef = useRef<string | null>(null);
+  if (capturedForTableIdRef.current !== tableId) {
+    capturedForTableIdRef.current = tableId;
+    defaultPaginationRef.current = null;
+  }
   const [storeReady, setStoreReady] = useState(() => Boolean(getTableStore(tableId)));
   // Recomputed every render (cheap: a handful of adapter.getParam reads) so
   // it changes whenever the URL's relevant params change, even for adapters

--- a/packages/ui/tests/hooks/use-table-url-sync.test.tsx
+++ b/packages/ui/tests/hooks/use-table-url-sync.test.tsx
@@ -219,4 +219,71 @@ describe('useTableUrlSync', () => {
     expect(burstCalls.length).toBe(1);
     expect(burstCalls[0]?.page).toBe('2');
   });
+
+  it('does not introduce default page/limit into a clean URL', async () => {
+    createStore();
+    const { adapter, setParamsCalls } = createFakeUrlAdapter(); // clean URL
+    const config: UrlSyncConfig = { filters: true, pagination: true };
+    renderHook(() => useTableUrlSync(TABLE_ID, config, adapter));
+    await waitFor(() => expect(getTableStore(TABLE_ID)).toBeDefined());
+    const store = getTableStore(TABLE_ID);
+    if (!store) {
+      throw new Error('Expected table store');
+    }
+
+    const before = setParamsCalls.length;
+    jest.useFakeTimers();
+    act(() => {
+      store.getState().manager.addFilter({
+        columnId: 'name',
+        type: 'text',
+        operator: 'contains',
+        values: ['x'],
+      });
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(URL_SYNC_DEBOUNCE_MS);
+    });
+    jest.useRealTimers();
+
+    const calls = setParamsCalls.slice(before);
+    expect(calls.length).toBeGreaterThan(0);
+    const last = calls[calls.length - 1] ?? {};
+    // The filter is written, but the default page/limit are NOT introduced into
+    // the (previously clean) URL.
+    expect(last.filters).toBeTruthy();
+    expect('page' in last).toBe(false);
+    expect('limit' in last).toBe(false);
+  });
+
+  it('suppresses a write when the change touches no synced param (pagination default)', async () => {
+    createStore();
+    const { adapter, setParamsCalls } = createFakeUrlAdapter(); // clean URL
+    // Only pagination is synced; a filter change touches nothing in the URL,
+    // and pagination is at its default, so there is nothing to write.
+    const config: UrlSyncConfig = { pagination: true };
+    renderHook(() => useTableUrlSync(TABLE_ID, config, adapter));
+    await waitFor(() => expect(getTableStore(TABLE_ID)).toBeDefined());
+    const store = getTableStore(TABLE_ID);
+    if (!store) {
+      throw new Error('Expected table store');
+    }
+
+    const before = setParamsCalls.length;
+    jest.useFakeTimers();
+    act(() => {
+      store.getState().manager.addFilter({
+        columnId: 'name',
+        type: 'text',
+        operator: 'contains',
+        values: ['x'],
+      });
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(URL_SYNC_DEBOUNCE_MS);
+    });
+    jest.useRealTimers();
+
+    expect(setParamsCalls.length - before).toBe(0);
+  });
 });


### PR DESCRIPTION
## Description

Table responsiveness work, in two areas — a page-size guard, and cutting unnecessary work per interaction (both server round-trips and client re-renders). The client-side items were found by profiling the homepage demo (React `<Profiler>` commit counts + row-render counters); dev-mode ms are inflated but the commit/render **counts** are exact.

### Server round-trips per interaction (homepage demo)

| Interaction | Before | After |
|---|--:|--:|
| Sort | 1 | 1 *(needed)* |
| Paginate | 1 | 1 *(needed)* |
| **Select a row** | **1** | **0** |
| **Select a row (1st, clean URL)** | **1** | **0** |
| Column show/hide, reorder | 1 | 0 |

### Client re-renders per interaction (row re-renders, 10-row page; dev, StrictMode-doubled)

| Interaction | Before | After |
|---|--:|--:|
| Select a row (1st, clean URL) | **62** | **2** |
| Apply filter | **40** | **20** |
| Sort / Paginate | 20 | 20 *(1 logical render; the 2× is dev StrictMode, not prod)* |

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ⚡ Performance improvement
- [x] 🔒 Security fix
- [x] ✅ Tests (adding or updating tests)

## Package(s) Affected

- [x] `@better-tables/core`
- [x] `@better-tables/ui`
- [x] `@better-tables/adapters-drizzle`
- [x] Documentation (marketing site demo)

## Changes Made

### 1. Page-size guard — `@better-tables/core` + `@better-tables/adapters-drizzle`
- Add `DEFAULT_MAX_PAGE_SIZE` (200) in core.
- Add a `maxPageSize` adapter option (default `DEFAULT_MAX_PAGE_SIZE`; non-positive disables). `fetchData` clamps an over-cap `pagination.limit` before querying and reflects the clamped value in returned pagination metadata. Never mutates the caller's params. `pagination.limit` is commonly URL-driven, so this closes an unbounded-query vector and a large-client-render source. New unit tests.

### 2. Avoid wasteful RSC round-trips — `@better-tables/ui` + marketing demo
- `useTableUrlSync`: skip the URL write-out entirely when every serialized param already equals the current URL. Changes that touch no synced param (row selection is the common one) no longer call `setParams`, so adapters that navigate on `setParams` don't refetch for nothing. Benefits every consumer/adapter.
- `useNextjsUrlAdapter.setParams` (demo): no-op when the resulting query is unchanged; `router.replace` (not `push`) only when a server-affecting param (page/limit/filters/sorting) actually changed value; otherwise a shallow `history.replaceState` for client-only view state (column visibility/order), keeping it shareable without a server round-trip.

### 3. Cut client re-renders — `@better-tables/ui`
- `useTableUrlSync`: don't introduce default `page`/`limit` into a URL that doesn't already carry them. Capture the table's starting pagination and drop `page`/`limit` from a write when they're at that default and absent from the URL. Previously the **first** interaction on a clean URL (e.g. a selection) serialized the default `page=1&limit=<default>`, which differed from the empty URL and triggered a navigation + refetch + full re-render cascade (**62 row re-renders → 2**).
- `autoShowFilteredColumns`: only call `setColumnVisibility` when visibility actually changed. Filtering an already-visible column (the common case) otherwise pushed a new-but-equal object into the store and re-rendered the whole table (**filter-apply row re-renders ~halved**).

## Testing

- [x] I have added/updated tests for my changes
- [x] All existing tests pass
- [x] I have tested manually in the following scenarios:
  - [x] Basic functionality
  - [x] Edge cases
  - [x] Browser compatibility (profiled in a real Chromium)

### Test Results

```
# adapter page-size clamp (new) + existing SQLite suite
34 pass, 0 fail (packages/adapters/drizzle)

# In-browser (Playwright, homepage demo)
RSC round-trips: sort=1 paginate=1 select-row=0 (incl. 1st on clean URL) column-toggle=0
  - "skip unchanged" core fix proven independently with a naive always-push adapter: select 1 -> 0
Client re-renders (row): first-selection 62 -> 2 ; filter-apply 40 -> 20
Functional: sort reorders + writes sorting= ; selection checks box, no URL change, no cascade ;
  sort works after selection (router not wedged) ; paginate updates + page= ; ?limit=1000 -> 200 rows
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

A changeset is included for the published-package changes (`@better-tables/core`, `@better-tables/adapters-drizzle`). `@better-tables/ui` is in the changeset ignore list (distributed via CLI copy, not npm), so it needs none.

Profiling also flagged a "double render" on data changes, but that turned out to be **React StrictMode in dev** (every render doubled), not a production issue — so no change there. A `setTotal`-guard optimization was prototyped and dropped because it had no measurable impact on the profiled interactions (`totalCount` is stable, so the effect doesn't re-fire `setTotal` with the same value).

🤖 Generated with [Claude Code](https://claude.com/claude-code)