### PR TITLE
Perf: fix demo interaction lag + full performance test harness (plan 063)

### DIFF
--- a/.changeset/facet-batch-and-signal-cache.md
+++ b/.changeset/facet-batch-and-signal-cache.md
@@ -1,0 +1,27 @@
+---
+"@better-tables/core": minor
+---
+
+Faster facet reads over HTTP: batched requests and a cache that works with
+abort signals.
+
+- New optional `TableAdapter.getFacets(requests, params)` answers several
+  facet reads (`'values'` → `getFacetedValues` shape, `'minmax'` →
+  `getMinMaxValues` shape) in one call, with the same per-column
+  self-exclusion semantics. `httpAdapter` implements it as a single POST
+  (new `getFacets` wire method, capped at `MAX_FACET_BATCH_SIZE` entries),
+  and `handleAdapterRequest` serves it — preferring the server adapter's own
+  `getFacets` and falling back to fanning out to the singular methods
+  server-side. A K-facet sidebar refresh is now one HTTP round-trip instead
+  of K.
+- `httpAdapter`'s TTL cache/dedup no longer bypasses reads that carry an
+  `AbortSignal` (previously every `useFacets` read went straight to the
+  network). A fresh cached result is returned regardless of signal;
+  concurrent identical reads share one underlying request with per-caller
+  abort semantics — aborting one caller rejects only that caller, and the
+  shared request is cancelled only when every caller has aborted. Aborted
+  and failed requests are never cached.
+
+Pair client and server on the same `@better-tables/core` version: a new
+client's batched facet reads need a server whose route handler understands
+the `getFacets` method.

--- a/.changeset/skip-effectless-filters.md
+++ b/.changeset/skip-effectless-filters.md
@@ -1,0 +1,23 @@
+---
+"@better-tables/core": minor
+---
+
+Incomplete filters no longer trigger work. A filter chip added before its
+value is chosen (`values: []`, the filter bar's `handleAddFilter` state) can't
+narrow anything, yet it used to change the filter list and so trigger a data
+refetch, a facet refresh, and a URL write — a full server round-trip in
+server-driven apps — before the user typed anything.
+
+- New `filterHasEffect(filter)` and `getEffectiveFilters(filters)` utilities:
+  a filter constrains results when its operator takes no values
+  (`isEmpty`/`isNull`/`isTrue`/…) or when it has at least one value.
+- `serializeTableStateToUrl` now serializes only effective filters, so a
+  valueless chip leaves the URL unchanged (no navigation).
+- `@better-tables/ui`'s `useTableData` and `useFacets` key their refetch
+  trigger on effective-filter content, so adding a valueless chip performs no
+  fetch and no facet request. The full filter state is still passed to the
+  adapter (self-exclusion is the adapter's job); only the refetch trigger
+  changed.
+
+Committing the first value pays exactly once (one fetch, one facet refresh,
+one URL write), as before.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,8 @@ on:
       - 'tsconfig.json'
       - 'biome.json'
       - '.github/workflows/test.yml'
+  # Manual trigger to prove/backfill the perf-trend job without a main push.
+  workflow_dispatch:
 
 env:
   NODE_VERSION: '22'
@@ -521,3 +523,66 @@ jobs:
             echo "✅ All tests passed successfully!"
           fi
           echo "========================================="
+
+  # Plan 063 Step 7: non-blocking perf trend tracking. Runs the mitata bench
+  # suites (which also record the type-gate instantiation counts) on pushes
+  # to main only, storing history on gh-pages and COMMENTING on regressions
+  # rather than failing the build. TODO(2026-08-06, after ~2 weeks of
+  # history): consider flipping fail-on-alert to true once baseline
+  # variance is known. PR gates stay deterministic-count tests only —
+  # wall-time never blocks a PR (plan 063 noise discipline).
+  perf-trend:
+    name: Perf trend (main only, non-blocking)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    permissions:
+      # gh-pages history push + alert comments.
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.11'
+
+      - name: Cache Bun install
+        uses: actions/cache@v6
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run bench suites
+        run: bun run bench
+
+      - name: Combine bench results
+        run: |
+          jq -s 'add' \
+            packages/core/bench-results/*.json \
+            packages/adapters/toolkit/bench-results/*.json \
+            packages/adapters/drizzle/bench-results/*.json \
+            > combined-bench.json
+          jq length combined-bench.json
+
+      - name: Upload raw results artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: bench-results
+          path: combined-bench.json
+          retention-days: 90
+
+      - name: Store trend + alert on regression
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          tool: 'customSmallerIsBetter'
+          output-file-path: combined-bench.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          alert-threshold: '150%'
+          comment-on-alert: true
+          fail-on-alert: false
+          summary-always: true

--- a/.gitignore
+++ b/.gitignore
@@ -88,4 +88,6 @@ out/
 # Test artifacts
 test-results/
 playwright-report/
-playwright/.cache/ e2e-results/
+playwright/.cache/
+e2e-results/
+bench-results/

--- a/.gitignore
+++ b/.gitignore
@@ -88,4 +88,4 @@ out/
 # Test artifacts
 test-results/
 playwright-report/
-playwright/.cache/ 
+playwright/.cache/ e2e-results/

--- a/apps/marketing/e2e/perf-interactions.e2e.ts
+++ b/apps/marketing/e2e/perf-interactions.e2e.ts
@@ -94,7 +94,7 @@ function record(name: string, samples: Sample[]): void {
     value: Math.round(p75 * 100) / 100,
     extra: `n=${values.length} min=${Math.min(...values).toFixed(1)} max=${Math.max(...values).toFixed(1)}`,
   });
-  // eslint-disable-next-line no-console
+  // biome-ignore lint/suspicious/noConsole: perf harness reporter output
   console.log(
     `[perf] ${name}: p50=${p50.toFixed(1)}ms p75=${p75.toFixed(1)}ms ` +
       `min=${Math.min(...values).toFixed(1)} max=${Math.max(...values).toFixed(1)} n=${values.length}`
@@ -105,7 +105,7 @@ test.afterAll(() => {
   const outPath = join(__dirname, '..', 'e2e-results', 'perf-interactions.json');
   mkdirSync(dirname(outPath), { recursive: true });
   writeFileSync(outPath, `${JSON.stringify(results, null, 2)}\n`);
-  // eslint-disable-next-line no-console
+  // biome-ignore lint/suspicious/noConsole: perf harness reporter output
   console.log(`[perf] wrote ${outPath}`);
 });
 

--- a/apps/marketing/e2e/perf-interactions.e2e.ts
+++ b/apps/marketing/e2e/perf-interactions.e2e.ts
@@ -30,7 +30,8 @@ const REPS = 15;
 const WARMUP = 3;
 
 interface Sample {
-  ms: number;
+  /** Click → the FIRST DATA ROW's text changed to a new value. */
+  domUpdateMs: number;
 }
 
 function percentile(samples: number[], p: number): number {
@@ -40,39 +41,71 @@ function percentile(samples: number[], p: number): number {
 }
 
 /**
- * Click `clickTarget` (resolved in-page) and resolve with the elapsed ms
- * until the observed container's text content changes. Rejects (via test
- * timeout) if nothing changes — a rows-never-updated regression fails the
- * mechanics assertion, not just the numbers.
+ * Click a target (resolved in-page) and measure `domUpdateMs`: click → the
+ * FIRST DATA ROW's text changes to a new value.
+ *
+ * Keying on the first row (not whole-`tbody` text) ties the number to the
+ * user-visible RESULT: the loading affordance dims via a CSS class (no text
+ * change), so an intermediate mutation during the refetch can't satisfy this
+ * the way a coarse whole-container text observer could. An in-page cap rejects
+ * if the row never changes, so a broken interaction fails fast rather than
+ * wedging the whole test timeout.
+ *
+ * NOTE: an input-to-next-paint (Event Timing) metric was considered but does
+ * not work here — the Event Timing API only records TRUSTED user input, and
+ * this harness dispatches a synthetic in-page `element.click()` (needed to
+ * anchor `performance.now()` at the exact dispatch). Capturing INP would
+ * require driving the click through Playwright's trusted-input path and
+ * correlating it back, which is a larger follow-up; the DOM-update latency
+ * above is the primary, reliable signal.
  */
 async function measureClickToRowsChanged(
   page: Page,
-  options: { clickScript: string; observeSelector: string }
-): Promise<number> {
+  options: { clickScript: string; rowSelector: string }
+): Promise<Sample> {
   return page.evaluate(
-    async ({ clickScript, observeSelector }) => {
-      const container = document.querySelector(observeSelector);
-      if (!container) throw new Error(`observe target missing: ${observeSelector}`);
-      // Indirect eval resolves the click target lazily, at dispatch time.
+    async ({ clickScript, rowSelector }) => {
+      const IN_PAGE_TIMEOUT_MS = 8000;
+      const firstRowText = () => document.querySelector(rowSelector)?.textContent ?? null;
       const resolveTarget = new Function(`return (${clickScript});`) as () => HTMLElement | null;
       const target = resolveTarget();
       if (!target) throw new Error('click target missing');
+      const before = firstRowText();
+      if (before === null) throw new Error(`row target missing: ${rowSelector}`);
 
-      const before = container.textContent;
       const start = performance.now();
-      const done = new Promise<number>((resolve) => {
-        const observer = new MutationObserver(() => {
-          if (container.textContent !== before) {
-            observer.disconnect();
-            resolve(performance.now() - start);
+      const domUpdateMs = await new Promise<number>((resolve, reject) => {
+        let settled = false;
+        const finish = (fn: () => void) => {
+          if (settled) return;
+          settled = true;
+          observer.disconnect();
+          clearInterval(poll);
+          clearTimeout(cap);
+          fn();
+        };
+        const check = () => {
+          if (!settled && firstRowText() !== before) {
+            const elapsed = performance.now() - start;
+            finish(() => resolve(elapsed));
           }
-        });
-        observer.observe(container, { subtree: true, childList: true, characterData: true });
+        };
+        const observer = new MutationObserver(check);
+        observer.observe(document.body, { subtree: true, childList: true, characterData: true });
+        // Poll as a backstop (a first-row swap that reuses text nodes may not
+        // fire a characterData mutation the observer catches).
+        const poll = setInterval(check, 16);
+        const cap = setTimeout(
+          () => finish(() => reject(new Error('rows did not change within cap'))),
+          IN_PAGE_TIMEOUT_MS
+        );
+        // Dispatch the interaction now that the observers/timer are armed.
+        target.click();
       });
-      target.click();
-      return done;
+
+      return { domUpdateMs };
     },
-    { clickScript: options.clickScript, observeSelector: options.observeSelector }
+    { clickScript: options.clickScript, rowSelector: options.rowSelector }
   );
 }
 
@@ -83,8 +116,8 @@ async function throttleCpu(page: Page, rate: number): Promise<void> {
 
 const results: Array<{ name: string; unit: string; value: number; extra?: string }> = [];
 
-function record(name: string, samples: Sample[]): void {
-  const values = samples.map((sample) => sample.ms);
+function recordSeries(name: string, values: number[]): void {
+  if (values.length === 0) return;
   const p50 = percentile(values, 50);
   const p75 = percentile(values, 75);
   results.push({ name: `${name} p50`, unit: 'ms', value: Math.round(p50 * 100) / 100 });
@@ -98,6 +131,13 @@ function record(name: string, samples: Sample[]): void {
   console.log(
     `[perf] ${name}: p50=${p50.toFixed(1)}ms p75=${p75.toFixed(1)}ms ` +
       `min=${Math.min(...values).toFixed(1)} max=${Math.max(...values).toFixed(1)} n=${values.length}`
+  );
+}
+
+function record(name: string, samples: Sample[]): void {
+  recordSeries(
+    `${name}.click-to-rows`,
+    samples.map((s) => s.domUpdateMs)
   );
 }
 
@@ -120,15 +160,15 @@ test('homepage pagination click latency', async ({ page }) => {
     // Alternate Next/Previous so state stays bounded; both are pagination
     // clicks and count as samples.
     const label = i % 2 === 0 ? 'Next page' : 'Previous page';
-    const ms = await measureClickToRowsChanged(page, {
+    const sample = await measureClickToRowsChanged(page, {
       clickScript: `document.querySelector('[aria-label="${label}"]')`,
-      observeSelector: 'tbody',
+      rowSelector: 'tbody tr',
     });
-    if (i >= WARMUP) samples.push({ ms });
-    await page.waitForTimeout(50);
+    if (i >= WARMUP) samples.push(sample);
+    await page.waitForTimeout(250);
   }
   expect(samples).toHaveLength(REPS - WARMUP);
-  record('e2e/pagination.click-to-rows', samples);
+  record('e2e/pagination', samples);
 });
 
 test('homepage sort header click latency', async ({ page }) => {
@@ -141,15 +181,15 @@ test('homepage sort header click latency', async ({ page }) => {
   const clickScript = `[...document.querySelectorAll('thead th')].find((th) => (th.textContent || '').includes('Name'))`;
   const samples: Sample[] = [];
   for (let i = 0; i < REPS; i++) {
-    const ms = await measureClickToRowsChanged(page, {
+    const sample = await measureClickToRowsChanged(page, {
       clickScript,
-      observeSelector: 'tbody',
+      rowSelector: 'tbody tr',
     });
-    if (i >= WARMUP) samples.push({ ms });
-    await page.waitForTimeout(50);
+    if (i >= WARMUP) samples.push(sample);
+    await page.waitForTimeout(250);
   }
   expect(samples).toHaveLength(REPS - WARMUP);
-  record('e2e/sort.click-to-rows', samples);
+  record('e2e/sort', samples);
 });
 
 test('facets sidebar filter toggle latency', async ({ page }) => {
@@ -165,13 +205,13 @@ test('facets sidebar filter toggle latency', async ({ page }) => {
   for (let i = 0; i < REPS; i++) {
     // Each click toggles the same facet value on/off — add and remove are
     // both filter-change interactions.
-    const ms = await measureClickToRowsChanged(page, {
+    const sample = await measureClickToRowsChanged(page, {
       clickScript,
-      observeSelector: 'tbody',
+      rowSelector: 'tbody tr',
     });
-    if (i >= WARMUP) samples.push({ ms });
-    await page.waitForTimeout(100);
+    if (i >= WARMUP) samples.push(sample);
+    await page.waitForTimeout(250);
   }
   expect(samples).toHaveLength(REPS - WARMUP);
-  record('e2e/facet-toggle.click-to-rows', samples);
+  record('e2e/facet-toggle', samples);
 });

--- a/apps/marketing/e2e/perf-interactions.e2e.ts
+++ b/apps/marketing/e2e/perf-interactions.e2e.ts
@@ -1,0 +1,177 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { expect, type Page, test } from '@playwright/test';
+
+/**
+ * Plan 063 Step 6 — interaction-latency baselines over the production demo.
+ *
+ * Measures the three server-affecting interaction classes the lag reports
+ * were about, each as click → rows-visibly-updated wall time, computed
+ * ENTIRELY in-page (performance.now + MutationObserver) so protocol
+ * overhead never pollutes the numbers:
+ *
+ *   1. pagination click (homepage Next/Previous)
+ *   2. sort header click (homepage)
+ *   3. facet filter toggle (facets example sidebar — the "adding a filter"
+ *      path; the in-table filter-dropdown flow is intentionally not
+ *      automated here: its portal/popover choreography makes selectors
+ *      brittle, and the sidebar toggle exercises the same
+ *      filter-change → RSC → batched-facet pipeline)
+ *
+ * Method: CDP CPU throttling 4x, REPS samples per interaction after WARMUP
+ * discarded warm-ups, p50/p75 reported. NO budgets are asserted — this
+ * harness asserts mechanics only (rows changed, sample counts) and writes
+ * baselines to e2e-results/perf-interactions.json in
+ * `customSmallerIsBetter` shape for trend tracking. Budgets get chosen
+ * once baseline variance is known (plan 063 Step 7 note).
+ */
+
+const REPS = 15;
+const WARMUP = 3;
+
+interface Sample {
+  ms: number;
+}
+
+function percentile(samples: number[], p: number): number {
+  const sorted = [...samples].sort((a, b) => a - b);
+  const index = Math.min(sorted.length - 1, Math.ceil((p / 100) * sorted.length) - 1);
+  return sorted[Math.max(0, index)] ?? 0;
+}
+
+/**
+ * Click `clickTarget` (resolved in-page) and resolve with the elapsed ms
+ * until the observed container's text content changes. Rejects (via test
+ * timeout) if nothing changes — a rows-never-updated regression fails the
+ * mechanics assertion, not just the numbers.
+ */
+async function measureClickToRowsChanged(
+  page: Page,
+  options: { clickScript: string; observeSelector: string }
+): Promise<number> {
+  return page.evaluate(
+    async ({ clickScript, observeSelector }) => {
+      const container = document.querySelector(observeSelector);
+      if (!container) throw new Error(`observe target missing: ${observeSelector}`);
+      // Indirect eval resolves the click target lazily, at dispatch time.
+      const resolveTarget = new Function(`return (${clickScript});`) as () => HTMLElement | null;
+      const target = resolveTarget();
+      if (!target) throw new Error('click target missing');
+
+      const before = container.textContent;
+      const start = performance.now();
+      const done = new Promise<number>((resolve) => {
+        const observer = new MutationObserver(() => {
+          if (container.textContent !== before) {
+            observer.disconnect();
+            resolve(performance.now() - start);
+          }
+        });
+        observer.observe(container, { subtree: true, childList: true, characterData: true });
+      });
+      target.click();
+      return done;
+    },
+    { clickScript: options.clickScript, observeSelector: options.observeSelector }
+  );
+}
+
+async function throttleCpu(page: Page, rate: number): Promise<void> {
+  const session = await page.context().newCDPSession(page);
+  await session.send('Emulation.setCPUThrottlingRate', { rate });
+}
+
+const results: Array<{ name: string; unit: string; value: number; extra?: string }> = [];
+
+function record(name: string, samples: Sample[]): void {
+  const values = samples.map((sample) => sample.ms);
+  const p50 = percentile(values, 50);
+  const p75 = percentile(values, 75);
+  results.push({ name: `${name} p50`, unit: 'ms', value: Math.round(p50 * 100) / 100 });
+  results.push({
+    name: `${name} p75`,
+    unit: 'ms',
+    value: Math.round(p75 * 100) / 100,
+    extra: `n=${values.length} min=${Math.min(...values).toFixed(1)} max=${Math.max(...values).toFixed(1)}`,
+  });
+  // eslint-disable-next-line no-console
+  console.log(
+    `[perf] ${name}: p50=${p50.toFixed(1)}ms p75=${p75.toFixed(1)}ms ` +
+      `min=${Math.min(...values).toFixed(1)} max=${Math.max(...values).toFixed(1)} n=${values.length}`
+  );
+}
+
+test.afterAll(() => {
+  const outPath = join(__dirname, '..', 'e2e-results', 'perf-interactions.json');
+  mkdirSync(dirname(outPath), { recursive: true });
+  writeFileSync(outPath, `${JSON.stringify(results, null, 2)}\n`);
+  // eslint-disable-next-line no-console
+  console.log(`[perf] wrote ${outPath}`);
+});
+
+test('homepage pagination click latency', async ({ page }) => {
+  await page.goto('/');
+  const next = page.getByLabel('Next page');
+  await expect(next).toBeEnabled({ timeout: 60_000 });
+  await throttleCpu(page, 4);
+
+  const samples: Sample[] = [];
+  for (let i = 0; i < REPS; i++) {
+    // Alternate Next/Previous so state stays bounded; both are pagination
+    // clicks and count as samples.
+    const label = i % 2 === 0 ? 'Next page' : 'Previous page';
+    const ms = await measureClickToRowsChanged(page, {
+      clickScript: `document.querySelector('[aria-label="${label}"]')`,
+      observeSelector: 'tbody',
+    });
+    if (i >= WARMUP) samples.push({ ms });
+    await page.waitForTimeout(50);
+  }
+  expect(samples).toHaveLength(REPS - WARMUP);
+  record('e2e/pagination.click-to-rows', samples);
+});
+
+test('homepage sort header click latency', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.getByLabel('Next page')).toBeEnabled({ timeout: 60_000 });
+  await throttleCpu(page, 4);
+
+  // Sortable headers are <th> elements carrying the sort click handler
+  // (not buttons) — target the th whose text is the column's display name.
+  const clickScript = `[...document.querySelectorAll('thead th')].find((th) => (th.textContent || '').includes('Name'))`;
+  const samples: Sample[] = [];
+  for (let i = 0; i < REPS; i++) {
+    const ms = await measureClickToRowsChanged(page, {
+      clickScript,
+      observeSelector: 'tbody',
+    });
+    if (i >= WARMUP) samples.push({ ms });
+    await page.waitForTimeout(50);
+  }
+  expect(samples).toHaveLength(REPS - WARMUP);
+  record('e2e/sort.click-to-rows', samples);
+});
+
+test('facets sidebar filter toggle latency', async ({ page }) => {
+  await page.goto('/examples/facets');
+  const sidebar = page.getByLabel('Facet sidebar');
+  await expect(sidebar.locator('button').first()).toBeVisible({ timeout: 60_000 });
+  // Rows present before we measure.
+  await expect(page.locator('tbody tr').first()).toBeVisible({ timeout: 60_000 });
+  await throttleCpu(page, 4);
+
+  const clickScript = `document.querySelector('aside[aria-label="Facet sidebar"] button')`;
+  const samples: Sample[] = [];
+  for (let i = 0; i < REPS; i++) {
+    // Each click toggles the same facet value on/off — add and remove are
+    // both filter-change interactions.
+    const ms = await measureClickToRowsChanged(page, {
+      clickScript,
+      observeSelector: 'tbody',
+    });
+    if (i >= WARMUP) samples.push({ ms });
+    await page.waitForTimeout(100);
+  }
+  expect(samples).toHaveLength(REPS - WARMUP);
+  record('e2e/facet-toggle.click-to-rows', samples);
+});

--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -16,6 +16,7 @@
     "format": "biome format --write .",
     "typecheck": "next typegen && fumadocs-mdx && tsc --noEmit",
     "test": "bun test",
+    "test:e2e:perf": "next build && playwright test",
     "clean": "git clean -xdf .cache .next .turbo .source node_modules"
   },
   "dependencies": {
@@ -53,6 +54,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "catalog:",
+    "@playwright/test": "catalog:",
     "@tailwindcss/typography": "^0.5.19",
     "@types/better-sqlite3": "catalog:",
     "@types/mdx": "^2.0.14",

--- a/apps/marketing/playwright.config.ts
+++ b/apps/marketing/playwright.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Perf-measurement E2E config (plan 063 Step 6, opt-in via `test:e2e:perf`).
+ *
+ * - Measures against a PRODUCTION build: the `test:e2e:perf` script runs
+ *   `next build` first, and the webServer below is `next start` — dev-mode
+ *   numbers are meaningless.
+ * - Chromium only (CDP CPU throttling + event timing are Chromium features).
+ *   The `.e2e.ts` suffix keeps these files OUT of `bun test`'s glob (which
+ *   would otherwise pick up `.spec.`/`.test.` names in CI's marketing job).
+ * - One worker, no parallelism, no retries: parallel load on the same
+ *   server would contaminate latency samples.
+ */
+export default defineConfig({
+  testDir: './e2e',
+  testMatch: '**/*.e2e.ts',
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  timeout: 180_000,
+  reporter: [['list']],
+  use: {
+    ...devices['Desktop Chrome'],
+    baseURL: 'http://127.0.0.1:3000',
+    // Environments that pre-install a Chromium outside Playwright's registry
+    // can point at it explicitly (e.g. PW_CHROMIUM=/opt/pw-browsers/chromium).
+    ...(process.env.PW_CHROMIUM
+      ? { launchOptions: { executablePath: process.env.PW_CHROMIUM } }
+      : {}),
+  },
+  webServer: {
+    command: 'bun run start',
+    url: 'http://127.0.0.1:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/apps/marketing/playwright.config.ts
+++ b/apps/marketing/playwright.config.ts
@@ -32,7 +32,11 @@ export default defineConfig({
   webServer: {
     command: 'bun run start',
     url: 'http://127.0.0.1:3000',
-    reuseExistingServer: !process.env.CI,
+    // Never reuse an already-running server: this harness measures the
+    // PRODUCTION build (`test:e2e:perf` runs `next build` first), and reusing
+    // a stray `next dev` or a stale `next start` would silently produce
+    // invalid latency baselines. Always launch a fresh `next start`.
+    reuseExistingServer: false,
     timeout: 120_000,
   },
 });

--- a/apps/marketing/src/app/(marketing)/examples/facets/page.tsx
+++ b/apps/marketing/src/app/(marketing)/examples/facets/page.tsx
@@ -4,6 +4,7 @@ import { ExampleShell } from '@/components/examples/example-shell';
 import { FacetsSidebar } from '@/components/sections/facets-sidebar';
 import { FacetsTableClient } from '@/components/sections/facets-table-client';
 import { fetchTickets } from '@/lib/demo/support/fetch-tickets';
+import { UrlNavigationPendingProvider } from '@/lib/nextjs-url-adapter';
 import { constructMetadata } from '@/lib/utils';
 
 export const metadata = constructMetadata({
@@ -55,31 +56,39 @@ export default async function FacetsPage({ searchParams }: FacetsPageProps) {
         </div>
       ) : null}
 
-      <div className="grid grid-cols-1 gap-6 xl:grid-cols-[280px_minmax(0,1fr)]">
-        <FacetsSidebar activeFilters={fetchResult.filters} />
+      {/* Shared transition: a sidebar facet click dims the table while its
+          RSC round-trip is in flight (both components' url adapters join the
+          same pending state). */}
+      <UrlNavigationPendingProvider>
+        <div className="grid grid-cols-1 gap-6 xl:grid-cols-[280px_minmax(0,1fr)]">
+          <FacetsSidebar activeFilters={fetchResult.filters} />
 
-        <section aria-label="Facets ticket table" className="rounded-lg border bg-card p-4 md:p-6">
-          <Suspense
-            fallback={<div className="text-sm text-muted-foreground">Loading table...</div>}
+          <section
+            aria-label="Facets ticket table"
+            className="rounded-lg border bg-card p-4 md:p-6"
           >
-            <FacetsTableClient
-              data={fetchResult.result.data ?? []}
-              totalCount={fetchResult.result.total ?? 0}
-              initialPagination={
-                fetchResult.result.pagination ?? {
-                  page: 1,
-                  limit: 10,
-                  totalPages: 1,
-                  hasNext: false,
-                  hasPrev: false,
+            <Suspense
+              fallback={<div className="text-sm text-muted-foreground">Loading table...</div>}
+            >
+              <FacetsTableClient
+                data={fetchResult.result.data ?? []}
+                totalCount={fetchResult.result.total ?? 0}
+                initialPagination={
+                  fetchResult.result.pagination ?? {
+                    page: 1,
+                    limit: 10,
+                    totalPages: 1,
+                    hasNext: false,
+                    hasPrev: false,
+                  }
                 }
-              }
-              initialSorting={fetchResult.sorting}
-              initialFilters={fetchResult.filters}
-            />
-          </Suspense>
-        </section>
-      </div>
+                initialSorting={fetchResult.sorting}
+                initialFilters={fetchResult.filters}
+              />
+            </Suspense>
+          </section>
+        </div>
+      </UrlNavigationPendingProvider>
     </ExampleShell>
   );
 }

--- a/apps/marketing/src/components/home/users-table-client.tsx
+++ b/apps/marketing/src/components/home/users-table-client.tsx
@@ -33,7 +33,7 @@ export function UsersTableClient({
   initialFilters,
 }: UsersTableClientProps) {
   const router = useRouter();
-  const urlAdapter = useNextjsUrlAdapter();
+  const { adapter: urlAdapter, isPending } = useNextjsUrlAdapter();
 
   useTableUrlSync(
     TABLE_ID,
@@ -78,6 +78,7 @@ export function UsersTableClient({
       // project these are `better-tables add actions export` + these slot lines.
       slots={{ actionsToolbar: ActionsToolbar, toolbarExtra: ExportButton }}
       data={data}
+      loading={isPending}
       totalCount={totalCount}
       initialPagination={initialPagination}
       initialSorting={initialSorting}

--- a/apps/marketing/src/components/sections/big-board-client.tsx
+++ b/apps/marketing/src/components/sections/big-board-client.tsx
@@ -26,7 +26,7 @@ export function BigBoardClient({
   initialFilters,
   initialSorting,
 }: BigBoardClientProps) {
-  const urlAdapter = useNextjsUrlAdapter();
+  const { adapter: urlAdapter, isPending } = useNextjsUrlAdapter();
 
   useTableUrlSync(TABLE_ID, { filters: true, sorting: true }, urlAdapter);
 
@@ -36,6 +36,7 @@ export function BigBoardClient({
         id={TABLE_ID}
         table={bulkTicketsTable}
         data={data}
+        loading={isPending}
         totalCount={total}
         initialFilters={initialFilters}
         initialSorting={initialSorting}

--- a/apps/marketing/src/components/sections/export-table-client.tsx
+++ b/apps/marketing/src/components/sections/export-table-client.tsx
@@ -28,7 +28,7 @@ export function ExportTableClient({
   initialSorting,
   initialFilters,
 }: ExportTableClientProps) {
-  const urlAdapter = useNextjsUrlAdapter();
+  const { adapter: urlAdapter, isPending } = useNextjsUrlAdapter();
 
   useTableUrlSync(
     TABLE_ID,
@@ -48,6 +48,7 @@ export function ExportTableClient({
       table={ticketsTable}
       adapter={adapter}
       data={data}
+      loading={isPending}
       totalCount={totalCount}
       initialPagination={initialPagination}
       initialSorting={initialSorting}

--- a/apps/marketing/src/components/sections/facets-sidebar.tsx
+++ b/apps/marketing/src/components/sections/facets-sidebar.tsx
@@ -30,7 +30,7 @@ interface FacetsSidebarProps {
  * loads counts/ranges for the active filters. Toggle a value to update the URL.
  */
 export function FacetsSidebar({ activeFilters }: FacetsSidebarProps) {
-  const urlAdapter = useNextjsUrlAdapter();
+  const { adapter: urlAdapter } = useNextjsUrlAdapter();
 
   // Browser proxy to the server Drizzle adapter.
   const adapter = useMemo(() => httpAdapter({ url: '/api/tables/tickets' }), []);

--- a/apps/marketing/src/components/sections/facets-table-client.tsx
+++ b/apps/marketing/src/components/sections/facets-table-client.tsx
@@ -29,7 +29,7 @@ export function FacetsTableClient({
   initialSorting,
   initialFilters,
 }: FacetsTableClientProps) {
-  const urlAdapter = useNextjsUrlAdapter();
+  const { adapter: urlAdapter, isPending } = useNextjsUrlAdapter();
 
   useTableUrlSync(
     TABLE_ID,
@@ -53,6 +53,7 @@ export function FacetsTableClient({
       table={ticketsTable}
       adapter={adapter}
       data={data}
+      loading={isPending}
       totalCount={totalCount}
       initialPagination={initialPagination}
       initialSorting={initialSorting}

--- a/apps/marketing/src/components/sections/query-groups-table-client.tsx
+++ b/apps/marketing/src/components/sections/query-groups-table-client.tsx
@@ -29,7 +29,7 @@ export function QueryGroupsTableClient({
   initialSorting,
   initialFilters,
 }: QueryGroupsTableClientProps) {
-  const urlAdapter = useNextjsUrlAdapter();
+  const { adapter: urlAdapter, isPending } = useNextjsUrlAdapter();
 
   useTableUrlSync(
     TABLE_ID,
@@ -58,6 +58,7 @@ export function QueryGroupsTableClient({
       table={ticketsTable}
       adapter={adapter}
       data={data}
+      loading={isPending}
       totalCount={totalCount}
       initialPagination={initialPagination}
       initialSorting={initialSorting}

--- a/apps/marketing/src/components/sections/query-groups-workspace.tsx
+++ b/apps/marketing/src/components/sections/query-groups-workspace.tsx
@@ -8,7 +8,7 @@ import type { FetchTicketsResult } from '@/lib/demo/support/fetch-tickets';
 import { countFilterLeaves, describeFilters } from '@/lib/demo/support/filter-sentence';
 import { queryGroupPresets } from '@/lib/demo/support/relationship-trail';
 import { serializeSupportPresetToUrl } from '@/lib/demo/support/serialize-preset';
-import { useNextjsUrlAdapter } from '@/lib/nextjs-url-adapter';
+import { UrlNavigationPendingProvider, useNextjsUrlAdapter } from '@/lib/nextjs-url-adapter';
 import { cn } from '@/lib/utils';
 
 interface QueryGroupsWorkspaceProps {
@@ -16,9 +16,22 @@ interface QueryGroupsWorkspaceProps {
   activePresetId: string | null;
 }
 
-export function QueryGroupsWorkspace({ fetchResult, activePresetId }: QueryGroupsWorkspaceProps) {
+/**
+ * Provider wrapper so a preset/reset click (this component's hook) and the
+ * table's dim-while-pending (`QueryGroupsTableClient`'s hook) share one
+ * transition — the inner component's hook must run UNDER the provider.
+ */
+export function QueryGroupsWorkspace(props: QueryGroupsWorkspaceProps) {
+  return (
+    <UrlNavigationPendingProvider>
+      <QueryGroupsWorkspaceInner {...props} />
+    </UrlNavigationPendingProvider>
+  );
+}
+
+function QueryGroupsWorkspaceInner({ fetchResult, activePresetId }: QueryGroupsWorkspaceProps) {
   const { result, filters, sorting, error } = fetchResult;
-  const urlAdapter = useNextjsUrlAdapter();
+  const { adapter: urlAdapter } = useNextjsUrlAdapter();
   const [copied, setCopied] = useState(false);
 
   const activePreset = queryGroupPresets.find((preset) => preset.id === activePresetId) ?? null;

--- a/apps/marketing/src/components/sections/support-demo-workspace.tsx
+++ b/apps/marketing/src/components/sections/support-demo-workspace.tsx
@@ -9,16 +9,29 @@ import {
   supportScenarioPresets,
 } from '@/lib/demo/support/relationship-trail';
 import { serializeSupportPresetToUrl } from '@/lib/demo/support/serialize-preset';
-import { useNextjsUrlAdapter } from '@/lib/nextjs-url-adapter';
+import { UrlNavigationPendingProvider, useNextjsUrlAdapter } from '@/lib/nextjs-url-adapter';
 import { cn } from '@/lib/utils';
 
 interface SupportDemoWorkspaceProps {
   fetchResult: FetchTicketsResult;
 }
 
-export function SupportDemoWorkspace({ fetchResult }: SupportDemoWorkspaceProps) {
+/**
+ * Provider wrapper so a preset/reset click (this component's hook) and the
+ * table's dim-while-pending (`TicketsTableClient`'s hook) share one
+ * transition — the inner component's hook must run UNDER the provider.
+ */
+export function SupportDemoWorkspace(props: SupportDemoWorkspaceProps) {
+  return (
+    <UrlNavigationPendingProvider>
+      <SupportDemoWorkspaceInner {...props} />
+    </UrlNavigationPendingProvider>
+  );
+}
+
+function SupportDemoWorkspaceInner({ fetchResult }: SupportDemoWorkspaceProps) {
   const { result, filters, sorting, error } = fetchResult;
-  const urlAdapter = useNextjsUrlAdapter();
+  const { adapter: urlAdapter } = useNextjsUrlAdapter();
   const relationshipTrail = useMemo(() => buildRelationshipTrail(filters), [filters]);
 
   const applyPreset = (presetId: string) => {

--- a/apps/marketing/src/components/sections/tickets-table-client.tsx
+++ b/apps/marketing/src/components/sections/tickets-table-client.tsx
@@ -29,7 +29,7 @@ export function TicketsTableClient({
   initialSorting,
   initialFilters,
 }: TicketsTableClientProps) {
-  const urlAdapter = useNextjsUrlAdapter();
+  const { adapter: urlAdapter, isPending } = useNextjsUrlAdapter();
 
   useTableUrlSync(
     TABLE_ID,
@@ -58,6 +58,7 @@ export function TicketsTableClient({
       table={ticketsTable}
       adapter={adapter}
       data={data}
+      loading={isPending}
       totalCount={totalCount}
       initialPagination={initialPagination}
       initialSorting={initialSorting}

--- a/apps/marketing/src/instrumentation.ts
+++ b/apps/marketing/src/instrumentation.ts
@@ -1,0 +1,36 @@
+/**
+ * Server-boot warmup for the demo databases (Next.js instrumentation hook).
+ *
+ * Both demo backends are lazy in-memory SQLite singletons seeded on first
+ * use — 5,000 users (+ profiles/posts) for the homepage and 12,000+ tickets
+ * for the examples. Without this hook the FIRST visitor's request paid the
+ * whole seed inline before getting a response. Kick both initializations at
+ * server start instead; concurrent early requests share the same memoized
+ * init promise, so the worst case becomes "seed still finishing", never
+ * "seed not started".
+ *
+ * Fire-and-forget on purpose: seeding must not delay server readiness, and
+ * a warmup failure is non-fatal — the first real read retries and surfaces
+ * the error through the normal path. `next build` never runs this (register
+ * fires on server start, not at build), so native-driver setup stays out of
+ * build-time page-data collection.
+ */
+export async function register(): Promise<void> {
+  if (process.env.NEXT_RUNTIME !== 'nodejs') return;
+
+  const warm = async () => {
+    const [users, support] = await Promise.all([
+      import('@/lib/demo/users/adapter'),
+      import('@/lib/demo/support/db'),
+    ]);
+    await Promise.all([users.getTables(), support.getSupportTables()]);
+  };
+
+  void warm().catch((error) => {
+    // biome-ignore lint/suspicious/noConsole: server-side demo bootstrap diagnostic
+    console.warn(
+      '[instrumentation] demo database warmup failed (first request will retry):',
+      error instanceof Error ? error.message : error
+    );
+  });
+}

--- a/apps/marketing/src/lib/demo/adapter-guard.test.ts
+++ b/apps/marketing/src/lib/demo/adapter-guard.test.ts
@@ -43,6 +43,34 @@ describe('createAdapterGuard', () => {
     ).toBe(false);
   });
 
+  it('collects every column of a batched getFacets request plus its filter columns', () => {
+    const body: AdapterRequestBody = {
+      method: 'getFacets',
+      requests: [
+        { columnId: 'status', kind: 'values' },
+        { columnId: 'name', kind: 'values' },
+        { columnId: 'owner.email', kind: 'minmax' },
+      ],
+      params: {
+        filters: [{ columnId: 'name', type: 'text', operator: 'contains', values: ['a'] }],
+      },
+    };
+    expect(collectAdapterColumnIds(body)).toEqual(['status', 'name', 'owner.email', 'name']);
+    expect(guard.isAllowed(body)).toBe(true);
+  });
+
+  it('rejects a batched getFacets request that references a column outside the allowlist', () => {
+    expect(
+      guard.isAllowed({
+        method: 'getFacets',
+        requests: [
+          { columnId: 'status', kind: 'values' },
+          { columnId: 'company', kind: 'values' },
+        ],
+      })
+    ).toBe(false);
+  });
+
   it('pins fetchData / describeColumns / resolveCellWriteTarget to the table', () => {
     const fetchConstrained = guard.constrain({
       method: 'fetchData',

--- a/apps/marketing/src/lib/demo/adapter-guard.ts
+++ b/apps/marketing/src/lib/demo/adapter-guard.ts
@@ -50,6 +50,15 @@ export function collectAdapterColumnIds(body: AdapterRequestBody): string[] {
     return ids;
   }
 
+  // Batched facets: every requested column + any filter column ids.
+  if (body.method === 'getFacets') {
+    for (const request of body.requests) {
+      ids.push(request.columnId);
+    }
+    ids.push(...collectFilterColumnIds(body.params?.filters));
+    return ids;
+  }
+
   // Facet / filter-option methods: target column + any filter column ids.
   ids.push(body.columnId);
   ids.push(...collectFilterColumnIds(body.params?.filters));

--- a/apps/marketing/src/lib/demo/users/adapter.ts
+++ b/apps/marketing/src/lib/demo/users/adapter.ts
@@ -112,8 +112,10 @@ export async function getUsersDatabaseAdapter(): Promise<UsersAdapter> {
 }
 
 /**
- * Reset is SQLite-only. Closes the in-memory DB so the next request re-seeds.
- * No-op-safe to call after checking supportsReset.
+ * Reset is SQLite-only. Closes the in-memory DB and immediately kicks the
+ * re-seed (fire-and-forget), so the fresh data is warming while the demo
+ * refreshes instead of the user's next interaction paying the whole seed
+ * cost inline. No-op-safe to call after checking supportsReset.
  */
 export async function resetUsersDatabase() {
   const dialect = await getUsersDialect();
@@ -122,6 +124,10 @@ export async function resetUsersDatabase() {
   }
   await resetSqliteDatabase();
   resetAdapterCaches();
+  void ensureResolved().catch(() => {
+    // Warmup failure is non-fatal: the next real read retries and surfaces
+    // the error through the normal fetch path.
+  });
 }
 
 /** Test helper — drop both backends' caches/connections. */

--- a/apps/marketing/src/lib/nextjs-url-adapter.tsx
+++ b/apps/marketing/src/lib/nextjs-url-adapter.tsx
@@ -2,7 +2,14 @@
 
 import type { UrlSyncAdapter } from '@better-tables/core';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { useMemo } from 'react';
+import {
+  createContext,
+  type ReactNode,
+  type TransitionStartFunction,
+  useContext,
+  useMemo,
+  useTransition,
+} from 'react';
 
 /**
  * URL params the server (the `LiveDemo` RSC) reads to build its query. A change
@@ -11,6 +18,43 @@ import { useMemo } from 'react';
  * client-only view preference the server ignores.
  */
 const SERVER_AFFECTING_PARAMS = ['page', 'limit', 'filters', 'sorting'] as const;
+
+/**
+ * What {@link useNextjsUrlAdapter} returns: the sync adapter plus a pending
+ * flag that is true while a server-affecting navigation (the RSC round-trip
+ * behind a pagination/filter/sort change) is in flight. Feed `isPending` to
+ * `<BetterTable loading>` so the rows dim during the round-trip instead of
+ * sitting frozen with no feedback.
+ */
+export interface NextjsUrlSync {
+  adapter: UrlSyncAdapter;
+  isPending: boolean;
+}
+
+interface NavigationPending {
+  isPending: boolean;
+  startTransition: TransitionStartFunction;
+}
+
+const NavigationPendingContext = createContext<NavigationPending | null>(null);
+
+/**
+ * Share ONE transition across sibling components. `useTransition` only tracks
+ * transitions the same hook instance started, so on pages where one component
+ * navigates (the facets sidebar, a preset picker) and another shows the data
+ * (the table client), each would otherwise have a private `isPending` and the
+ * table would sit frozen during a sidebar-initiated round-trip. Wrap such
+ * siblings in this provider and every `useNextjsUrlAdapter` under it reports
+ * the shared pending state. Components without a provider fall back to a
+ * local transition — fine when the same component navigates and renders.
+ */
+export function UrlNavigationPendingProvider({ children }: { children: ReactNode }) {
+  const [isPending, startTransition] = useTransition();
+  const value = useMemo(() => ({ isPending, startTransition }), [isPending, startTransition]);
+  return (
+    <NavigationPendingContext.Provider value={value}>{children}</NavigationPendingContext.Provider>
+  );
+}
 
 /**
  * Next.js App Router URL sync adapter.
@@ -25,17 +69,22 @@ const SERVER_AFFECTING_PARAMS = ['page', 'limit', 'filters', 'sorting'] as const
  *    one (selection changes, redundant writes) — no navigation at all;
  *  - uses `router.replace` (not `push`, so an interaction isn't a back-button
  *    stop) only when a *server-affecting* param actually changed value, since
- *    only then does the server need to refetch;
+ *    only then does the server need to refetch — wrapped in a transition so
+ *    `isPending` exposes the round-trip to the UI;
  *  - otherwise updates the URL with a shallow `history.replaceState`, keeping
  *    client-only view state (column visibility/order) shareable in the URL
  *    without paying a server round-trip the server would ignore.
  */
-export function useNextjsUrlAdapter(): UrlSyncAdapter {
+export function useNextjsUrlAdapter(): NextjsUrlSync {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  const shared = useContext(NavigationPendingContext);
+  const [localIsPending, localStartTransition] = useTransition();
+  const isPending = shared ? shared.isPending : localIsPending;
+  const startTransition = shared ? shared.startTransition : localStartTransition;
 
-  return useMemo(
+  const adapter = useMemo<UrlSyncAdapter>(
     () => ({
       getParam: (key: string) => searchParams.get(key),
 
@@ -68,7 +117,9 @@ export function useNextjsUrlAdapter(): UrlSyncAdapter {
         const newUrl = `${pathname}${nextQuery ? `?${nextQuery}` : ''}${hash}`;
 
         if (serverChanged) {
-          router.replace(newUrl, { scroll: false });
+          startTransition(() => {
+            router.replace(newUrl, { scroll: false });
+          });
         } else if (typeof window !== 'undefined') {
           // Client-only view state: keep it in the URL without a server
           // round-trip. Preserve Next's history state so routing stays intact;
@@ -77,6 +128,8 @@ export function useNextjsUrlAdapter(): UrlSyncAdapter {
         }
       },
     }),
-    [router, pathname, searchParams]
+    [router, pathname, searchParams, startTransition]
   );
+
+  return useMemo(() => ({ adapter, isPending }), [adapter, isPending]);
 }

--- a/biome.json
+++ b/biome.json
@@ -16,7 +16,11 @@
       "!!.git",
       "!!.turbo",
       "!!**/next-env.d.ts",
-      "!!packages/cli/ui-src"
+      "!!packages/cli/ui-src",
+      "!!**/test-results",
+      "!!**/e2e-results",
+      "!!**/playwright-report",
+      "!!**/bench-results"
     ]
   },
   "linter": {

--- a/bun.lock
+++ b/bun.lock
@@ -53,6 +53,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "catalog:",
+        "@playwright/test": "catalog:",
         "@tailwindcss/typography": "^0.5.19",
         "@types/better-sqlite3": "catalog:",
         "@types/mdx": "^2.0.14",
@@ -77,6 +78,7 @@
         "better-sqlite3": "catalog:",
         "dotenv": "^17.2.3",
         "drizzle-orm": "catalog:",
+        "mitata": "catalog:",
         "mysql2": "^3.12.0",
         "postgres": "^3.4.0",
         "react": "catalog:",
@@ -103,6 +105,7 @@
       "devDependencies": {
         "@better-tables/core": "workspace:*",
         "drizzle-orm": "catalog:",
+        "mitata": "catalog:",
         "tsdown": "catalog:",
         "typescript": "catalog:",
       },
@@ -140,6 +143,7 @@
       "devDependencies": {
         "@types/react": "catalog:",
         "@types/react-dom": "catalog:",
+        "mitata": "catalog:",
         "react": "catalog:",
         "react-dom": "catalog:",
         "tsdown": "catalog:",
@@ -201,6 +205,7 @@
     "@biomejs/biome": "2.3.11",
     "@date-fns/tz": "^1.5.0",
     "@happy-dom/global-registrator": "^20.0.0",
+    "@playwright/test": "^1.57.0",
     "@tailwindcss/postcss": "^4.1.18",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/react": "^16.3.0",
@@ -215,6 +220,7 @@
     "drizzle-orm": "^0.45.1",
     "lucide-react": "^0.562.0",
     "lz-string": "^1.5.0",
+    "mitata": "^1.0.34",
     "next": "^16.1.3",
     "postcss": "^8.5.10",
     "react": "19.2.3",
@@ -546,6 +552,8 @@
     "@orama/orama": ["@orama/orama@3.1.18", "", {}, "sha512-a61ljmRVVyG5MC/698C8/FfFDw5a8LOIvyOLW5fztgUXqUpc1jOfQzOitSCbge657OgXXThmY3Tk8fpiDb4UcA=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.99.0", "", {}, "sha512-LLDEhXB7g1m5J+woRSgfKsFPS3LhR9xRhTeIoEBm5WrkwMxn6eZ0Ld0c0K5eHB57ChZX6I3uSmmLjZ8pcjlRcw=="],
+
+    "@playwright/test": ["@playwright/test@1.61.1", "", { "dependencies": { "playwright": "1.61.1" }, "bin": { "playwright": "cli.js" } }, "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig=="],
 
     "@quansync/fs": ["@quansync/fs@1.0.0", "", { "dependencies": { "quansync": "^1.0.0" } }, "sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ=="],
 
@@ -1101,6 +1109,8 @@
 
     "fs-extra": ["fs-extra@7.0.1", "", { "dependencies": { "graceful-fs": "^4.1.2", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw=="],
 
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
     "fumadocs-core": ["fumadocs-core@16.11.5", "", { "dependencies": { "@orama/orama": "^3.1.18", "estree-util-value-to-estree": "^3.5.0", "github-slugger": "^2.0.0", "hast-util-to-estree": "^3.1.3", "hast-util-to-jsx-runtime": "^2.3.6", "mdast-util-mdx": "^3.0.0", "mdast-util-to-markdown": "^2.1.2", "remark": "^15.0.1", "remark-gfm": "^4.0.1", "remark-rehype": "^11.1.2", "scroll-into-view-if-needed": "^3.1.0", "shiki": "^4.3.1", "tinyglobby": "^0.2.17", "unified": "^11.0.5", "unist-util-visit": "^5.1.0", "vfile": "^6.0.3", "yaml": "^2.9.0" }, "peerDependencies": { "@mdx-js/mdx": "*", "@mixedbread/sdk": "0.x.x", "@orama/core": "1.x.x", "@oramacloud/client": "2.x.x", "@tanstack/react-router": "1.x.x", "@types/estree-jsx": "*", "@types/hast": "*", "@types/mdast": "*", "@types/react": "*", "algoliasearch": "5.x.x", "flexsearch": "*", "lucide-react": "*", "next": "16.x.x", "react": "^19.2.0", "react-dom": "^19.2.0", "react-router": "7.x.x || 8.x.x", "waku": "*", "zod": "4.x.x" }, "optionalPeers": ["@mdx-js/mdx", "@mixedbread/sdk", "@orama/core", "@oramacloud/client", "@tanstack/react-router", "@types/estree-jsx", "@types/hast", "@types/mdast", "@types/react", "algoliasearch", "flexsearch", "lucide-react", "next", "react", "react-dom", "react-router", "waku", "zod"] }, "sha512-YrHjS09+QYYKOSTGyiZbxF/VDs7ciMcjurYBGfmYqtzdj14k7Ho0HX9c6VuvG54YsYHQs5mGWemT1TXm7vDBaA=="],
 
     "fumadocs-mdx": ["fumadocs-mdx@15.2.0", "", { "dependencies": { "@mdx-js/mdx": "^3.1.1", "@standard-schema/spec": "^1.1.0", "chokidar": "^5.0.0", "esbuild": "^0.28.1", "estree-util-value-to-estree": "^3.5.0", "github-slugger": "^2.0.0", "magic-string": "^0.30.21", "mdast-util-mdx": "^3.0.0", "picocolors": "^1.1.1", "picomatch": "^4.0.5", "tinyexec": "^1.2.4", "tinyglobby": "^0.2.17", "unified": "^11.0.5", "unist-util-remove-position": "^5.0.0", "unist-util-visit": "^5.1.0", "vfile": "^6.0.3", "yaml": "^2.9.0", "yuku-analyzer": "^0.6.3", "zod": "^4.4.3" }, "peerDependencies": { "@fumadocs/satteri": "0.x.x", "@types/mdast": "*", "@types/mdx": "*", "@types/react": "*", "fumadocs-core": "^16.7.0", "mdast-util-directive": "*", "next": "^15.3.0 || ^16.0.0", "react": "^19.2.0", "rolldown": "*", "satteri": "^0.9.4", "vite": "7.x.x || 8.x.x" }, "optionalPeers": ["@fumadocs/satteri", "@types/mdast", "@types/mdx", "@types/react", "mdast-util-directive", "next", "react", "rolldown", "satteri", "vite"], "bin": { "fumadocs-mdx": "./bin.js" } }, "sha512-+yBP8QYw5wA9LF5eVdMhwbP7KT1OF4B/YfC6PZoD2jz0amZi1B+6QHTI6XoRRSTmhWrI4cL5LU1DspW0itk+NA=="],
@@ -1447,6 +1457,8 @@
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
+    "mitata": ["mitata@1.0.34", "", {}, "sha512-Mc3zrtNBKIMeHSCQ0XqRLo1vbdIx1wvFV9c8NJAiyho6AjNfMY8bVhbS12bwciUdd1t4rj8099CH3N3NFahaUA=="],
+
     "mkdirp-classic": ["mkdirp-classic@0.5.3", "", {}, "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="],
 
     "motion": ["motion@12.42.2", "", { "dependencies": { "framer-motion": "^12.42.2", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-Atvv11yUKIid41cVrRBDVX5m8tF8kNpExRSlbpt6APClhDjtwQssgFHhQzejxw7/7YYbjHSPKBVbHo05BuJT5Q=="],
@@ -1550,6 +1562,10 @@
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
     "pkg-up": ["pkg-up@3.1.0", "", { "dependencies": { "find-up": "^3.0.0" } }, "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA=="],
+
+    "playwright": ["playwright@1.61.1", "", { "dependencies": { "playwright-core": "1.61.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ=="],
+
+    "playwright-core": ["playwright-core@1.61.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg=="],
 
     "postcss": ["postcss@8.5.19", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ=="],
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
       "zustand": "^5.0.14",
       "@happy-dom/global-registrator": "^20.0.0",
       "@testing-library/dom": "^10.4.0",
-      "@testing-library/react": "^16.3.0"
+      "@testing-library/react": "^16.3.0",
+      "@playwright/test": "^1.57.0",
+      "mitata": "^1.0.34"
     }
   },
   "scripts": {
@@ -48,6 +50,7 @@
     "dev:run": "turbo run dev",
     "typecheck": "turbo run typecheck",
     "test": "turbo run test",
+    "bench": "turbo run bench",
     "clean": "turbo run clean",
     "lint": "biome check --write --unsafe .",
     "changeset": "changeset",

--- a/packages/adapters/drizzle/bench/index.ts
+++ b/packages/adapters/drizzle/bench/index.ts
@@ -1,0 +1,188 @@
+/**
+ * @fileoverview mitata micro-benchmarks for @better-tables/adapters-drizzle
+ * (plan 063 Step 4).
+ *
+ * Trend tier — NOT part of `bun test` (lives in bench/, outside the test
+ * globs) and never a PR gate. Absolute numbers are machine-dependent; they
+ * feed `bench-results/@better-tables-adapters-drizzle.json`
+ * (github-action-benchmark `customSmallerIsBetter` format) for trend
+ * tracking on main only.
+ *
+ * Run with `bun bench/index.ts` from packages/adapters/drizzle, or
+ * `bun run bench` at the repo root (turbo). Emitted `value` is mitata's p50
+ * (median) of the measured samples, in nanoseconds per iteration.
+ *
+ * Measurement choice (plan 063 Step 4): `fetchData` runs end-to-end against
+ * an in-memory bun:sqlite database seeded with the shared 3-row test fixture
+ * (tests/helpers/test-fixtures.ts). Isolating "pure SQL generation" would
+ * mean benching private query-builder internals — a brittle, non-public
+ * seam — so these numbers are SQL generation + statement execution against
+ * a trivially small :memory: dataset; generation dominates. The adapter's
+ * LRU result cache is DISABLED so every iteration regenerates SQL instead
+ * of measuring a cache hit.
+ */
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { FilterGroupNode, FilterState } from '@better-tables/core';
+import { bench, do_not_optimize, run } from 'mitata';
+import { DrizzleAdapter } from '../src/drizzle-adapter';
+import type { DrizzleAdapterConfig, DrizzleDatabase } from '../src/types';
+import { createSQLiteDatabase, setupSQLiteDatabase } from '../tests/helpers/test-fixtures';
+import { relationsSchema, schema } from '../tests/helpers/test-schema';
+
+const PACKAGE_NAME = '@better-tables/adapters-drizzle';
+const ENTRY_PREFIX = 'drizzle';
+
+/** github-action-benchmark `customSmallerIsBetter` entry. */
+interface BenchEntry {
+  name: string;
+  unit: string;
+  value: number;
+}
+
+/** Write entries to <package>/bench-results/<package-name>.json. */
+function writeBenchResults(entries: BenchEntry[]): string {
+  const dir = join(import.meta.dir, '..', 'bench-results');
+  mkdirSync(dir, { recursive: true });
+  const file = join(dir, `${PACKAGE_NAME.replace('/', '-')}.json`);
+  writeFileSync(file, `${JSON.stringify(entries, null, 2)}\n`);
+  return file;
+}
+
+// ---------------------------------------------------------------------------
+// Adapter over in-memory bun:sqlite (mirrors tests/helpers/test-fixtures.ts's
+// createSQLiteAdapter, plus a disabled result cache so repeat fetchData calls
+// regenerate SQL instead of hitting the plan-040 LRU)
+// ---------------------------------------------------------------------------
+
+const { db } = createSQLiteDatabase();
+await setupSQLiteDatabase(db);
+
+const config: DrizzleAdapterConfig<typeof schema, 'sqlite'> = {
+  // Same cast rationale as tests/helpers/test-fixtures.ts: the suite runs on
+  // bun:sqlite while the adapter types assume better-sqlite3; the query API
+  // surface used here is identical across both drivers.
+  db: db as unknown as DrizzleDatabase<'sqlite'>,
+  schema,
+  driver: 'sqlite',
+  autoDetectRelationships: true,
+  relations: relationsSchema,
+  options: { defaultPrimaryTable: 'users', cache: { enabled: false, ttl: 0 } },
+};
+
+const adapter = new DrizzleAdapter(config);
+
+// ---------------------------------------------------------------------------
+// Filter fixtures
+// ---------------------------------------------------------------------------
+
+/** 20 AND-ed leaves cycling over users.name/email (text) and users.age (number). */
+function makeLeafFilters(count: number): FilterState[] {
+  const leaves: FilterState[] = [];
+  for (let i = 0; i < count; i++) {
+    switch (i % 4) {
+      case 0:
+        leaves.push({ columnId: 'name', type: 'text', operator: 'contains', values: [`n${i}`] });
+        break;
+      case 1:
+        leaves.push({ columnId: 'email', type: 'text', operator: 'contains', values: [`e${i}`] });
+        break;
+      case 2:
+        leaves.push({ columnId: 'age', type: 'number', operator: 'greaterThan', values: [i] });
+        break;
+      default:
+        leaves.push({ columnId: 'age', type: 'number', operator: 'lessThan', values: [100 + i] });
+    }
+  }
+  return leaves;
+}
+
+const leafFilters20 = makeLeafFilters(20);
+
+/** Depth-3 AND(leaf, OR(leaf, AND(leaf, leaf)), OR(leaf, leaf)) tree. */
+const depth3Tree: FilterGroupNode = {
+  kind: 'group',
+  logic: 'and',
+  children: [
+    { columnId: 'age', type: 'number', operator: 'greaterThan', values: [18] },
+    {
+      kind: 'group',
+      logic: 'or',
+      children: [
+        { columnId: 'name', type: 'text', operator: 'contains', values: ['Jo'] },
+        {
+          kind: 'group',
+          logic: 'and',
+          children: [
+            { columnId: 'age', type: 'number', operator: 'lessThan', values: [40] },
+            { columnId: 'email', type: 'text', operator: 'endsWith', values: ['example.com'] },
+          ],
+        },
+      ],
+    },
+    {
+      kind: 'group',
+      logic: 'or',
+      children: [
+        { columnId: 'email', type: 'text', operator: 'contains', values: ['j'] },
+        { columnId: 'name', type: 'text', operator: 'startsWith', values: ['B'] },
+      ],
+    },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Benchmarks
+// ---------------------------------------------------------------------------
+
+bench('fetchData.no-filters', async () => {
+  do_not_optimize(await adapter.fetchData({ pagination: { page: 1, limit: 10 } }));
+});
+
+bench('fetchData.20-leaf-filters', async () => {
+  do_not_optimize(
+    await adapter.fetchData({ filters: leafFilters20, pagination: { page: 1, limit: 10 } })
+  );
+});
+
+bench('fetchData.depth-3-tree', async () => {
+  do_not_optimize(
+    await adapter.fetchData({ filters: depth3Tree, pagination: { page: 1, limit: 10 } })
+  );
+});
+
+// Relational column selection: one-to-one (profile.bio) + one-to-many
+// (posts.title) → JOIN generation and the plan-020 two-phase fan-out path.
+bench('fetchData.relational-columns', async () => {
+  do_not_optimize(
+    await adapter.fetchData({
+      columns: ['id', 'name', 'email', 'profile.bio', 'posts.title'],
+      pagination: { page: 1, limit: 10 },
+    })
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Run + report
+// ---------------------------------------------------------------------------
+
+const result = await run();
+
+const entries: BenchEntry[] = [];
+for (const trial of result.benchmarks) {
+  for (const benchRun of trial.runs) {
+    if (benchRun.error !== undefined || benchRun.stats === undefined) {
+      throw new Error(`bench "${benchRun.name}" failed: ${String(benchRun.error)}`);
+    }
+    entries.push({
+      name: `${ENTRY_PREFIX}/${benchRun.name}`,
+      unit: 'ns',
+      value: Math.round(benchRun.stats.p50 * 100) / 100,
+    });
+  }
+}
+
+const file = writeBenchResults(entries);
+// biome-ignore lint/suspicious/noConsole: bench reporter output
+console.log(`wrote ${entries.length} entries to ${file}`);

--- a/packages/adapters/drizzle/package.json
+++ b/packages/adapters/drizzle/package.json
@@ -24,6 +24,7 @@
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch",
+    "bench": "bun bench/index.ts",
     "test": "bun test",
     "test:watch": "bun test --watch",
     "test:coverage": "bun test --coverage",

--- a/packages/adapters/drizzle/package.json
+++ b/packages/adapters/drizzle/package.json
@@ -62,6 +62,7 @@
     "better-sqlite3": "catalog:",
     "dotenv": "^17.2.3",
     "drizzle-orm": "catalog:",
+    "mitata": "catalog:",
     "mysql2": "^3.12.0",
     "postgres": "^3.4.0",
     "react": "catalog:",

--- a/packages/adapters/drizzle/tests/query-count.test.ts
+++ b/packages/adapters/drizzle/tests/query-count.test.ts
@@ -1,0 +1,379 @@
+/**
+ * Plan 063 Step 2 — Tier 1 query-count + plan-shape gates (SQLite, bun:sqlite).
+ *
+ * Pins the EXACT number of SQL statements the Drizzle adapter issues per
+ * public operation, observed through drizzle-orm's `logger` seam
+ * (`drizzle(sqlite, { logger })` — every adapter query runs through the
+ * drizzle session, so the logger sees them all; DDL/seeding below
+ * deliberately uses the raw bun:sqlite handle so it is NOT counted).
+ * Also pins EXPLAIN QUERY PLAN canaries for index usage, run against the
+ * SAME SQL text (and bound params) the adapter actually issued.
+ *
+ * Everything here is a deterministic integer or plan-shape string — no
+ * timing. If a pinned count changes, that is a product-behavior change
+ * (a statement added to or removed from an operation): update the number
+ * in the same PR with a comment citing the plan/PR that changed it
+ * (plan 063 maintenance notes — the test is the changelog).
+ *
+ * Characterized 2026-07-23 on this branch; every number below was verified
+ * by printing the captured statements before pinning.
+ */
+
+import { Database } from 'bun:sqlite';
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { relations } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/bun-sqlite';
+import type { Logger } from 'drizzle-orm/logger';
+import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { drizzleAdapter } from '../src/factory';
+
+/**
+ * Fixture schema: `tickets` (primary) with one many-to-one relation
+ * (`tickets.agentId` → `agents`, alias `agent`) and one one-to-many
+ * relation (`notes.ticketId` → `tickets`, alias `notes`), mirroring the
+ * users/profiles/posts idiom in `helpers/test-schema.ts`.
+ */
+const agents = sqliteTable('agents', {
+  id: integer('id').primaryKey(),
+  name: text('name').notNull(),
+});
+
+const tickets = sqliteTable('tickets', {
+  id: integer('id').primaryKey(),
+  subject: text('subject').notNull(),
+  status: text('status').notNull(),
+  priority: integer('priority').notNull(),
+  agentId: integer('agent_id')
+    .notNull()
+    .references(() => agents.id),
+});
+
+const notes = sqliteTable('notes', {
+  id: integer('id').primaryKey(),
+  ticketId: integer('ticket_id')
+    .notNull()
+    .references(() => tickets.id),
+  body: text('body').notNull(),
+});
+
+const schema = { agents, tickets, notes };
+
+const ticketsRelations = relations(tickets, ({ one, many }) => ({
+  agent: one(agents, { fields: [tickets.agentId], references: [agents.id] }),
+  notes: many(notes),
+}));
+const agentsRelations = relations(agents, ({ many }) => ({
+  tickets: many(tickets),
+}));
+const notesRelations = relations(notes, ({ one }) => ({
+  ticket: one(tickets, { fields: [notes.ticketId], references: [tickets.id] }),
+}));
+
+const relationsSchema = {
+  tickets: ticketsRelations,
+  agents: agentsRelations,
+  notes: notesRelations,
+};
+
+type LoggedStatement = { query: string; params: unknown[] };
+
+describe('DrizzleAdapter — query-count gates (plan 063 Step 2)', () => {
+  let sqlite: Database;
+  let statements: LoggedStatement[];
+  let adapter: ReturnType<typeof drizzleAdapter>;
+
+  /** Statements captured after `mark` (use `statements.length` as the mark). */
+  const statementsSince = (mark: number): LoggedStatement[] => statements.slice(mark);
+
+  /**
+   * Run EXPLAIN QUERY PLAN for a statement the adapter issued, binding the
+   * exact params the adapter bound, and return the plan `detail` strings.
+   */
+  const explainDetails = (stmt: LoggedStatement): string[] => {
+    const rows = sqlite
+      .prepare(`EXPLAIN QUERY PLAN ${stmt.query}`)
+      .all(...(stmt.params as (string | number)[])) as Array<{ detail: string }>;
+    return rows.map((row) => String(row.detail));
+  };
+
+  beforeEach(() => {
+    sqlite = new Database(':memory:');
+    // DDL + deterministic seed through the RAW handle (not drizzle) so none
+    // of it is counted by the logger. INDEX on `status` — the commonly
+    // filtered column — is what the EXPLAIN canaries below guard.
+    sqlite.exec(`
+      CREATE TABLE agents (id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+      CREATE TABLE tickets (
+        id INTEGER PRIMARY KEY,
+        subject TEXT NOT NULL,
+        status TEXT NOT NULL,
+        priority INTEGER NOT NULL,
+        agent_id INTEGER NOT NULL REFERENCES agents(id)
+      );
+      CREATE TABLE notes (
+        id INTEGER PRIMARY KEY,
+        ticket_id INTEGER NOT NULL REFERENCES tickets(id),
+        body TEXT NOT NULL
+      );
+      CREATE INDEX idx_tickets_status ON tickets(status);
+    `);
+    const insertAgent = sqlite.prepare('INSERT INTO agents (id, name) VALUES (?, ?)');
+    for (let i = 1; i <= 3; i++) insertAgent.run(i, `Agent ${i}`);
+    // 20 tickets: statuses cycle open/closed/pending/open → 10 open,
+    // 5 closed, 5 pending; 2 notes per ticket (40 note rows).
+    const statuses = ['open', 'closed', 'pending', 'open'] as const;
+    const insertTicket = sqlite.prepare(
+      'INSERT INTO tickets (id, subject, status, priority, agent_id) VALUES (?, ?, ?, ?, ?)'
+    );
+    const insertNote = sqlite.prepare('INSERT INTO notes (id, ticket_id, body) VALUES (?, ?, ?)');
+    for (let i = 1; i <= 20; i++) {
+      insertTicket.run(
+        i,
+        `Ticket ${i}`,
+        statuses[(i - 1) % 4] as string,
+        ((i - 1) % 5) + 1,
+        ((i - 1) % 3) + 1
+      );
+      insertNote.run(i * 2 - 1, i, `Note ${i}a`);
+      insertNote.run(i * 2, i, `Note ${i}b`);
+    }
+
+    statements = [];
+    const countingLogger: Logger = {
+      logQuery(query: string, params: unknown[]): void {
+        statements.push({ query, params });
+      },
+    };
+    const db = drizzle(sqlite, { schema, logger: countingLogger });
+    adapter = drizzleAdapter(db, {
+      driver: 'sqlite',
+      schema,
+      relations: relationsSchema,
+      options: { defaultPrimaryTable: 'tickets', defaultMutationTable: 'tickets' },
+    });
+  });
+
+  afterEach(() => {
+    sqlite.close();
+  });
+
+  describe('statement counts per operation (exact integers)', () => {
+    it('plain fetchData issues exactly 2 statements (data page + total count)', async () => {
+      const mark = statements.length;
+      const result = await adapter.fetchData({
+        columns: ['subject', 'status', 'priority'],
+        pagination: { page: 1, limit: 10 },
+      });
+
+      expect(result.data).toHaveLength(10);
+      expect(result.total).toBe(20);
+
+      const issued = statementsSince(mark);
+      // 2 = one LIMIT'd data SELECT + one `select count(*)` — executed in
+      // parallel by fetchData (drizzle-adapter.ts `Promise.all`). Anything
+      // above 2 here is a duplicate-query/N+1 regression.
+      expect(issued).toHaveLength(2);
+      expect(issued.filter((s) => /count\(/i.test(s.query))).toHaveLength(1);
+    });
+
+    it('fetchData with a many-to-one relation column still issues exactly 2 statements', async () => {
+      const mark = statements.length;
+      const result = await adapter.fetchData({
+        columns: ['subject', 'agent.name'],
+        pagination: { page: 1, limit: 10 },
+      });
+
+      expect(result.total).toBe(20);
+
+      const issued = statementsSince(mark);
+      // 2 = one LEFT JOIN data SELECT + one `count(distinct tickets.id)`
+      // (the distinct-primary-key guard under joins). A many-to-one join
+      // cannot fan out, so no phase split happens — the single-query path.
+      expect(issued).toHaveLength(2);
+      expect(issued.filter((s) => /count\(distinct/i.test(s.query))).toHaveLength(1);
+      expect(issued.filter((s) => /left join "agents"/i.test(s.query))).toHaveLength(2);
+    });
+
+    it('fetchData with a one-to-many relation column issues exactly 3 statements (two-phase fan-out)', async () => {
+      const mark = statements.length;
+      const result = await adapter.fetchData({
+        columns: ['subject', 'notes.body'],
+        pagination: { page: 1, limit: 5 },
+      });
+
+      expect(result.data).toHaveLength(5);
+      expect(result.total).toBe(20);
+
+      const issued = statementsSince(mark);
+      // 3 = plan 020's two-phase fan-out pagination plus the count:
+      //   1. phase 1 — DISTINCT primary-key page (GROUP BY pk … LIMIT),
+      //   2. `count(distinct tickets.id)` under the join,
+      //   3. phase 2 — full joined rows for exactly that page's keys
+      //      (WHERE tickets.id IN (…), no LIMIT/OFFSET).
+      // 4+ would mean a per-row N+1; 2 would mean the fan-out under-fill
+      // fix (plan 020, ADAPTER-03) silently stopped engaging.
+      expect(issued).toHaveLength(3);
+      expect(issued.filter((s) => /group by "tickets"\."id"/i.test(s.query))).toHaveLength(1);
+      expect(issued.filter((s) => /count\(distinct/i.test(s.query))).toHaveLength(1);
+      expect(issued.filter((s) => /"tickets"\."id" in \(/i.test(s.query))).toHaveLength(1);
+    });
+
+    it('one getFacetedValues call issues exactly 1 statement', async () => {
+      const mark = statements.length;
+      const facets = await adapter.getFacetedValues('status');
+
+      expect(facets.get('open')).toBe(10);
+      expect(facets.get('closed')).toBe(5);
+      expect(facets.get('pending')).toBe(5);
+
+      // 1 = a single GROUP BY count aggregate (top-100 LIMIT'd, plan 040).
+      expect(statementsSince(mark)).toHaveLength(1);
+    });
+
+    it('one getMinMaxValues call issues exactly 1 statement', async () => {
+      const mark = statements.length;
+      const [min, max] = await adapter.getMinMaxValues('priority');
+
+      expect(min).toBe(1);
+      expect(max).toBe(5);
+
+      // 1 = a single `select min(…), max(…)` — both bounds in one query.
+      expect(statementsSince(mark)).toHaveLength(1);
+    });
+
+    it('a repeated identical fetchData issues 0 statements (plan 040 LRU cache hit)', async () => {
+      await adapter.fetchData({
+        columns: ['subject', 'status', 'priority'],
+        pagination: { page: 1, limit: 10 },
+      });
+
+      const mark = statements.length;
+      const result = await adapter.fetchData({
+        columns: ['subject', 'status', 'priority'],
+        pagination: { page: 1, limit: 10 },
+      });
+
+      expect(result.data).toHaveLength(10);
+      expect(result.meta?.cached).toBe(true);
+
+      // 0 = the bounded LRU cache (plan 040) is DEFAULT-ON (5 min TTL,
+      // maxSize 500) and identical params produce an identical cache key.
+      // Any statement here means the default cache stopped covering
+      // fetchData — the exact regression class plan 040 fixed.
+      expect(statementsSince(mark)).toHaveLength(0);
+    });
+
+    it('a write invalidates the cache: updateRecord = 1 statement, next fetchData re-queries (2)', async () => {
+      const params = {
+        columns: ['subject', 'status', 'priority'],
+        pagination: { page: 1, limit: 10 },
+      };
+      await adapter.fetchData(params);
+
+      let mark = statements.length;
+      await adapter.updateRecord('1', { status: 'closed' });
+      // 1 = a single `UPDATE … RETURNING` (SQLite supports RETURNING, so
+      // no follow-up SELECT is needed to echo the updated row).
+      expect(statementsSince(mark)).toHaveLength(1);
+
+      mark = statements.length;
+      const result = await adapter.fetchData(params);
+      // 2 = data + count again: updateRecord calls cache.invalidate(), so
+      // the identical params MISS. 0 here would mean stale-after-write.
+      expect(statementsSince(mark)).toHaveLength(2);
+      expect(result.meta?.cached).toBe(false);
+      const updated = (result.data as Array<{ id: number; status: string }>).find(
+        (row) => row.id === 1
+      );
+      expect(updated?.status).toBe('closed');
+    });
+  });
+
+  describe('EXPLAIN QUERY PLAN canaries (run on the exact SQL the adapter issued)', () => {
+    // Format note: bun 1.3.x's vendored SQLite prints "SEARCH tickets …";
+    // older SQLites print "SEARCH TABLE tickets …" — the regexes accept
+    // both so a bun bump doesn't false-fail the canary.
+
+    it('a fetchData filtered on the indexed status column SEARCHes via idx_tickets_status (no full scan)', async () => {
+      const mark = statements.length;
+      const result = await adapter.fetchData({
+        columns: ['subject', 'status', 'priority'],
+        filters: [{ columnId: 'status', type: 'option', operator: 'isAnyOf', values: ['open'] }],
+        pagination: { page: 1, limit: 10 },
+      });
+      expect(result.total).toBe(10);
+
+      const issued = statementsSince(mark);
+      expect(issued).toHaveLength(2); // filtered data + filtered count
+
+      // Why this shape matters: filtering on a facet/status column is the
+      // hottest adapter path in the demos. If the WHERE clause ever stops
+      // being sargable (e.g. wrapped in a function/collation change), the
+      // plan flips to "SCAN tickets" and every filtered fetch goes O(n).
+      const dataStmt = issued.find((s) => !/count\(/i.test(s.query));
+      expect(dataStmt).toBeDefined();
+      const dataPlan = explainDetails(dataStmt as LoggedStatement);
+      expect(
+        dataPlan.some((d) =>
+          /^SEARCH (TABLE )?tickets USING (COVERING )?INDEX idx_tickets_status/.test(d)
+        )
+      ).toBe(true);
+      expect(dataPlan.some((d) => /^SCAN (TABLE )?tickets$/.test(d))).toBe(false);
+
+      // The paired count query must use the same index — as a covering
+      // index it never touches the table at all.
+      const countStmt = issued.find((s) => /count\(/i.test(s.query));
+      expect(countStmt).toBeDefined();
+      const countPlan = explainDetails(countStmt as LoggedStatement);
+      expect(
+        countPlan.some((d) =>
+          /^SEARCH (TABLE )?tickets USING (COVERING )?INDEX idx_tickets_status/.test(d)
+        )
+      ).toBe(true);
+      expect(countPlan.some((d) => /^SCAN (TABLE )?tickets$/.test(d))).toBe(false);
+    });
+
+    it('a many-to-one join probes the joined table by INTEGER PRIMARY KEY, never full-scanning it', async () => {
+      const mark = statements.length;
+      await adapter.fetchData({
+        columns: ['subject', 'agent.name'],
+        pagination: { page: 1, limit: 10 },
+      });
+
+      const dataStmt = statementsSince(mark).find((s) => !/count\(/i.test(s.query));
+      expect(dataStmt).toBeDefined();
+      const plan = explainDetails(dataStmt as LoggedStatement);
+
+      // Why this shape matters: the LEFT JOIN's ON condition targets the
+      // agents PK. If join planning ever emits a non-PK condition (alias
+      // drift, quoting bug), SQLite degrades to "SCAN agents" per ticket
+      // row — the classic O(n×m) join. Scanning `tickets` itself is fine
+      // here (unfiltered pagination walks the primary table by design).
+      expect(plan.some((d) => /^SEARCH (TABLE )?agents USING INTEGER PRIMARY KEY/.test(d))).toBe(
+        true
+      );
+      expect(plan.some((d) => /^SCAN (TABLE )?agents/.test(d))).toBe(false);
+    });
+
+    it('a facet count on the indexed status column walks the covering index, not the table', async () => {
+      const mark = statements.length;
+      await adapter.getFacetedValues('status');
+
+      const facetStmt = statementsSince(mark)[0];
+      expect(facetStmt).toBeDefined();
+      const plan = explainDetails(facetStmt as LoggedStatement);
+
+      // Why this shape matters: facets GROUP BY the column over the WHOLE
+      // table on every filter commit. With the index present SQLite
+      // satisfies the grouping via "SCAN … USING COVERING INDEX
+      // idx_tickets_status" (index-only, pre-grouped — no row lookups, no
+      // GROUP BY temp b-tree). Losing the covering-index scan silently
+      // makes every facet refresh a full-table scan + sort.
+      // (A temp b-tree for ORDER BY `count(*) desc` remains — ordering by
+      // an aggregate can't use an index; that part is expected.)
+      expect(plan.some((d) => /USING COVERING INDEX idx_tickets_status/.test(d))).toBe(true);
+      expect(plan.some((d) => /^SCAN (TABLE )?tickets$/.test(d))).toBe(false);
+      expect(plan.some((d) => /USE TEMP B-TREE FOR GROUP BY/.test(d))).toBe(false);
+    });
+  });
+});

--- a/packages/adapters/drizzle/tests/scale-growth.test.ts
+++ b/packages/adapters/drizzle/tests/scale-growth.test.ts
@@ -76,27 +76,26 @@ function createSeededFixture(rowCount: number) {
   return { sqlite, adapter };
 }
 
-/** Median of 5 timed runs after 1 discarded warm-up (plan 063 method). */
-async function medianMs(run: () => Promise<unknown>): Promise<number> {
-  await run(); // warm-up, discarded
+// Run the op BATCH times inside each timed sample so even the fast 1k case
+// measures well above timer resolution — the 10k/1k ratio then never needs a
+// denominator floor (which could otherwise mask a real regression when the 1k
+// time dips into sub-millisecond noise). BATCH cancels out of the ratio.
+const BATCH = 20;
+
+/** Median of 5 batched runs after 1 discarded warm-up batch (plan 063 method). */
+async function medianBatchMs(run: () => Promise<unknown>): Promise<number> {
+  for (let i = 0; i < BATCH; i++) await run(); // warm-up batch, discarded
   const samples: number[] = [];
-  for (let i = 0; i < 5; i++) {
+  for (let s = 0; s < 5; s++) {
     const start = performance.now();
-    await run();
+    for (let i = 0; i < BATCH; i++) await run();
     samples.push(performance.now() - start);
   }
   samples.sort((a, b) => a - b);
   return samples[2] as number;
 }
 
-/**
- * Guard the ratio's denominator: a sub-0.1 ms median is inside timer/GC
- * noise, and dividing by it fabricates huge ratios out of nothing. The
- * floor only ever LOWERS a reported ratio for operations that are already
- * far too fast to regress meaningfully at this scale.
- */
-const MIN_DENOMINATOR_MS = 0.1;
-const ratioOf = (t10k: number, t1k: number): number => t10k / Math.max(t1k, MIN_DENOMINATOR_MS);
+const ratioOf = (t10k: number, t1k: number): number => t10k / t1k;
 
 describe('DrizzleAdapter — 10k/1k growth ratios (plan 063 Step 3)', () => {
   let small: ReturnType<typeof createSeededFixture>;
@@ -119,8 +118,8 @@ describe('DrizzleAdapter — 10k/1k growth ratios (plan 063 Step 3)', () => {
         pagination: { page: 1, limit: 50 },
       });
 
-    const t1k = await medianMs(pageFetch(small));
-    const t10k = await medianMs(pageFetch(large));
+    const t1k = await medianBatchMs(pageFetch(small));
+    const t10k = await medianBatchMs(pageFetch(large));
     const ratio = ratioOf(t10k, t1k);
     console.log(
       `[scale-growth] page-1 fetchData: 1k=${t1k.toFixed(3)}ms 10k=${t10k.toFixed(3)}ms ratio=${ratio.toFixed(2)}`
@@ -131,8 +130,9 @@ describe('DrizzleAdapter — 10k/1k growth ratios (plan 063 Step 3)', () => {
     // resolves via a rowid scan — cheap at both scales. 8× is wide slack
     // over "near-flat"; an O(n) data path would already land ~10×.
     expect(ratio).toBeLessThanOrEqual(8);
-    // Catastrophic ceiling only (never a wall-time budget): a page fetch
-    // over 10k in-memory rows taking 2 s means something is pathological.
+    // Catastrophic ceiling only (never a wall-time budget): BATCH page fetches
+    // over 10k in-memory rows taking 2 s (≈100 ms each) means something is
+    // pathological.
     expect(t10k).toBeLessThan(2_000);
   }, 30_000);
 
@@ -153,8 +153,8 @@ describe('DrizzleAdapter — 10k/1k growth ratios (plan 063 Step 3)', () => {
     });
     expect(sanity.total).toBe(5_000);
 
-    const t1k = await medianMs(filteredFetch(small));
-    const t10k = await medianMs(filteredFetch(large));
+    const t1k = await medianBatchMs(filteredFetch(small));
+    const t10k = await medianBatchMs(filteredFetch(large));
     const ratio = ratioOf(t10k, t1k);
     console.log(
       `[scale-growth] filtered fetchData+count: 1k=${t1k.toFixed(3)}ms 10k=${t10k.toFixed(3)}ms ratio=${ratio.toFixed(2)}`

--- a/packages/adapters/drizzle/tests/scale-growth.test.ts
+++ b/packages/adapters/drizzle/tests/scale-growth.test.ts
@@ -8,11 +8,15 @@
  * only absolute number is a catastrophic ceiling wide enough to never
  * flake on a slow shared runner.
  *
- * Method (per plan 063): `performance.now()`, median of 5 runs after 1
- * discarded warm-up run. Plan 040's LRU cache is explicitly DISABLED on
- * these adapters — with the default-on cache every timed run after the
- * warm-up would be a 0-query cache hit and the ratio would measure the
- * cache, not the database.
+ * Method (per plan 063): `performance.now()`, median of 5 BATCHED samples
+ * after 1 discarded warm-up batch — each sample runs the op `BATCH` (20)
+ * times so even the fast 1k case measures well above timer resolution, so the
+ * 10k/1k ratio needs no denominator floor (BATCH cancels out of the ratio).
+ * The absolute catastrophic ceiling is therefore on the BATCH total, not a
+ * single op (noted at the assertion). Plan 040's LRU cache is explicitly
+ * DISABLED on these adapters — with the default-on cache every timed run
+ * after the warm-up would be a 0-query cache hit and the ratio would measure
+ * the cache, not the database.
  *
  * Bun caveat (plan 063 Step 3): this bun version has a `.rejects`/pending-
  * promise matcher bug — everything here is plain async/await over promises

--- a/packages/adapters/drizzle/tests/scale-growth.test.ts
+++ b/packages/adapters/drizzle/tests/scale-growth.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Plan 063 Step 3 — Tier 2 growth-ratio gates for the Drizzle adapter
+ * (SQLite, bun:sqlite).
+ *
+ * Gates scale BEHAVIOR, not machine speed: the same operation runs against
+ * 1,000 and 10,000 seeded rows and the assertion bounds the 10k/1k RATIO
+ * (ratios cancel host speed; an accidental O(n²) shows up as ~100×). The
+ * only absolute number is a catastrophic ceiling wide enough to never
+ * flake on a slow shared runner.
+ *
+ * Method (per plan 063): `performance.now()`, median of 5 runs after 1
+ * discarded warm-up run. Plan 040's LRU cache is explicitly DISABLED on
+ * these adapters — with the default-on cache every timed run after the
+ * warm-up would be a 0-query cache hit and the ratio would measure the
+ * cache, not the database.
+ *
+ * Bun caveat (plan 063 Step 3): this bun version has a `.rejects`/pending-
+ * promise matcher bug — everything here is plain async/await over promises
+ * that always settle, with expect() on computed numbers only.
+ */
+
+import { Database } from 'bun:sqlite';
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import { drizzle } from 'drizzle-orm/bun-sqlite';
+import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { drizzleAdapter } from '../src/factory';
+
+const events = sqliteTable('events', {
+  id: integer('id').primaryKey(),
+  title: text('title').notNull(),
+  status: text('status').notNull(),
+  amount: integer('amount').notNull(),
+});
+
+const schema = { events };
+
+/**
+ * Deterministic fixture at a given row count. Seeding uses the RAW
+ * bun:sqlite handle with one prepared INSERT inside a single transaction
+ * (11k total rows seed in well under 1 s). `status` is deliberately NOT
+ * indexed here: the filtered-count gate below wants the linear-ish scan
+ * so the ratio bound is exercised honestly (index-usage guarantees live
+ * in query-count.test.ts, on an indexed fixture).
+ */
+function createSeededFixture(rowCount: number) {
+  const sqlite = new Database(':memory:');
+  sqlite.exec(`
+    CREATE TABLE events (
+      id INTEGER PRIMARY KEY,
+      title TEXT NOT NULL,
+      status TEXT NOT NULL,
+      amount INTEGER NOT NULL
+    );
+  `);
+  const statuses = ['active', 'archived', 'draft', 'active'] as const;
+  const insert = sqlite.prepare(
+    'INSERT INTO events (id, title, status, amount) VALUES (?, ?, ?, ?)'
+  );
+  const seedAll = sqlite.transaction(() => {
+    for (let i = 1; i <= rowCount; i++) {
+      insert.run(i, `Event ${i}`, statuses[(i - 1) % 4] as string, ((i - 1) * 37) % 1000);
+    }
+  });
+  seedAll();
+
+  const db = drizzle(sqlite, { schema });
+  const adapter = drizzleAdapter(db, {
+    driver: 'sqlite',
+    schema,
+    options: {
+      defaultPrimaryTable: 'events',
+      // See file header: growth must measure the DB, not plan 040's LRU.
+      cache: { enabled: false, ttl: 0 },
+    },
+  });
+  return { sqlite, adapter };
+}
+
+/** Median of 5 timed runs after 1 discarded warm-up (plan 063 method). */
+async function medianMs(run: () => Promise<unknown>): Promise<number> {
+  await run(); // warm-up, discarded
+  const samples: number[] = [];
+  for (let i = 0; i < 5; i++) {
+    const start = performance.now();
+    await run();
+    samples.push(performance.now() - start);
+  }
+  samples.sort((a, b) => a - b);
+  return samples[2] as number;
+}
+
+/**
+ * Guard the ratio's denominator: a sub-0.1 ms median is inside timer/GC
+ * noise, and dividing by it fabricates huge ratios out of nothing. The
+ * floor only ever LOWERS a reported ratio for operations that are already
+ * far too fast to regress meaningfully at this scale.
+ */
+const MIN_DENOMINATOR_MS = 0.1;
+const ratioOf = (t10k: number, t1k: number): number => t10k / Math.max(t1k, MIN_DENOMINATOR_MS);
+
+describe('DrizzleAdapter — 10k/1k growth ratios (plan 063 Step 3)', () => {
+  let small: ReturnType<typeof createSeededFixture>;
+  let large: ReturnType<typeof createSeededFixture>;
+
+  beforeAll(() => {
+    small = createSeededFixture(1_000);
+    large = createSeededFixture(10_000);
+  });
+
+  afterAll(() => {
+    small.sqlite.close();
+    large.sqlite.close();
+  });
+
+  it("page-1 LIMIT'd fetchData stays near-flat: 10k ≤ 8× the 1k time, and < 2 s absolute", async () => {
+    const pageFetch = (fixture: ReturnType<typeof createSeededFixture>) => () =>
+      fixture.adapter.fetchData({
+        columns: ['title', 'status', 'amount'],
+        pagination: { page: 1, limit: 50 },
+      });
+
+    const t1k = await medianMs(pageFetch(small));
+    const t10k = await medianMs(pageFetch(large));
+    const ratio = ratioOf(t10k, t1k);
+    console.log(
+      `[scale-growth] page-1 fetchData: 1k=${t1k.toFixed(3)}ms 10k=${t10k.toFixed(3)}ms ratio=${ratio.toFixed(2)}`
+    );
+
+    // A LIMIT 50 page reads 50 rows regardless of table size; the only
+    // size-dependent statement is the parallel `count(*)`, which SQLite
+    // resolves via a rowid scan — cheap at both scales. 8× is wide slack
+    // over "near-flat"; an O(n) data path would already land ~10×.
+    expect(ratio).toBeLessThanOrEqual(8);
+    // Catastrophic ceiling only (never a wall-time budget): a page fetch
+    // over 10k in-memory rows taking 2 s means something is pathological.
+    expect(t10k).toBeLessThan(2_000);
+  }, 30_000);
+
+  it('filtered fetchData (WHERE + COUNT over the un-indexed status column) grows ≤ 15×', async () => {
+    const filteredFetch = (fixture: ReturnType<typeof createSeededFixture>) => () =>
+      fixture.adapter.fetchData({
+        columns: ['title', 'status', 'amount'],
+        filters: [{ columnId: 'status', type: 'option', operator: 'isAnyOf', values: ['active'] }],
+        pagination: { page: 1, limit: 50 },
+      });
+
+    // Sanity that the filter actually selects (half the rows are
+    // 'active'), so the timed COUNT below does real filtered work.
+    const sanity = await large.adapter.fetchData({
+      columns: ['title', 'status', 'amount'],
+      filters: [{ columnId: 'status', type: 'option', operator: 'isAnyOf', values: ['active'] }],
+      pagination: { page: 1, limit: 50 },
+    });
+    expect(sanity.total).toBe(5_000);
+
+    const t1k = await medianMs(filteredFetch(small));
+    const t10k = await medianMs(filteredFetch(large));
+    const ratio = ratioOf(t10k, t1k);
+    console.log(
+      `[scale-growth] filtered fetchData+count: 1k=${t1k.toFixed(3)}ms 10k=${t10k.toFixed(3)}ms ratio=${ratio.toFixed(2)}`
+    );
+
+    // The filtered `count(*)` must scan every matching row (no index on
+    // status here by design) → linear-ish, ideal ratio ~10×. 15× is the
+    // plan's slack for that; a quadratic regression would be ~100×.
+    expect(ratio).toBeLessThanOrEqual(15);
+  }, 30_000);
+});

--- a/packages/adapters/toolkit/bench/index.ts
+++ b/packages/adapters/toolkit/bench/index.ts
@@ -1,0 +1,192 @@
+/**
+ * @fileoverview mitata micro-benchmarks for @better-tables/adapters-toolkit
+ * (plan 063 Step 4).
+ *
+ * Trend tier — NOT part of `bun test` (lives in bench/, outside the test
+ * globs) and never a PR gate. Absolute numbers are machine-dependent; they
+ * feed `bench-results/@better-tables-adapters-toolkit.json`
+ * (github-action-benchmark `customSmallerIsBetter` format) for trend
+ * tracking on main only.
+ *
+ * Run with `bun bench/index.ts` from packages/adapters/toolkit, or
+ * `bun run bench` at the repo root (turbo). Emitted `value` is mitata's p50
+ * (median) of the measured samples, in nanoseconds per iteration.
+ *
+ * Benches `DataTransformer.transformToNested` on 1k and 10k flat rows,
+ * flat-only vs. with a one-to-many relation (4 posts per user). Port
+ * construction mirrors tests/data-transformer-cache.test.ts. The growth-
+ * RATIO gate for the same operation lives in the Tier-2 test suite; this
+ * file only records absolute trend numbers.
+ */
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { bench, do_not_optimize, run } from 'mitata';
+import { DataTransformer } from '../src/data-transformer';
+import type { ColumnPath, RelationshipManagerPort, SchemaIntrospectionPort } from '../src/types';
+
+const PACKAGE_NAME = '@better-tables/adapters-toolkit';
+const ENTRY_PREFIX = 'toolkit';
+
+/** github-action-benchmark `customSmallerIsBetter` entry. */
+interface BenchEntry {
+  name: string;
+  unit: string;
+  value: number;
+}
+
+/** Write entries to <package>/bench-results/<package-name>.json. */
+function writeBenchResults(entries: BenchEntry[]): string {
+  const dir = join(import.meta.dir, '..', 'bench-results');
+  mkdirSync(dir, { recursive: true });
+  const file = join(dir, `${PACKAGE_NAME.replace('/', '-')}.json`);
+  writeFileSync(file, `${JSON.stringify(entries, null, 2)}\n`);
+  return file;
+}
+
+// ---------------------------------------------------------------------------
+// Toy schema + ports (mirroring tests/data-transformer-cache.test.ts)
+// ---------------------------------------------------------------------------
+
+interface ToyTable {
+  columns: string[];
+  primaryKey: string;
+}
+
+const users: ToyTable = { columns: ['id', 'email', 'name', 'age'], primaryKey: 'id' };
+const posts: ToyTable = { columns: ['id', 'title', 'userId'], primaryKey: 'id' };
+const schema = { users, posts };
+
+const relationshipManager: RelationshipManagerPort = {
+  resolveColumnPath(columnId, primaryTable): ColumnPath {
+    if (!columnId.includes('.')) {
+      return { columnId, table: primaryTable, field: columnId, isNested: false };
+    }
+    const [, field = ''] = columnId.split('.');
+    return {
+      columnId,
+      table: 'posts',
+      field,
+      isNested: true,
+      relationshipPath: [
+        {
+          from: primaryTable,
+          to: 'posts',
+          foreignKey: 'userId',
+          localKey: 'id',
+          cardinality: 'many',
+        },
+      ],
+    };
+  },
+  getRelationshipByAlias() {
+    return null;
+  },
+  isArrayRelationship(relationshipPath) {
+    return relationshipPath.some((rel) => rel.cardinality === 'many');
+  },
+};
+
+const schemaPort: SchemaIntrospectionPort<ToyTable> = {
+  getColumnNames(table) {
+    return table.columns;
+  },
+  getForeignKeyColumns() {
+    return [];
+  },
+  getPrimaryKeyColumns(table) {
+    return [{ name: table.primaryKey, column: table.primaryKey }];
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Datasets (built once; transformToNested does not mutate its input)
+// ---------------------------------------------------------------------------
+
+/** N flat rows, one row per user, primary-table columns only. */
+function makeFlatRows(count: number): Record<string, unknown>[] {
+  const rows: Record<string, unknown>[] = new Array(count);
+  for (let i = 0; i < count; i++) {
+    rows[i] = {
+      id: i + 1,
+      email: `user${i}@example.com`,
+      name: `User ${i}`,
+      age: 18 + (i % 60),
+    };
+  }
+  return rows;
+}
+
+/** N flat rows total: N/4 users × 4 posts each (one-to-many JOIN fan-out shape). */
+function makeOneToManyRows(count: number): Record<string, unknown>[] {
+  const postsPerUser = 4;
+  const rows: Record<string, unknown>[] = new Array(count);
+  for (let i = 0; i < count; i++) {
+    const userId = Math.floor(i / postsPerUser) + 1;
+    rows[i] = {
+      id: userId,
+      email: `user${userId}@example.com`,
+      name: `User ${userId}`,
+      age: 18 + (userId % 60),
+      posts_id: i + 1,
+      posts_title: `Post ${i}`,
+    };
+  }
+  return rows;
+}
+
+const flatDatasets = new Map<number, Record<string, unknown>[]>([
+  [1000, makeFlatRows(1000)],
+  [10_000, makeFlatRows(10_000)],
+]);
+
+const oneToManyDatasets = new Map<number, Record<string, unknown>[]>([
+  [1000, makeOneToManyRows(1000)],
+  [10_000, makeOneToManyRows(10_000)],
+]);
+
+// ---------------------------------------------------------------------------
+// Benchmarks
+// ---------------------------------------------------------------------------
+
+bench('transformToNested.flat.$rows-rows', function* (state) {
+  const rows = state.get('rows') as number;
+  const data = flatDatasets.get(rows);
+  if (!data) throw new Error(`no flat dataset for ${rows}`);
+  const transformer = new DataTransformer(schema, relationshipManager, schemaPort);
+  yield () =>
+    do_not_optimize(transformer.transformToNested(data, 'users', ['email', 'name', 'age']));
+}).args('rows', [1000, 10_000]);
+
+bench('transformToNested.one-to-many.$rows-rows', function* (state) {
+  const rows = state.get('rows') as number;
+  const data = oneToManyDatasets.get(rows);
+  if (!data) throw new Error(`no one-to-many dataset for ${rows}`);
+  const transformer = new DataTransformer(schema, relationshipManager, schemaPort);
+  yield () =>
+    do_not_optimize(transformer.transformToNested(data, 'users', ['email', 'posts.title']));
+}).args('rows', [1000, 10_000]);
+
+// ---------------------------------------------------------------------------
+// Run + report
+// ---------------------------------------------------------------------------
+
+const result = await run();
+
+const entries: BenchEntry[] = [];
+for (const trial of result.benchmarks) {
+  for (const benchRun of trial.runs) {
+    if (benchRun.error !== undefined || benchRun.stats === undefined) {
+      throw new Error(`bench "${benchRun.name}" failed: ${String(benchRun.error)}`);
+    }
+    entries.push({
+      name: `${ENTRY_PREFIX}/${benchRun.name}`,
+      unit: 'ns',
+      value: Math.round(benchRun.stats.p50 * 100) / 100,
+    });
+  }
+}
+
+const file = writeBenchResults(entries);
+// biome-ignore lint/suspicious/noConsole: bench reporter output
+console.log(`wrote ${entries.length} entries to ${file}`);

--- a/packages/adapters/toolkit/package.json
+++ b/packages/adapters/toolkit/package.json
@@ -24,6 +24,7 @@
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch",
+    "bench": "bun bench/index.ts",
     "test": "bun test",
     "test:watch": "bun test --watch",
     "test:coverage": "bun test --coverage",

--- a/packages/adapters/toolkit/package.json
+++ b/packages/adapters/toolkit/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "@better-tables/core": "workspace:*",
     "drizzle-orm": "catalog:",
+    "mitata": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:"
   },

--- a/packages/adapters/toolkit/tests/transformer-scale-growth.test.ts
+++ b/packages/adapters/toolkit/tests/transformer-scale-growth.test.ts
@@ -6,7 +6,10 @@
  * transform over 1,000 and 10,000 flat rows and bound the 10k/1k RATIO
  * (ratios cancel host speed; an accidental O(n²) — the exact regression
  * class plan 040's hoists removed — lands ~100×, far past the 15× bound).
- * The only absolute assertion is a catastrophic ceiling.
+ * Each timed sample runs the op `BATCH` (20) times so even the 1k case
+ * measures well above timer resolution (no denominator floor needed; BATCH
+ * cancels out of the ratio). The only absolute assertion is a catastrophic
+ * ceiling on the BATCH total.
  *
  * Port construction mirrors tests/data-transformer-cache.test.ts (and the
  * bench/ suite): a toy schema-introspection + relationship-manager pair,

--- a/packages/adapters/toolkit/tests/transformer-scale-growth.test.ts
+++ b/packages/adapters/toolkit/tests/transformer-scale-growth.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Plan 063 Step 3 — Tier 2 growth-ratio gates for the toolkit's flat→nested
+ * transformer.
+ *
+ * Same method as the drizzle scale-growth suite: run the identical
+ * transform over 1,000 and 10,000 flat rows and bound the 10k/1k RATIO
+ * (ratios cancel host speed; an accidental O(n²) — the exact regression
+ * class plan 040's hoists removed — lands ~100×, far past the 15× bound).
+ * The only absolute assertion is a catastrophic ceiling.
+ *
+ * Port construction mirrors tests/data-transformer-cache.test.ts (and the
+ * bench/ suite): a toy schema-introspection + relationship-manager pair,
+ * `users` primary with a one-to-many `posts` relation (4 posts per user in
+ * the fan-out dataset).
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { DataTransformer } from '../src/data-transformer';
+import type { ColumnPath, RelationshipManagerPort, SchemaIntrospectionPort } from '../src/types';
+
+interface ToyTable {
+  columns: string[];
+  primaryKey: string;
+}
+
+const users: ToyTable = { columns: ['id', 'email', 'name', 'age'], primaryKey: 'id' };
+const posts: ToyTable = { columns: ['id', 'title', 'userId'], primaryKey: 'id' };
+const schema = { users, posts };
+
+const relationshipManager: RelationshipManagerPort = {
+  resolveColumnPath(columnId, primaryTable): ColumnPath {
+    if (!columnId.includes('.')) {
+      return { columnId, table: primaryTable, field: columnId, isNested: false };
+    }
+    const [, field = ''] = columnId.split('.');
+    return {
+      columnId,
+      table: 'posts',
+      field,
+      isNested: true,
+      relationshipPath: [
+        {
+          from: primaryTable,
+          to: 'posts',
+          foreignKey: 'userId',
+          localKey: 'id',
+          cardinality: 'many',
+        },
+      ],
+    };
+  },
+  getRelationshipByAlias() {
+    return null;
+  },
+  isArrayRelationship(relationshipPath) {
+    return relationshipPath.some((rel) => rel.cardinality === 'many');
+  },
+};
+
+const schemaPort: SchemaIntrospectionPort<ToyTable> = {
+  getColumnNames(table) {
+    return table.columns;
+  },
+  getForeignKeyColumns() {
+    return [];
+  },
+  getPrimaryKeyColumns(table) {
+    return [{ name: table.primaryKey, column: table.primaryKey }];
+  },
+};
+
+function makeFlatRows(count: number): Record<string, unknown>[] {
+  const rows: Record<string, unknown>[] = new Array(count);
+  for (let i = 0; i < count; i++) {
+    rows[i] = {
+      id: i + 1,
+      email: `user${i}@example.com`,
+      name: `User ${i}`,
+      age: 18 + (i % 60),
+    };
+  }
+  return rows;
+}
+
+function makeOneToManyRows(count: number): Record<string, unknown>[] {
+  const postsPerUser = 4;
+  const rows: Record<string, unknown>[] = new Array(count);
+  for (let i = 0; i < count; i++) {
+    const userId = Math.floor(i / postsPerUser) + 1;
+    rows[i] = {
+      id: userId,
+      email: `user${userId}@example.com`,
+      name: `User ${userId}`,
+      age: 18 + (userId % 60),
+      posts_id: i + 1,
+      posts_title: `Post ${i}`,
+    };
+  }
+  return rows;
+}
+
+/** Median of 5 timed runs after 1 discarded warm-up (plan 063 method). */
+function medianMs(run: () => unknown): number {
+  run(); // warm-up, discarded
+  const samples: number[] = [];
+  for (let i = 0; i < 5; i++) {
+    const start = performance.now();
+    run();
+    samples.push(performance.now() - start);
+  }
+  samples.sort((a, b) => a - b);
+  return samples[2] as number;
+}
+
+/** Same denominator floor as the drizzle suite — see its comment. */
+const MIN_DENOMINATOR_MS = 0.1;
+const ratioOf = (t10k: number, t1k: number): number => t10k / Math.max(t1k, MIN_DENOMINATOR_MS);
+
+describe('DataTransformer — 10k/1k growth ratios (plan 063 Step 3)', () => {
+  it('flat transform grows ≤ 15× from 1k to 10k rows', () => {
+    const flat1k = makeFlatRows(1_000);
+    const flat10k = makeFlatRows(10_000);
+    const transformer = new DataTransformer(schema, relationshipManager, schemaPort);
+    const columns = ['email', 'name', 'age'];
+
+    const t1k = medianMs(() => transformer.transformToNested(flat1k, 'users', columns));
+    const t10k = medianMs(() => transformer.transformToNested(flat10k, 'users', columns));
+    const ratio = ratioOf(t10k, t1k);
+    console.log(
+      `[transformer-growth] flat: 1k=${t1k.toFixed(3)}ms 10k=${t10k.toFixed(3)}ms ratio=${ratio.toFixed(2)}`
+    );
+
+    expect(ratio).toBeLessThanOrEqual(15);
+    expect(t10k).toBeLessThan(2_000);
+  }, 30_000);
+
+  it('one-to-many transform (4 posts/user fan-out) grows ≤ 15× from 1k to 10k flat rows', () => {
+    const fanOut1k = makeOneToManyRows(1_000);
+    const fanOut10k = makeOneToManyRows(10_000);
+    const transformer = new DataTransformer(schema, relationshipManager, schemaPort);
+    const columns = ['email', 'name', 'posts.title'];
+
+    const t1k = medianMs(() => transformer.transformToNested(fanOut1k, 'users', columns));
+    const t10k = medianMs(() => transformer.transformToNested(fanOut10k, 'users', columns));
+    const ratio = ratioOf(t10k, t1k);
+    console.log(
+      `[transformer-growth] one-to-many: 1k=${t1k.toFixed(3)}ms 10k=${t10k.toFixed(3)}ms ratio=${ratio.toFixed(2)}`
+    );
+
+    expect(ratio).toBeLessThanOrEqual(15);
+    expect(t10k).toBeLessThan(2_000);
+  }, 30_000);
+});

--- a/packages/adapters/toolkit/tests/transformer-scale-growth.test.ts
+++ b/packages/adapters/toolkit/tests/transformer-scale-growth.test.ts
@@ -99,22 +99,26 @@ function makeOneToManyRows(count: number): Record<string, unknown>[] {
   return rows;
 }
 
-/** Median of 5 timed runs after 1 discarded warm-up (plan 063 method). */
-function medianMs(run: () => unknown): number {
-  run(); // warm-up, discarded
+// Run the op BATCH times inside each timed sample. Batching pushes even the
+// fast 1k case well above timer resolution, so the 10k/1k ratio never needs a
+// denominator floor (which could otherwise mask a real regression when the 1k
+// time dips into sub-millisecond noise). BATCH cancels out of the ratio.
+const BATCH = 20;
+
+/** Median of 5 batched runs after 1 discarded warm-up (plan 063 method). */
+function medianBatchMs(op: () => unknown): number {
+  for (let i = 0; i < BATCH; i++) op(); // warm-up batch, discarded
   const samples: number[] = [];
-  for (let i = 0; i < 5; i++) {
+  for (let s = 0; s < 5; s++) {
     const start = performance.now();
-    run();
+    for (let i = 0; i < BATCH; i++) op();
     samples.push(performance.now() - start);
   }
   samples.sort((a, b) => a - b);
   return samples[2] as number;
 }
 
-/** Same denominator floor as the drizzle suite — see its comment. */
-const MIN_DENOMINATOR_MS = 0.1;
-const ratioOf = (t10k: number, t1k: number): number => t10k / Math.max(t1k, MIN_DENOMINATOR_MS);
+const ratioOf = (t10k: number, t1k: number): number => t10k / t1k;
 
 describe('DataTransformer — 10k/1k growth ratios (plan 063 Step 3)', () => {
   it('flat transform grows ≤ 15× from 1k to 10k rows', () => {
@@ -123,11 +127,11 @@ describe('DataTransformer — 10k/1k growth ratios (plan 063 Step 3)', () => {
     const transformer = new DataTransformer(schema, relationshipManager, schemaPort);
     const columns = ['email', 'name', 'age'];
 
-    const t1k = medianMs(() => transformer.transformToNested(flat1k, 'users', columns));
-    const t10k = medianMs(() => transformer.transformToNested(flat10k, 'users', columns));
+    const t1k = medianBatchMs(() => transformer.transformToNested(flat1k, 'users', columns));
+    const t10k = medianBatchMs(() => transformer.transformToNested(flat10k, 'users', columns));
     const ratio = ratioOf(t10k, t1k);
     console.log(
-      `[transformer-growth] flat: 1k=${t1k.toFixed(3)}ms 10k=${t10k.toFixed(3)}ms ratio=${ratio.toFixed(2)}`
+      `[transformer-growth batched] flat: 1k=${t1k.toFixed(3)}ms 10k=${t10k.toFixed(3)}ms ratio=${ratio.toFixed(2)}`
     );
 
     expect(ratio).toBeLessThanOrEqual(15);
@@ -140,11 +144,11 @@ describe('DataTransformer — 10k/1k growth ratios (plan 063 Step 3)', () => {
     const transformer = new DataTransformer(schema, relationshipManager, schemaPort);
     const columns = ['email', 'name', 'posts.title'];
 
-    const t1k = medianMs(() => transformer.transformToNested(fanOut1k, 'users', columns));
-    const t10k = medianMs(() => transformer.transformToNested(fanOut10k, 'users', columns));
+    const t1k = medianBatchMs(() => transformer.transformToNested(fanOut1k, 'users', columns));
+    const t10k = medianBatchMs(() => transformer.transformToNested(fanOut10k, 'users', columns));
     const ratio = ratioOf(t10k, t1k);
     console.log(
-      `[transformer-growth] one-to-many: 1k=${t1k.toFixed(3)}ms 10k=${t10k.toFixed(3)}ms ratio=${ratio.toFixed(2)}`
+      `[transformer-growth batched] one-to-many: 1k=${t1k.toFixed(3)}ms 10k=${t10k.toFixed(3)}ms ratio=${ratio.toFixed(2)}`
     );
 
     expect(ratio).toBeLessThanOrEqual(15);

--- a/packages/core/bench/index.ts
+++ b/packages/core/bench/index.ts
@@ -1,0 +1,286 @@
+/**
+ * @fileoverview mitata micro-benchmarks for @better-tables/core (plan 063 Step 4).
+ *
+ * Trend tier — NOT part of `bun test` (lives in bench/, outside the test
+ * globs) and never a PR gate. Absolute numbers are machine-dependent; they
+ * feed `bench-results/@better-tables-core.json` (github-action-benchmark
+ * `customSmallerIsBetter` format) for trend tracking on main only.
+ *
+ * Run with `bun bench/index.ts` from packages/core, or `bun run bench` at
+ * the repo root (turbo). Emitted `value` is mitata's p50 (median) of the
+ * measured samples, in nanoseconds per iteration.
+ *
+ * This file ALSO re-measures the plan 031/018 type-perf fixtures with
+ * `tsc --extendedDiagnostics` and appends their instantiation counts as
+ * `unit: "instantiations"` entries, so the trend graph tracks compile-time
+ * cost next to runtime cost (plan 063 Step 5). The blocking budget for those
+ * lives in tests/types/type-perf-gate.test.ts — here they are trend-only.
+ *
+ * Fixture construction mirrors tests/managers/*.test.ts idioms.
+ */
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { bench, do_not_optimize, run } from 'mitata';
+import { FilterManager } from '../src/managers/filter-manager';
+import { PaginationManager } from '../src/managers/pagination-manager';
+import { SortingManager } from '../src/managers/sorting-manager';
+import type { ColumnDefinition } from '../src/types/column';
+import type { FilterGroupNode, FilterState } from '../src/types/filter';
+import type { PaginationState } from '../src/types/pagination';
+import type { SortingState } from '../src/types/sorting';
+import { serializeFiltersToURL } from '../src/utils/filter-serialization';
+import { serializeTableStateToUrl } from '../src/utils/url-serialization';
+
+const PACKAGE_NAME = '@better-tables/core';
+const ENTRY_PREFIX = 'core';
+
+/** github-action-benchmark `customSmallerIsBetter` entry. */
+interface BenchEntry {
+  name: string;
+  unit: string;
+  value: number;
+}
+
+/** Write entries to <package>/bench-results/<package-name>.json. */
+function writeBenchResults(entries: BenchEntry[]): string {
+  const dir = join(import.meta.dir, '..', 'bench-results');
+  mkdirSync(dir, { recursive: true });
+  const file = join(dir, `${PACKAGE_NAME.replace('/', '-')}.json`);
+  writeFileSync(file, `${JSON.stringify(entries, null, 2)}\n`);
+  return file;
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures (mirroring tests/managers/*.test.ts construction idioms)
+// ---------------------------------------------------------------------------
+
+/** Text/number/option column mix, all filterable+sortable, like the FilterManager suite. */
+function makeColumns(count: number): ColumnDefinition[] {
+  const columns: ColumnDefinition[] = [];
+  for (let i = 0; i < count; i++) {
+    if (i % 3 === 0) {
+      columns.push({
+        id: `text${i}`,
+        displayName: `Text ${i}`,
+        type: 'text',
+        accessor: (row: unknown) => (row as Record<string, unknown>)[`text${i}`],
+        filterable: true,
+        sortable: true,
+      });
+    } else if (i % 3 === 1) {
+      columns.push({
+        id: `num${i}`,
+        displayName: `Number ${i}`,
+        type: 'number',
+        accessor: (row: unknown) => (row as Record<string, unknown>)[`num${i}`],
+        filterable: true,
+        sortable: true,
+      });
+    } else {
+      columns.push({
+        id: `opt${i}`,
+        displayName: `Option ${i}`,
+        type: 'option',
+        accessor: (row: unknown) => (row as Record<string, unknown>)[`opt${i}`],
+        filterable: true,
+        sortable: true,
+        filter: {
+          options: [
+            { value: 'a', label: 'A' },
+            { value: 'b', label: 'B' },
+          ],
+        },
+      });
+    }
+  }
+  return columns;
+}
+
+/** One valid leaf filter per column (type-matched operator + values). */
+function makeLeafFilters(columns: ColumnDefinition[]): FilterState[] {
+  return columns.map((column, i): FilterState => {
+    if (column.type === 'number') {
+      return { columnId: column.id, type: 'number', operator: 'greaterThan', values: [i] };
+    }
+    if (column.type === 'option') {
+      return { columnId: column.id, type: 'option', operator: 'is', values: ['a'] };
+    }
+    return { columnId: column.id, type: 'text', operator: 'contains', values: [`v${i}`] };
+  });
+}
+
+const columns50 = makeColumns(50);
+const leafFilters50 = makeLeafFilters(columns50);
+
+/** Depth-3 FilterGroupNode built fresh per call — the "build" half of the bench. */
+function buildDepth3Node(): FilterGroupNode {
+  return {
+    kind: 'group',
+    logic: 'and',
+    children: [
+      { columnId: 'num1', type: 'number', operator: 'greaterThan', values: [18] },
+      {
+        kind: 'group',
+        logic: 'or',
+        children: [
+          { columnId: 'text0', type: 'text', operator: 'contains', values: ['Jo'] },
+          { columnId: 'opt2', type: 'option', operator: 'is', values: ['a'] },
+          {
+            kind: 'group',
+            logic: 'and',
+            children: [
+              { columnId: 'num4', type: 'number', operator: 'lessThan', values: [40] },
+              { columnId: 'text3', type: 'text', operator: 'endsWith', values: ['@example.com'] },
+            ],
+          },
+        ],
+      },
+      {
+        kind: 'group',
+        logic: 'or',
+        children: [
+          { columnId: 'text6', type: 'text', operator: 'startsWith', values: ['B'] },
+          {
+            kind: 'group',
+            logic: 'and',
+            children: [
+              { columnId: 'num7', type: 'number', operator: 'between', values: [10, 90] },
+              { columnId: 'opt5', type: 'option', operator: 'isNot', values: ['b'] },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Benchmarks
+// ---------------------------------------------------------------------------
+
+{
+  // Real page changes on a large dataset: 100k rows / limit 10 = 10k pages.
+  // Alternate 2 ↔ 3 so every call is a genuine page change (no no-op path).
+  const pagination = new PaginationManager({}, { page: 1, limit: 10 });
+  pagination.setTotal(100_000);
+  let flip = false;
+  bench('pagination.goToPage', () => {
+    flip = !flip;
+    pagination.goToPage(flip ? 2 : 3);
+  });
+}
+
+{
+  // toggleSort cycles asc → desc → none, so every call mutates state.
+  const sorting = new SortingManager(makeColumns(3));
+  bench('sorting.toggleSort', () => {
+    sorting.toggleSort('text0');
+  });
+}
+
+{
+  // Replace-all with a 50-leaf flat array: measures per-leaf validation
+  // (column lookup, type/operator checks) + replace + notify.
+  const filterManager = new FilterManager(columns50);
+  bench('filter.setFilters.50-leaves', () => {
+    filterManager.setFilters(leafFilters50);
+  });
+}
+
+// Build a depth-3 AND(OR(AND)) tree and serialize it to the URL wire format
+// (key-shortening + lz-string), the round trip a tree-shaped filter state
+// pays on every URL sync.
+bench('filter-node.build+serialize.depth-3', () => {
+  do_not_optimize(serializeFiltersToURL(buildDepth3Node()));
+});
+
+// Whole-table-state URL serialization at 1 / 10 / 50 filters — dominated by
+// lz-string compression cost as the filter payload grows.
+bench('url-state.serialize.$filters-filters', function* (state) {
+  const count = state.get('filters') as number;
+  const filters = leafFilters50.slice(0, count);
+  const pagination: PaginationState = {
+    page: 3,
+    limit: 25,
+    totalPages: 40,
+    hasNext: true,
+    hasPrev: true,
+  };
+  const sorting: SortingState = [{ columnId: 'text0', direction: 'asc' }];
+  yield () => do_not_optimize(serializeTableStateToUrl({ filters, pagination, sorting }));
+}).args('filters', [1, 10, 50]);
+
+// ---------------------------------------------------------------------------
+// Type-perf fixture instantiation counts (trend entries; gate lives in
+// tests/types/type-perf-gate.test.ts). Measured via the per-fixture
+// tsconfigs (real package options + skipLibCheck), so counts reflect the
+// fixture, not stdlib churn — NOT comparable to the old manual bare-file
+// numbers in plans/design/table-definition-dx.md.
+// ---------------------------------------------------------------------------
+
+async function measureInstantiations(projectRelPath: string): Promise<number> {
+  const packageRoot = join(import.meta.dir, '..');
+  // `-p <fixture tsconfig>` (NOT a bare `tsc <file>`): bare file mode
+  // ignores tsconfig — default ES5 target breaks src imports, strictness
+  // differs, and every hoisted @types package auto-loads. The per-fixture
+  // configs extend the real package options with only @types/node.
+  const proc = Bun.spawn(['bunx', 'tsc', '-p', projectRelPath, '--extendedDiagnostics'], {
+    cwd: packageRoot,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (exitCode !== 0) {
+    throw new Error(`tsc failed (exit ${exitCode}) for ${fixtureRelPath}:\n${stdout}\n${stderr}`);
+  }
+  const match = stdout.match(/^Instantiations:\s+([\d,]+)/m);
+  if (!match?.[1]) {
+    throw new Error(`could not parse Instantiations from tsc output for ${fixtureRelPath}`);
+  }
+  return Number(match[1].replaceAll(',', ''));
+}
+
+// ---------------------------------------------------------------------------
+// Run + report
+// ---------------------------------------------------------------------------
+
+const result = await run();
+
+const entries: BenchEntry[] = [];
+for (const trial of result.benchmarks) {
+  for (const benchRun of trial.runs) {
+    if (benchRun.error !== undefined || benchRun.stats === undefined) {
+      throw new Error(`bench "${benchRun.name}" failed: ${String(benchRun.error)}`);
+    }
+    entries.push({
+      name: `${ENTRY_PREFIX}/${benchRun.name}`,
+      unit: 'ns',
+      value: Math.round(benchRun.stats.p50 * 100) / 100,
+    });
+  }
+}
+
+for (const fixture of [
+  {
+    entry: 'core/types.filter-fixture.instantiations',
+    path: 'tests/types/tsconfig.filter-perf.json',
+  },
+  {
+    entry: 'core/types.table-def-fixture.instantiations',
+    path: 'tests/types/tsconfig.table-def-perf.json',
+  },
+]) {
+  const instantiations = await measureInstantiations(fixture.path);
+  entries.push({ name: fixture.entry, unit: 'instantiations', value: instantiations });
+  // biome-ignore lint/suspicious/noConsole: bench reporter output
+  console.log(`${fixture.entry}: ${instantiations}`);
+}
+
+const file = writeBenchResults(entries);
+// biome-ignore lint/suspicious/noConsole: bench reporter output
+console.log(`wrote ${entries.length} entries to ${file}`);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,6 +24,7 @@
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch",
+    "bench": "bun bench/index.ts",
     "test": "bun test",
     "typecheck": "tsc --noEmit",
     "test:watch": "bun test --watch",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,6 +46,7 @@
   "devDependencies": {
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
+    "mitata": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
     "tsdown": "catalog:",

--- a/packages/core/src/adapters/http-adapter.ts
+++ b/packages/core/src/adapters/http-adapter.ts
@@ -14,7 +14,9 @@ import type {
   CellWriteTarget,
   ExportParams,
   ExportResult,
+  FacetBatchResult,
   FacetQueryParams,
+  FacetRequest,
   FetchDataParams,
   FetchDataResult,
   InferredColumnSpec,
@@ -134,10 +136,11 @@ export class HttpAdapterError extends Error {
 }
 
 /**
- * Create a client-side {@link TableAdapter} that proxies its four read methods
- * (`fetchData`, `getFilterOptions`, `getFacetedValues`, `getMinMaxValues`) to
- * an HTTP endpoint. Mount {@link handleAdapterRequest} at that endpoint,
- * backed by your real (server-only) adapter.
+ * Create a client-side {@link TableAdapter} that proxies its read methods
+ * (`fetchData`, `getFilterOptions`, `getFacetedValues`, `getMinMaxValues`,
+ * and the batched `getFacets`) to an HTTP endpoint. Mount
+ * {@link handleAdapterRequest} at that endpoint, backed by your real
+ * (server-only) adapter.
  *
  * @example
  * ```tsx
@@ -162,7 +165,22 @@ export function httpAdapter<TData = unknown>(config: HttpAdapterConfig): TableAd
 
   const cacheTtlMs =
     config.cacheTtlMs === false || config.cacheTtlMs === 0 ? 0 : (config.cacheTtlMs ?? 2000);
-  const inFlight = new Map<string, Promise<unknown>>();
+  /**
+   * One shared underlying request per identical body. Followers with an
+   * `AbortSignal` get per-caller abort semantics (their promise rejects
+   * immediately) without cancelling the shared request out from under other
+   * callers — it is aborted only when every follower has aborted and no
+   * signal-less caller pinned it.
+   */
+  interface InFlightEntry {
+    promise: Promise<unknown>;
+    controller: AbortController;
+    /** Followers whose signal has not (yet) aborted. */
+    activeWaiters: number;
+    /** A signal-less caller joined — never abort the shared request. */
+    pinned: boolean;
+  }
+  const inFlight = new Map<string, InFlightEntry>();
   const resultCache = new Map<string, { result: unknown; expiresAt: number }>();
 
   async function resolveHeaders(): Promise<Record<string, string>> {
@@ -202,27 +220,100 @@ export function httpAdapter<TData = unknown>(config: HttpAdapterConfig): TableAd
     return performFetch(body, signal);
   }
 
-  async function sendCacheable(body: AdapterRequestBody): Promise<unknown> {
+  function abortError(): Error {
+    const error = new Error('The operation was aborted.');
+    error.name = 'AbortError';
+    return error;
+  }
+
+  /**
+   * TTL cache + in-flight dedup for idempotent reads. A caller's
+   * `AbortSignal` no longer routes around the cache (the pre-fix behavior
+   * made every `useFacets` read a fresh POST): a fresh cached result is
+   * returned regardless of signal, and concurrent identical reads share one
+   * underlying request while keeping per-caller abort semantics.
+   */
+  async function sendCacheable(body: AdapterRequestBody, signal?: AbortSignal): Promise<unknown> {
+    if (cacheTtlMs <= 0) return performFetch(body, signal);
+    if (signal?.aborted) throw abortError();
+
     const cacheKey = JSON.stringify(body);
-    if (cacheTtlMs > 0) {
-      const cached = resultCache.get(cacheKey);
-      if (cached && cached.expiresAt > Date.now()) return cached.result;
-      let pending = inFlight.get(cacheKey);
-      if (pending) return pending;
-      pending = performFetch(body);
-      inFlight.set(cacheKey, pending);
-      try {
-        const result = await pending;
-        resultCache.set(cacheKey, { result, expiresAt: Date.now() + cacheTtlMs });
-        return result;
-      } catch (error) {
-        resultCache.delete(cacheKey);
-        throw error;
-      } finally {
-        inFlight.delete(cacheKey);
-      }
+    const cached = resultCache.get(cacheKey);
+    if (cached && cached.expiresAt > Date.now()) return cached.result;
+
+    let entry = inFlight.get(cacheKey);
+    if (!entry) {
+      const controller = new AbortController();
+      const created: InFlightEntry = {
+        promise: Promise.resolve<unknown>(undefined),
+        controller,
+        activeWaiters: 0,
+        pinned: false,
+      };
+      created.promise = performFetch(body, controller.signal)
+        .then((result) => {
+          resultCache.set(cacheKey, { result, expiresAt: Date.now() + cacheTtlMs });
+          return result;
+        })
+        .catch((error) => {
+          resultCache.delete(cacheKey);
+          throw error;
+        })
+        .finally(() => {
+          // Only remove OUR entry — an all-aborted entry is evicted early so a
+          // fresh caller may already have replaced it under the same key.
+          if (inFlight.get(cacheKey) === created) {
+            inFlight.delete(cacheKey);
+          }
+        });
+      entry = created;
+      inFlight.set(cacheKey, entry);
     }
-    return performFetch(body);
+
+    if (!signal) {
+      entry.pinned = true;
+      return entry.promise;
+    }
+
+    const shared = entry;
+    shared.activeWaiters += 1;
+    return new Promise((resolve, reject) => {
+      let settled = false;
+      const onAbort = () => {
+        if (settled) return;
+        settled = true;
+        shared.activeWaiters -= 1;
+        if (shared.activeWaiters <= 0 && !shared.pinned) {
+          shared.controller.abort();
+          // Evict immediately: a caller arriving after this must start a
+          // fresh request, not join a doomed one.
+          if (inFlight.get(cacheKey) === shared) {
+            inFlight.delete(cacheKey);
+          }
+        }
+        reject(abortError());
+      };
+      signal.addEventListener('abort', onAbort, { once: true });
+      // Both handlers are attached for every follower, so a late settlement
+      // after this caller aborted is still "handled" (the settled guard
+      // no-ops it) — no unhandled-rejection noise.
+      shared.promise.then(
+        (result) => {
+          if (settled) return;
+          settled = true;
+          signal.removeEventListener('abort', onAbort);
+          shared.activeWaiters -= 1;
+          resolve(result);
+        },
+        (error) => {
+          if (settled) return;
+          settled = true;
+          signal.removeEventListener('abort', onAbort);
+          shared.activeWaiters -= 1;
+          reject(error);
+        }
+      );
+    });
   }
 
   // Default meta advertises the real capability surface: update flips on
@@ -298,7 +389,7 @@ export function httpAdapter<TData = unknown>(config: HttpAdapterConfig): TableAd
         columnId,
         ...(hasParams ? { params: serializable } : {}),
       };
-      const result = signal ? await send(body, signal) : await sendCacheable(body);
+      const result = await sendCacheable(body, signal);
       return result as FilterOption[];
     },
 
@@ -313,7 +404,7 @@ export function httpAdapter<TData = unknown>(config: HttpAdapterConfig): TableAd
         columnId,
         ...(hasParams ? { params: serializable } : {}),
       };
-      const result = signal ? await send(body, signal) : await sendCacheable(body);
+      const result = await sendCacheable(body, signal);
       return new Map(result as [string, number][]);
     },
 
@@ -325,8 +416,34 @@ export function httpAdapter<TData = unknown>(config: HttpAdapterConfig): TableAd
         columnId,
         ...(hasParams ? { params: serializable } : {}),
       };
-      const result = signal ? await send(body, signal) : await sendCacheable(body);
+      const result = await sendCacheable(body, signal);
       return result as [number, number];
+    },
+
+    /**
+     * Batched facet reads — one POST for a whole sidebar refresh instead of
+     * one per column. Cached/deduped like the singular facet reads.
+     */
+    async getFacets(
+      requests: FacetRequest[],
+      params?: FacetQueryParams
+    ): Promise<FacetBatchResult> {
+      const { signal, ...serializable } = params ?? {};
+      const hasParams = Object.keys(serializable).length > 0;
+      const body = {
+        method: 'getFacets' as const,
+        requests,
+        ...(hasParams ? { params: serializable } : {}),
+      };
+      const raw = (await sendCacheable(body, signal)) as {
+        values?: Record<string, [string, number][]>;
+        ranges?: Record<string, [number, number]>;
+      };
+      const values: FacetBatchResult['values'] = {};
+      for (const [id, entries] of Object.entries(raw.values ?? {})) {
+        values[id] = new Map(entries);
+      }
+      return { values, ranges: raw.ranges ?? {} };
     },
 
     async describeColumns(table?: string): Promise<InferredColumnSpec[]> {

--- a/packages/core/src/adapters/http-adapter.ts
+++ b/packages/core/src/adapters/http-adapter.ts
@@ -182,6 +182,19 @@ export function httpAdapter<TData = unknown>(config: HttpAdapterConfig): TableAd
   }
   const inFlight = new Map<string, InFlightEntry>();
   const resultCache = new Map<string, { result: unknown; expiresAt: number }>();
+  // Bound the TTL cache. Filter-varied reads produce a fresh JSON key each
+  // time, so without a cap a long-lived table session accretes one entry per
+  // param combination forever (the TTL only blocks stale HITS, it never frees
+  // keys). Map preserves insertion order, so the first key is the
+  // least-recently-used (reads re-insert on hit — see `sendCacheable`).
+  const MAX_CACHE_ENTRIES = 100;
+  function evictOverCap(): void {
+    while (resultCache.size > MAX_CACHE_ENTRIES) {
+      const oldest = resultCache.keys().next().value;
+      if (oldest === undefined) break;
+      resultCache.delete(oldest);
+    }
+  }
 
   async function resolveHeaders(): Promise<Record<string, string>> {
     const base = { 'content-type': 'application/json' };
@@ -239,7 +252,16 @@ export function httpAdapter<TData = unknown>(config: HttpAdapterConfig): TableAd
 
     const cacheKey = JSON.stringify(body);
     const cached = resultCache.get(cacheKey);
-    if (cached && cached.expiresAt > Date.now()) return cached.result;
+    if (cached) {
+      if (cached.expiresAt > Date.now()) {
+        // LRU touch: re-insert so this key becomes most-recently-used.
+        resultCache.delete(cacheKey);
+        resultCache.set(cacheKey, cached);
+        return cached.result;
+      }
+      // Expired — free it now rather than leaving it resident until eviction.
+      resultCache.delete(cacheKey);
+    }
 
     let entry = inFlight.get(cacheKey);
     if (!entry) {
@@ -252,11 +274,21 @@ export function httpAdapter<TData = unknown>(config: HttpAdapterConfig): TableAd
       };
       created.promise = performFetch(body, controller.signal)
         .then((result) => {
-          resultCache.set(cacheKey, { result, expiresAt: Date.now() + cacheTtlMs });
+          // Cache only if this exact request is still the live entry AND wasn't
+          // aborted — a late settle from an evicted/aborted request must never
+          // populate or overwrite a NEWER entry's cache under the same key.
+          if (!controller.signal.aborted && inFlight.get(cacheKey) === created) {
+            resultCache.set(cacheKey, { result, expiresAt: Date.now() + cacheTtlMs });
+            evictOverCap();
+          }
           return result;
         })
         .catch((error) => {
-          resultCache.delete(cacheKey);
+          // Only clear cache for OUR live entry, for the same reason — a late
+          // failure from an evicted request must not delete a newer result.
+          if (inFlight.get(cacheKey) === created) {
+            resultCache.delete(cacheKey);
+          }
           throw error;
         })
         .finally(() => {

--- a/packages/core/src/adapters/http-handler.ts
+++ b/packages/core/src/adapters/http-handler.ts
@@ -8,8 +8,9 @@
  */
 
 import { coerceCellValue } from '../lib/cell-edit-core';
-import type { FetchDataResult, TableAdapter } from '../types/adapter';
+import type { FacetBatchResult, FetchDataResult, TableAdapter } from '../types/adapter';
 import type { AdapterRequestBody, AdapterResponseBody } from './http-protocol';
+import { MAX_FACET_BATCH_SIZE } from './http-protocol';
 
 /**
  * Opt-in write configuration (plan 055). Absent/false = writes disabled
@@ -98,6 +99,22 @@ function isValidBody(body: unknown): body is AdapterRequestBody {
     method === 'getMinMaxValues'
   ) {
     return typeof (body as { columnId?: unknown }).columnId === 'string';
+  }
+  if (method === 'getFacets') {
+    const requests = (body as { requests?: unknown }).requests;
+    return (
+      Array.isArray(requests) &&
+      requests.length > 0 &&
+      requests.length <= MAX_FACET_BATCH_SIZE &&
+      requests.every(
+        (entry: unknown) =>
+          !!entry &&
+          typeof entry === 'object' &&
+          typeof (entry as { columnId?: unknown }).columnId === 'string' &&
+          ((entry as { kind?: unknown }).kind === 'values' ||
+            (entry as { kind?: unknown }).kind === 'minmax')
+      )
+    );
   }
   if (method === 'describeColumns') {
     const table = (body as { table?: unknown }).table;
@@ -188,6 +205,41 @@ export async function handleAdapterRequest<TData = unknown>(
       case 'getMinMaxValues': {
         const result = await adapter.getMinMaxValues(body.columnId, body.params);
         return { ok: true, result };
+      }
+      case 'getFacets': {
+        // One POST, K facet reads. Prefer the adapter's own batch when it has
+        // one; otherwise fan out to the singular methods server-side — the
+        // round-trips this saves are the client↔server ones, not the
+        // adapter↔DB ones.
+        let batch: FacetBatchResult;
+        if (adapter.getFacets) {
+          batch = await adapter.getFacets(body.requests, body.params);
+        } else {
+          const values: FacetBatchResult['values'] = {};
+          const ranges: FacetBatchResult['ranges'] = {};
+          await Promise.all(
+            body.requests.map(async (entry) => {
+              if (entry.kind === 'values') {
+                values[entry.columnId] = await adapter.getFacetedValues(
+                  entry.columnId,
+                  body.params
+                );
+              } else {
+                ranges[entry.columnId] = await adapter.getMinMaxValues(entry.columnId, body.params);
+              }
+            })
+          );
+          batch = { values, ranges };
+        }
+        return {
+          ok: true,
+          result: {
+            values: Object.fromEntries(
+              Object.entries(batch.values).map(([key, map]) => [key, Array.from(map.entries())])
+            ),
+            ranges: batch.ranges,
+          },
+        };
       }
       case 'describeColumns': {
         // Optional capability (plan 054): an adapter without it is a caller

--- a/packages/core/src/adapters/http-protocol.ts
+++ b/packages/core/src/adapters/http-protocol.ts
@@ -6,7 +6,7 @@
  * fetch plumbing or `Map` (de)serialization.
  */
 
-import type { FacetQueryParams, FetchDataParams } from '../types/adapter';
+import type { FacetQueryParams, FacetRequest, FetchDataParams } from '../types/adapter';
 
 /**
  * The methods the HTTP transport proxies: the reads (always available) plus
@@ -18,9 +18,17 @@ export type AdapterMethod =
   | 'getFilterOptions'
   | 'getFacetedValues'
   | 'getMinMaxValues'
+  | 'getFacets'
   | 'describeColumns'
   | 'resolveCellWriteTarget'
   | 'cellEdit';
+
+/**
+ * Upper bound on entries in one `getFacets` batch. Far above any real
+ * sidebar (a handful of facets); exists so a malicious body can't fan a
+ * single POST out into thousands of adapter queries.
+ */
+export const MAX_FACET_BATCH_SIZE = 50;
 
 /**
  * A single request over the wire. `fetchData` carries a `params` object
@@ -37,6 +45,17 @@ export type AdapterRequestBody =
   | {
       method: 'getFilterOptions' | 'getFacetedValues' | 'getMinMaxValues';
       columnId: string;
+      /** {@link FacetQueryParams} without `signal` (handled client-side). */
+      params?: Omit<FacetQueryParams, 'signal'>;
+    }
+  | {
+      method: 'getFacets';
+      /**
+       * Batched facet reads answered in one round-trip. At most
+       * {@link MAX_FACET_BATCH_SIZE} entries; the server rejects larger
+       * batches as `bad_request`.
+       */
+      requests: FacetRequest[];
       /** {@link FacetQueryParams} without `signal` (handled client-side). */
       params?: Omit<FacetQueryParams, 'signal'>;
     }
@@ -72,6 +91,8 @@ export type AdapterRequestBody =
  * The response envelope. `result` is the method's return value already made
  * JSON-safe:
  * - a `getFacetedValues` `Map` is sent as its `[value, count][]` entries
+ * - a `getFacets` result's `values` maps are sent the same way
+ *   (`{ values: Record<columnId, [value, count][]>, ranges: ... }`)
  * - `fetchData` result's optional `faceted` maps are sent the same way
  *   (`Record<string, [value, count][]>`) and rebuilt into `Map`s on the client
  * - `Date` values in filter params / rows serialize as ISO strings (JSON)

--- a/packages/core/src/adapters/index.ts
+++ b/packages/core/src/adapters/index.ts
@@ -25,5 +25,10 @@ export {
   type HandleAdapterRequestOptions,
   handleAdapterRequest,
 } from './http-handler';
-export type { AdapterMethod, AdapterRequestBody, AdapterResponseBody } from './http-protocol';
+export {
+  type AdapterMethod,
+  type AdapterRequestBody,
+  type AdapterResponseBody,
+  MAX_FACET_BATCH_SIZE,
+} from './http-protocol';
 export { type MemoryAdapterOptions, memoryAdapter } from './memory-adapter';

--- a/packages/core/src/types/adapter.ts
+++ b/packages/core/src/types/adapter.ts
@@ -225,6 +225,31 @@ export interface FacetQueryParams {
 }
 
 /**
+ * One entry in a batched facet read ({@link TableAdapter.getFacets}).
+ */
+export interface FacetRequest {
+  /** The column to facet — same resolution as the singular facet methods. */
+  columnId: string;
+  /**
+   * Which facet shape to compute for this column:
+   * `'values'` → distinct value counts (the {@link TableAdapter.getFacetedValues}
+   * shape); `'minmax'` → a `[min, max]` range (the
+   * {@link TableAdapter.getMinMaxValues} shape).
+   */
+  kind: 'values' | 'minmax';
+}
+
+/**
+ * Result of a batched facet read: every requested `'values'` column appears
+ * in `values`, every requested `'minmax'` column in `ranges`. Columns the
+ * caller did not request MUST NOT appear.
+ */
+export interface FacetBatchResult {
+  values: Record<string, Map<string, number>>;
+  ranges: Record<string, [number, number]>;
+}
+
+/**
  * Schema-derived column description — the raw material for auto columns
  * (plan 054). Returned by {@link TableAdapter.describeColumns}; consumed by
  * `resolveTableColumns` (core) to enrich explicit column definitions and to
@@ -471,6 +496,17 @@ export interface TableAdapter<TData = unknown> {
    * ```
    */
   getMinMaxValues(columnId: string, params?: FacetQueryParams): Promise<[number, number]>;
+
+  /**
+   * Optional: answer several facet reads in ONE call. Semantically identical
+   * to calling {@link TableAdapter.getFacetedValues} (`kind: 'values'`) /
+   * {@link TableAdapter.getMinMaxValues} (`kind: 'minmax'`) once per entry
+   * with the same `params` — including the mandatory self-exclusion rule,
+   * applied per column. Exists so transports can collapse a K-facet sidebar
+   * refresh into a single round-trip; in-process adapters gain nothing and
+   * may omit it (callers fall back to the singular methods).
+   */
+  getFacets?(requests: FacetRequest[], params?: FacetQueryParams): Promise<FacetBatchResult>;
 
   /**
    * Optional: describe a table's columns from the underlying schema —

--- a/packages/core/src/utils/filter-effect.ts
+++ b/packages/core/src/utils/filter-effect.ts
@@ -17,7 +17,6 @@
 
 import type { FilterGroupNode, FilterState } from '../types/filter';
 import { getOperatorDefinition } from '../types/filter-operators';
-import { flattenFilterNode, isFilterGroupNode } from './type-guards';
 
 /**
  * Does `filter` actually constrain query results?
@@ -60,33 +59,32 @@ export function getEffectiveFilters(
 }
 
 /**
- * A stable string key for the EFFECTIVE filters, safe to use as a React memo
- * dependency (so an incomplete chip doesn't refire fetch/facets — plan 063
- * follow-up). `undefined` → `'null'`.
+ * A stable, value-sensitive string key for the EFFECTIVE filters, safe to use
+ * as a React memo dependency (so an incomplete chip doesn't refire
+ * fetch/facets — plan 063 follow-up). `undefined` → `'null'`.
  *
  * `JSON.stringify` alone is unsafe here: a `custom` filter's `values` is
  * `unknown[]`, so a `BigInt` value throws `TypeError` and a circular value
- * throws — during render, which would crash the consuming hook. This uses a
- * BigInt-aware replacer and, on any remaining serialization failure, falls
- * back to a structural signature (per effective leaf: `columnId`, `operator`,
- * value count) that still changes when the effective filters change without
- * touching the offending value.
+ * throws — during render, which would crash the consuming hook. The replacer
+ * below handles both INLINE so the stringify never throws AND stays sensitive
+ * to actual value content: `BigInt` serializes as `<n>n`, and a circular
+ * reference is replaced with a `[Circular]` marker (rather than dropping the
+ * value), so changing any value still changes the key.
  */
 export function getEffectiveFilterKey(
   filters: FilterState[] | FilterGroupNode | undefined
 ): string {
   if (filters === undefined) return 'null';
   const effective = getEffectiveFilters(filters);
-  try {
-    return (
-      JSON.stringify(effective, (_key, value) =>
-        typeof value === 'bigint' ? `${value}n` : value
-      ) ?? 'null'
-    );
-  } catch {
-    const leaves = isFilterGroupNode(effective) ? flattenFilterNode(effective) : effective;
-    return `shape:${leaves
-      .map((leaf) => `${leaf.columnId}:${leaf.operator}:${leaf.values.length}`)
-      .join('|')}`;
-  }
+  const seen = new WeakSet<object>();
+  return (
+    JSON.stringify(effective, (_key, value) => {
+      if (typeof value === 'bigint') return `${value}n`;
+      if (typeof value === 'object' && value !== null) {
+        if (seen.has(value)) return '[Circular]';
+        seen.add(value);
+      }
+      return value;
+    }) ?? 'null'
+  );
 }

--- a/packages/core/src/utils/filter-effect.ts
+++ b/packages/core/src/utils/filter-effect.ts
@@ -17,6 +17,7 @@
 
 import type { FilterGroupNode, FilterState } from '../types/filter';
 import { getOperatorDefinition } from '../types/filter-operators';
+import { flattenFilterNode, isFilterGroupNode } from './type-guards';
 
 /**
  * Does `filter` actually constrain query results?
@@ -56,4 +57,36 @@ export function getEffectiveFilters(
     return filters.filter(filterHasEffect);
   }
   return filters;
+}
+
+/**
+ * A stable string key for the EFFECTIVE filters, safe to use as a React memo
+ * dependency (so an incomplete chip doesn't refire fetch/facets — plan 063
+ * follow-up). `undefined` → `'null'`.
+ *
+ * `JSON.stringify` alone is unsafe here: a `custom` filter's `values` is
+ * `unknown[]`, so a `BigInt` value throws `TypeError` and a circular value
+ * throws — during render, which would crash the consuming hook. This uses a
+ * BigInt-aware replacer and, on any remaining serialization failure, falls
+ * back to a structural signature (per effective leaf: `columnId`, `operator`,
+ * value count) that still changes when the effective filters change without
+ * touching the offending value.
+ */
+export function getEffectiveFilterKey(
+  filters: FilterState[] | FilterGroupNode | undefined
+): string {
+  if (filters === undefined) return 'null';
+  const effective = getEffectiveFilters(filters);
+  try {
+    return (
+      JSON.stringify(effective, (_key, value) =>
+        typeof value === 'bigint' ? `${value}n` : value
+      ) ?? 'null'
+    );
+  } catch {
+    const leaves = isFilterGroupNode(effective) ? flattenFilterNode(effective) : effective;
+    return `shape:${leaves
+      .map((leaf) => `${leaf.columnId}:${leaf.operator}:${leaf.values.length}`)
+      .join('|')}`;
+  }
 }

--- a/packages/core/src/utils/filter-effect.ts
+++ b/packages/core/src/utils/filter-effect.ts
@@ -1,0 +1,59 @@
+/**
+ * @fileoverview "Does this filter actually constrain results?" — the predicate
+ * that lets consumers ignore an incomplete filter (plan 063 follow-up).
+ *
+ * @module utils/filter-effect
+ *
+ * @remarks
+ * The filter bar adds a chip the instant a column is picked, before the user
+ * has entered a value (`filter-bar.tsx` builds `{ ..., values: [] }`). That
+ * chip cannot narrow anything, yet — treated as a real filter — it changed
+ * the filter list identity and so triggered a data refetch, a facet refresh,
+ * AND a URL write (a full server round-trip in server-driven apps) before the
+ * user typed anything. These helpers let the fetch/facet/URL layers key their
+ * work on the filters that actually constrain results, so an empty chip is
+ * free until it gets a value.
+ */
+
+import type { FilterGroupNode, FilterState } from '../types/filter';
+import { getOperatorDefinition } from '../types/filter-operators';
+
+/**
+ * Does `filter` actually constrain query results?
+ *
+ * - No-value operators (`isEmpty`, `isNotEmpty`, `isNull`, `isNotNull`,
+ *   `isTrue`, `isFalse`, `isToday`, …; `valueCount === 0`) constrain results
+ *   on their own — always effective.
+ * - Every value-taking operator needs at least one value; a freshly added
+ *   chip (`values: []`) does not have one, so it has no effect yet.
+ *
+ * Deliberately NOT the stricter {@link validateOperatorValues}: this only
+ * asks "is there anything to apply", so a partially-entered multi-value
+ * filter (e.g. one bound of a `between`) keeps its current behavior — the
+ * scope here is the empty-chip case, not full input validation.
+ */
+export function filterHasEffect(filter: FilterState): boolean {
+  const definition = getOperatorDefinition(filter.operator, filter.type);
+  if (definition?.valueCount === 0) return true;
+  return filter.values.length > 0;
+}
+
+/**
+ * The subset of `filters` that actually constrains results — a flat list with
+ * every no-effect leaf (see {@link filterHasEffect}) removed.
+ *
+ * A {@link FilterGroupNode} tree is returned unchanged: the flat filter bar
+ * (the surface that produces empty chips) always emits `FilterState[]`, and
+ * pruning no-effect leaves out of an AND/OR tree — dropping emptied groups,
+ * unwrapping single-child groups — is the nested-builder's concern
+ * (plan 048), not this helper's. Callers that only need a stable
+ * "effective filters" signature can compare this output by content.
+ */
+export function getEffectiveFilters(
+  filters: FilterState[] | FilterGroupNode
+): FilterState[] | FilterGroupNode {
+  if (Array.isArray(filters)) {
+    return filters.filter(filterHasEffect);
+  }
+  return filters;
+}

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -10,6 +10,7 @@ export * from './column-order';
 export * from './column-visibility';
 export * from './compression';
 export * from './equality';
+export * from './filter-effect';
 export * from './filter-serialization';
 export * from './filter-value';
 export * from './meta-accessors';

--- a/packages/core/src/utils/url-serialization.ts
+++ b/packages/core/src/utils/url-serialization.ts
@@ -21,6 +21,7 @@
 
 import type { FilterGroupNode, FilterState, PaginationState, SortingState } from '@/types';
 import { compressAndEncode, decompressAndDecode } from './compression';
+import { getEffectiveFilters } from './filter-effect';
 import { deserializeFiltersFromURL, serializeFiltersToURL } from './filter-serialization';
 
 /**
@@ -104,15 +105,22 @@ export function serializeTableStateToUrl(
 ): Record<string, string | null> {
   const params: Record<string, string | null> = {};
 
-  // Serialize filters (compressed and encoded) - use core serialization function
+  // Serialize filters (compressed and encoded) - use core serialization function.
+  // Only filters that actually constrain results are written: a chip added
+  // before its value is chosen (`values: []`) must not change the URL — that
+  // would trigger a needless refetch / RSC round-trip for a filter that can't
+  // narrow anything yet (plan 063 follow-up). `getEffectiveFilters` drops those
+  // no-effect leaves from a flat list; a FilterGroupNode passes through
+  // unchanged (see its docs).
   if (state.filters !== undefined) {
+    const effectiveFilters = getEffectiveFilters(state.filters);
     // A FilterGroupNode has no `.length` and (per design §1.4) is never
     // meaningfully "empty" after validation, so only an empty FilterState[]
     // array counts as "nothing to serialize".
-    const isEmptyArray = Array.isArray(state.filters) && state.filters.length === 0;
+    const isEmptyArray = Array.isArray(effectiveFilters) && effectiveFilters.length === 0;
     if (!isEmptyArray) {
       try {
-        params.filters = serializeFiltersToURL(state.filters);
+        params.filters = serializeFiltersToURL(effectiveFilters);
       } catch {
         // Silently ignore serialization errors
       }

--- a/packages/core/src/utils/url-serialization.ts
+++ b/packages/core/src/utils/url-serialization.ts
@@ -79,6 +79,13 @@ export interface DeserializedTableState {
  * - 4 filters: ~400 chars → ~150-200 chars (50-60% reduction)
  * - 10+ filters: ~1000+ chars → ~300-400 chars (60-70% reduction)
  *
+ * **Filter handling:** only filters that actually constrain results are
+ * serialized — a value-taking filter with empty `values` (e.g. a chip added
+ * before its value is chosen) is dropped via `getEffectiveFilters`, so it
+ * never appears in the URL and never triggers a needless refetch / RSC
+ * round-trip. No-value operators (`isEmpty`/`isNull`/…) still serialize.
+ * (A `FilterGroupNode` tree is serialized as-is; see `getEffectiveFilters`.)
+ *
  * @param state - Table state to serialize
  * @returns Record of URL parameter keys and values (null values should be removed from URL)
  *

--- a/packages/core/tests/adapters/http-adapter.test.ts
+++ b/packages/core/tests/adapters/http-adapter.test.ts
@@ -854,6 +854,53 @@ describe('signal-aware facet caching (lag fix: cache no longer bypassed)', () =>
     });
     expect(map.get('open')).toBe(12);
     expect(fetchCount).toBe(2);
+
+    // The fresh result IS cached: a later read hits it (fetchCount stays 2).
+    // If the aborted request's late `.catch` had deleted the shared key, this
+    // would refetch — the abort-guard prevents that cross-entry delete.
+    const again = await client.getFacetedValues('status', {
+      signal: new AbortController().signal,
+    });
+    expect(again.get('open')).toBe(12);
+    expect(fetchCount).toBe(2);
+  });
+
+  it('bounds the result cache (LRU): an evicted key refetches, a touched key survives', async () => {
+    let fetchCount = 0;
+    const { adapter: server } = makeServerAdapter();
+    const client = httpAdapter({
+      url: '/api/tables',
+      cacheTtlMs: 60_000,
+      fetch: async (url, init) => {
+        fetchCount += 1;
+        return loopbackFetch(server)(url, init);
+      },
+    });
+
+    // Fill the cache to its cap with distinct facet keys (one per columnId).
+    // MAX_CACHE_ENTRIES is 100; use column 'c0' first so we can watch it.
+    await client.getFacetedValues('c0');
+    for (let i = 1; i < 100; i++) {
+      await client.getFacetedValues(`c${i}`);
+    }
+    expect(fetchCount).toBe(100);
+
+    // Touch 'c0' (cache hit → marked most-recently-used, no fetch).
+    await client.getFacetedValues('c0');
+    expect(fetchCount).toBe(100);
+
+    // One more distinct key pushes size over the cap → the LRU entry is
+    // evicted. 'c0' was just touched, so 'c1' (now oldest) is evicted, not 'c0'.
+    await client.getFacetedValues('c100');
+    expect(fetchCount).toBe(101);
+
+    // 'c0' still cached (touch saved it): no refetch.
+    await client.getFacetedValues('c0');
+    expect(fetchCount).toBe(101);
+
+    // 'c1' was evicted: it refetches.
+    await client.getFacetedValues('c1');
+    expect(fetchCount).toBe(102);
   });
 
   it('a pre-aborted signal rejects without fetching', async () => {

--- a/packages/core/tests/adapters/http-adapter.test.ts
+++ b/packages/core/tests/adapters/http-adapter.test.ts
@@ -737,3 +737,242 @@ describe('httpAdapter export (plan 050)', () => {
     expect((result?.data as string).split('\n')).toHaveLength(1);
   });
 });
+
+describe('signal-aware facet caching (lag fix: cache no longer bypassed)', () => {
+  it('serves signalled facet reads from the TTL cache and dedups them', async () => {
+    let fetchCount = 0;
+    const { adapter: server } = makeServerAdapter();
+    const client = httpAdapter({
+      url: '/api/tables',
+      cacheTtlMs: 5000,
+      fetch: async (url, init) => {
+        fetchCount += 1;
+        return loopbackFetch(server)(url, init);
+      },
+    });
+
+    // Two sequential identical reads, each with a live AbortSignal (the
+    // useFacets pattern) — the second must hit the cache.
+    await client.getFacetedValues('status', { signal: new AbortController().signal });
+    await client.getFacetedValues('status', { signal: new AbortController().signal });
+    expect(fetchCount).toBe(1);
+
+    // Concurrent identical signalled reads share one request.
+    await Promise.all([
+      client.getMinMaxValues('reopens', { signal: new AbortController().signal }),
+      client.getMinMaxValues('reopens', { signal: new AbortController().signal }),
+    ]);
+    expect(fetchCount).toBe(2);
+  });
+
+  it('aborting one follower rejects it without cancelling the shared request', async () => {
+    let release: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const { adapter: server } = makeServerAdapter();
+    let underlyingAborted = false;
+    const client = httpAdapter({
+      url: '/api/tables',
+      cacheTtlMs: 5000,
+      fetch: async (url, init) => {
+        init?.signal?.addEventListener('abort', () => {
+          underlyingAborted = true;
+        });
+        await gate;
+        return loopbackFetch(server)(url, init);
+      },
+    });
+
+    const controllerA = new AbortController();
+    const controllerB = new AbortController();
+    const promiseA = client.getFacetedValues('status', { signal: controllerA.signal });
+    const promiseB = client.getFacetedValues('status', { signal: controllerB.signal });
+
+    controllerA.abort();
+    await expect(promiseA).rejects.toMatchObject({ name: 'AbortError' });
+    expect(underlyingAborted).toBe(false);
+
+    release();
+    const map = await promiseB;
+    expect(map.get('open')).toBe(12);
+  });
+
+  it('aborts the shared request when EVERY follower aborts, and a later caller refetches', async () => {
+    const { adapter: server } = makeServerAdapter();
+    let fetchCount = 0;
+    const client = httpAdapter({
+      url: '/api/tables',
+      cacheTtlMs: 5000,
+      fetch: async (url, init) => {
+        fetchCount += 1;
+        if (fetchCount === 1) {
+          // First request: reject on abort like real fetch — including a
+          // signal that is ALREADY aborted when the fetch starts (listeners
+          // added after abort never fire, and a forever-pending promise
+          // wedges the test runner).
+          await new Promise<void>((_resolve, reject) => {
+            const rejectAborted = () => {
+              const error = new Error('The operation was aborted.');
+              error.name = 'AbortError';
+              reject(error);
+            };
+            if (init?.signal?.aborted) {
+              rejectAborted();
+              return;
+            }
+            init?.signal?.addEventListener('abort', rejectAborted);
+          });
+        }
+        return loopbackFetch(server)(url, init);
+      },
+    });
+
+    const controllerA = new AbortController();
+    const controllerB = new AbortController();
+    const promiseA = client.getFacetedValues('status', { signal: controllerA.signal });
+    const promiseB = client.getFacetedValues('status', { signal: controllerB.signal });
+
+    // Attach plain settle handlers BEFORE aborting so neither rejection is
+    // ever handler-less (the runner reports late-handled rejections). Not
+    // `.rejects` matchers: attached to a still-pending promise they wedge
+    // this bun version once it rejects.
+    const settle = (promise: Promise<unknown>) =>
+      promise.then(
+        () => 'resolved' as const,
+        (error: unknown) => (error instanceof Error ? error.name : 'unknown')
+      );
+    const settled = Promise.all([settle(promiseA), settle(promiseB)]);
+    controllerA.abort();
+    controllerB.abort();
+    expect(await settled).toEqual(['AbortError', 'AbortError']);
+
+    // Aborted request was not cached; a fresh caller starts a NEW request
+    // (never joins the doomed entry) and succeeds.
+    const map = await client.getFacetedValues('status', {
+      signal: new AbortController().signal,
+    });
+    expect(map.get('open')).toBe(12);
+    expect(fetchCount).toBe(2);
+  });
+
+  it('a pre-aborted signal rejects without fetching', async () => {
+    let fetchCount = 0;
+    const { adapter: server } = makeServerAdapter();
+    const client = httpAdapter({
+      url: '/api/tables',
+      cacheTtlMs: 5000,
+      fetch: async (url, init) => {
+        fetchCount += 1;
+        return loopbackFetch(server)(url, init);
+      },
+    });
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      client.getFacetedValues('status', { signal: controller.signal })
+    ).rejects.toMatchObject({ name: 'AbortError' });
+    expect(fetchCount).toBe(0);
+  });
+});
+
+describe('getFacets batch (lag fix: one round-trip per sidebar refresh)', () => {
+  it('answers a mixed values/minmax batch in ONE request via server fan-out', async () => {
+    let fetchCount = 0;
+    const { adapter: server, calls } = makeServerAdapter();
+    const client = httpAdapter({
+      url: '/api/tables',
+      fetch: async (url, init) => {
+        fetchCount += 1;
+        return loopbackFetch(server)(url, init);
+      },
+    });
+
+    const result = await client.getFacets?.(
+      [
+        { columnId: 'status', kind: 'values' },
+        { columnId: 'priority', kind: 'values' },
+        { columnId: 'reopens', kind: 'minmax' },
+      ],
+      { filters: [{ columnId: 'status', type: 'option', operator: 'is', values: ['open'] }] }
+    );
+
+    expect(fetchCount).toBe(1);
+    expect(result?.values.status).toBeInstanceOf(Map);
+    expect(result?.values.status?.get('open')).toBe(12);
+    expect(result?.values.priority?.get('closed')).toBe(3);
+    expect(result?.ranges.reopens).toEqual([0, 9]);
+    // The server-side fan-out hit the singular methods once per entry.
+    expect(calls.filter((c) => c.method === 'getFacetedValues')).toHaveLength(2);
+    expect(calls.filter((c) => c.method === 'getMinMaxValues')).toHaveLength(1);
+  });
+
+  it('prefers the server adapter own getFacets when implemented', async () => {
+    const { adapter: server, calls } = makeServerAdapter();
+    let batchCalls = 0;
+    server.getFacets = async (requests) => {
+      batchCalls += 1;
+      expect(requests).toHaveLength(2);
+      return {
+        values: { status: new Map([['open', 7]]) },
+        ranges: { reopens: [1, 2] },
+      };
+    };
+    const client = httpAdapter({ url: '/api/tables', fetch: loopbackFetch(server) });
+
+    const result = await client.getFacets?.([
+      { columnId: 'status', kind: 'values' },
+      { columnId: 'reopens', kind: 'minmax' },
+    ]);
+
+    expect(batchCalls).toBe(1);
+    expect(calls.filter((c) => c.method === 'getFacetedValues')).toHaveLength(0);
+    expect(result?.values.status?.get('open')).toBe(7);
+    expect(result?.ranges.reopens).toEqual([1, 2]);
+  });
+
+  it('caches identical batches and keys distinct batches separately', async () => {
+    let fetchCount = 0;
+    const { adapter: server } = makeServerAdapter();
+    const client = httpAdapter({
+      url: '/api/tables',
+      cacheTtlMs: 5000,
+      fetch: async (url, init) => {
+        fetchCount += 1;
+        return loopbackFetch(server)(url, init);
+      },
+    });
+
+    const batch = [{ columnId: 'status', kind: 'values' as const }];
+    await client.getFacets?.(batch, { signal: new AbortController().signal });
+    await client.getFacets?.(batch, { signal: new AbortController().signal });
+    expect(fetchCount).toBe(1);
+    await client.getFacets?.([{ columnId: 'priority', kind: 'values' }]);
+    expect(fetchCount).toBe(2);
+  });
+
+  it('rejects malformed and oversized getFacets bodies as bad_request', async () => {
+    const { adapter: server } = makeServerAdapter();
+
+    expect(await handleAdapterRequest(server, { method: 'getFacets', requests: [] })).toMatchObject(
+      { ok: false, kind: 'bad_request' }
+    );
+
+    expect(
+      await handleAdapterRequest(server, {
+        method: 'getFacets',
+        requests: [{ columnId: 'status', kind: 'bogus' }],
+      })
+    ).toMatchObject({ ok: false, kind: 'bad_request' });
+
+    expect(
+      await handleAdapterRequest(server, {
+        method: 'getFacets',
+        requests: Array.from({ length: 51 }, (_, i) => ({
+          columnId: `c${i}`,
+          kind: 'values' as const,
+        })),
+      })
+    ).toMatchObject({ ok: false, kind: 'bad_request' });
+  });
+});

--- a/packages/core/tests/types/tsconfig.filter-perf.json
+++ b/packages/core/tests/types/tsconfig.filter-perf.json
@@ -1,0 +1,16 @@
+{
+  // Isolated-check config for the plan 031 filter type-perf fixture: real
+  // package compiler options (extends), but ONLY this fixture included, and
+  // only @types/node loaded — a bare `tsc <file>` would use DEFAULT options
+  // (target ES5) and auto-load every hoisted @types package (@types/mdx
+  // breaks without JSX), which is why the gate runs through this config.
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false,
+    "types": ["node"]
+  },
+  "include": ["filter-perf-fixture.ts"]
+}

--- a/packages/core/tests/types/tsconfig.table-def-perf.json
+++ b/packages/core/tests/types/tsconfig.table-def-perf.json
@@ -1,0 +1,16 @@
+{
+  // Isolated-check config for the plan 018 table-definition type-perf
+  // fixture — see tsconfig.filter-perf.json for why the gate cannot use a
+  // bare `tsc <file>` invocation. This fixture imports real src modules
+  // (defineTable), so the package's actual target/strictness flags are
+  // load-bearing for both correctness and the instantiation count.
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false,
+    "types": ["node"]
+  },
+  "include": ["table-def-perf-fixture.ts"]
+}

--- a/packages/core/tests/types/type-perf-gate.test.ts
+++ b/packages/core/tests/types/type-perf-gate.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'bun:test';
+import { join } from 'node:path';
+
+/**
+ * Plan 063 Step 5 — the type-perf gate, automated.
+ *
+ * The plan 031/018 fixtures existed for a MANUAL `tsc --extendedDiagnostics`
+ * check (budgets recorded in plans/design/table-definition-dx.md: ≤ 2M
+ * instantiations, ≤ 2.5 s local check time) that no CI step ever ran. This
+ * test runs it on every `bun test` of core:
+ *
+ * - HARD gate: instantiations ≤ 2,000,000 per fixture — deterministic, the
+ *   real budget.
+ * - LOOSE gate: check time ≤ 7.5 s (3× the 2.5 s local target) — slow-runner
+ *   slack only; wall time never gets a tight CI budget (plan 063 noise
+ *   discipline). The measured values are printed so CI logs double as a
+ *   trend record (and the bench suite emits them as trend entries).
+ *
+ * Measurement mode: `tsc -p tests/types/tsconfig.<fixture>.json` — the
+ * package's REAL compiler options with only @types/node loaded. A bare
+ * `tsc <file>` ignores tsconfig (ES5 default target breaks src imports;
+ * every hoisted @types package auto-loads; skipLibCheck is off, so counts
+ * drown in stdlib churn). Numbers are therefore NOT comparable to the old
+ * manual bare-file measurements.
+ *
+ * Local fast loops may skip via SKIP_TYPE_PERF=1; in GitHub Actions the
+ * skip is ignored so the gate can never silently vanish from CI (same
+ * idiom as the drizzle ci-integration-guard).
+ */
+
+const inGitHubActions = process.env.GITHUB_ACTIONS === 'true';
+const skipRequested = process.env.SKIP_TYPE_PERF === '1' && !inGitHubActions;
+
+const PACKAGE_ROOT = join(import.meta.dir, '..', '..');
+const INSTANTIATION_BUDGET = 2_000_000;
+const CHECK_TIME_CEILING_S = 7.5;
+
+interface TypePerfMeasurement {
+  instantiations: number;
+  checkTimeSeconds: number;
+}
+
+async function measureFixture(projectRelPath: string): Promise<TypePerfMeasurement> {
+  const proc = Bun.spawn(['bunx', 'tsc', '-p', projectRelPath, '--extendedDiagnostics'], {
+    cwd: PACKAGE_ROOT,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (exitCode !== 0) {
+    throw new Error(`tsc failed (exit ${exitCode}) for ${projectRelPath}:\n${stdout}\n${stderr}`);
+  }
+  const instantiations = stdout.match(/^Instantiations:\s+([\d,]+)/m);
+  const checkTime = stdout.match(/^Check time:\s+([\d.]+)s/m);
+  if (!instantiations?.[1] || !checkTime?.[1]) {
+    throw new Error(`could not parse extendedDiagnostics output for ${projectRelPath}:\n${stdout}`);
+  }
+  return {
+    instantiations: Number(instantiations[1].replaceAll(',', '')),
+    checkTimeSeconds: Number(checkTime[1]),
+  };
+}
+
+describe.skipIf(skipRequested)('type-perf gate (plan 063 Step 5)', () => {
+  const fixtures = [
+    { label: 'filter-perf-fixture (plan 031)', project: 'tests/types/tsconfig.filter-perf.json' },
+    {
+      label: 'table-def-perf-fixture (plan 018)',
+      project: 'tests/types/tsconfig.table-def-perf.json',
+    },
+  ];
+
+  for (const fixture of fixtures) {
+    it(`${fixture.label}: ≤ ${INSTANTIATION_BUDGET.toLocaleString()} instantiations (hard), ≤ ${CHECK_TIME_CEILING_S}s check (loose)`, async () => {
+      const measured = await measureFixture(fixture.project);
+      // biome-ignore lint/suspicious/noConsole: trend record in CI logs
+      console.log(
+        `[type-perf] ${fixture.label}: instantiations=${measured.instantiations.toLocaleString()} ` +
+          `checkTime=${measured.checkTimeSeconds}s (budget ${INSTANTIATION_BUDGET.toLocaleString()} / local target 2.5s)`
+      );
+      expect(measured.instantiations).toBeGreaterThan(0);
+      expect(measured.instantiations).toBeLessThanOrEqual(INSTANTIATION_BUDGET);
+      expect(measured.checkTimeSeconds).toBeLessThanOrEqual(CHECK_TIME_CEILING_S);
+    }, 60_000);
+  }
+});

--- a/packages/core/tests/utils/filter-effect.test.ts
+++ b/packages/core/tests/utils/filter-effect.test.ts
@@ -149,7 +149,10 @@ describe('getEffectiveFilterKey (BigInt/circular-safe)', () => {
     expect(key).toContain('"label":"a"');
     // Changing the (circular) value's non-circular content changes the key —
     // the fallback must NOT collapse to a value-insensitive signature.
-    const changed: CustomFilterState = { ...custom, values: [makeCircular('b') as unknown as string] };
+    const changed: CustomFilterState = {
+      ...custom,
+      values: [makeCircular('b') as unknown as string],
+    };
     expect(getEffectiveFilterKey([changed])).not.toBe(key);
   });
 });

--- a/packages/core/tests/utils/filter-effect.test.ts
+++ b/packages/core/tests/utils/filter-effect.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'bun:test';
+import type { FilterGroupNode, FilterState } from '../../src/types/filter';
+import { filterHasEffect, getEffectiveFilters } from '../../src/utils/filter-effect';
+import { serializeTableStateToUrl } from '../../src/utils/url-serialization';
+
+/**
+ * Plan 063 follow-up: an incomplete filter (a chip added before its value is
+ * chosen) must not constrain results, so it must not trigger a fetch / facet
+ * refresh / URL write. These tests pin the predicate and the serializer's use
+ * of it.
+ */
+
+describe('filterHasEffect', () => {
+  it('a value-taking operator with no values has no effect', () => {
+    const empty: FilterState = { columnId: 'name', type: 'text', operator: 'contains', values: [] };
+    expect(filterHasEffect(empty)).toBe(false);
+  });
+
+  it('a value-taking operator with a value has effect', () => {
+    const filled: FilterState = {
+      columnId: 'name',
+      type: 'text',
+      operator: 'contains',
+      values: ['john'],
+    };
+    expect(filterHasEffect(filled)).toBe(true);
+  });
+
+  it('an empty option filter (isAnyOf, no values) has no effect', () => {
+    const empty: FilterState = {
+      columnId: 'status',
+      type: 'option',
+      operator: 'isAnyOf',
+      values: [],
+    };
+    expect(filterHasEffect(empty)).toBe(false);
+  });
+
+  it('a no-value operator (isEmpty / isNull) constrains without values', () => {
+    const isEmpty: FilterState = {
+      columnId: 'name',
+      type: 'text',
+      operator: 'isEmpty',
+      values: [],
+    };
+    const isNull: FilterState = {
+      columnId: 'name',
+      type: 'text',
+      operator: 'isNull',
+      values: [],
+    };
+    expect(filterHasEffect(isEmpty)).toBe(true);
+    expect(filterHasEffect(isNull)).toBe(true);
+  });
+
+  it('a boolean no-value operator (isTrue) constrains without values', () => {
+    const isTrue: FilterState = {
+      columnId: 'active',
+      type: 'boolean',
+      operator: 'isTrue',
+      values: [],
+    };
+    expect(filterHasEffect(isTrue)).toBe(true);
+  });
+});
+
+describe('getEffectiveFilters', () => {
+  it('drops no-effect leaves from a flat list, keeps the rest', () => {
+    const filters: FilterState[] = [
+      { columnId: 'name', type: 'text', operator: 'contains', values: ['a'] },
+      { columnId: 'status', type: 'option', operator: 'isAnyOf', values: [] },
+      { columnId: 'bio', type: 'text', operator: 'isEmpty', values: [] },
+    ];
+    const effective = getEffectiveFilters(filters) as FilterState[];
+    expect(effective).toHaveLength(2);
+    expect(effective.map((f) => f.columnId)).toEqual(['name', 'bio']);
+  });
+
+  it('returns an empty array when every filter is incomplete', () => {
+    const filters: FilterState[] = [
+      { columnId: 'name', type: 'text', operator: 'contains', values: [] },
+    ];
+    expect(getEffectiveFilters(filters)).toEqual([]);
+  });
+
+  it('passes a FilterGroupNode tree through unchanged', () => {
+    const tree: FilterGroupNode = {
+      kind: 'group',
+      logic: 'and',
+      children: [{ columnId: 'name', type: 'text', operator: 'contains', values: ['a'] }],
+    };
+    expect(getEffectiveFilters(tree)).toBe(tree);
+  });
+});
+
+describe('serializeTableStateToUrl drops no-effect filters', () => {
+  it('an added empty chip does not change the serialized filters param', () => {
+    const withValue: FilterState[] = [
+      { columnId: 'name', type: 'text', operator: 'contains', values: ['john'] },
+    ];
+    const withValueAndEmptyChip: FilterState[] = [
+      ...withValue,
+      { columnId: 'status', type: 'option', operator: 'isAnyOf', values: [] },
+    ];
+
+    const a = serializeTableStateToUrl({ filters: withValue });
+    const b = serializeTableStateToUrl({ filters: withValueAndEmptyChip });
+    // Identical serialized filters — the empty chip left no trace, so an
+    // adapter that navigates on setParams sees no change.
+    expect(b.filters).toBe(a.filters);
+  });
+
+  it('a lone empty chip serializes to null (nothing to write)', () => {
+    const params = serializeTableStateToUrl({
+      filters: [{ columnId: 'name', type: 'text', operator: 'contains', values: [] }],
+    });
+    expect(params.filters).toBeNull();
+  });
+
+  it('a no-value operator (isEmpty) still serializes (it constrains)', () => {
+    const params = serializeTableStateToUrl({
+      filters: [{ columnId: 'name', type: 'text', operator: 'isEmpty', values: [] }],
+    });
+    expect(typeof params.filters).toBe('string');
+    expect(params.filters).toContain('c2:');
+  });
+});

--- a/packages/core/tests/utils/filter-effect.test.ts
+++ b/packages/core/tests/utils/filter-effect.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'bun:test';
-import type { FilterGroupNode, FilterState } from '../../src/types/filter';
-import { filterHasEffect, getEffectiveFilters } from '../../src/utils/filter-effect';
+import type { CustomFilterState, FilterGroupNode, FilterState } from '../../src/types/filter';
+import {
+  filterHasEffect,
+  getEffectiveFilterKey,
+  getEffectiveFilters,
+} from '../../src/utils/filter-effect';
 import { serializeTableStateToUrl } from '../../src/utils/url-serialization';
 
 /**
@@ -90,6 +94,55 @@ describe('getEffectiveFilters', () => {
       children: [{ columnId: 'name', type: 'text', operator: 'contains', values: ['a'] }],
     };
     expect(getEffectiveFilters(tree)).toBe(tree);
+  });
+});
+
+describe('getEffectiveFilterKey (BigInt/circular-safe)', () => {
+  it('returns "null" for undefined and a stable key for equal effective filters', () => {
+    expect(getEffectiveFilterKey(undefined)).toBe('null');
+    const a: FilterState[] = [
+      { columnId: 'name', type: 'text', operator: 'contains', values: ['x'] },
+    ];
+    const b: FilterState[] = [
+      { columnId: 'name', type: 'text', operator: 'contains', values: ['x'] },
+      // an incomplete chip is dropped, so the key matches `a`
+      { columnId: 'status', type: 'option', operator: 'isAnyOf', values: [] },
+    ];
+    expect(getEffectiveFilterKey(b)).toBe(getEffectiveFilterKey(a));
+  });
+
+  it('does NOT throw on a BigInt custom filter value (would crash the hook render)', () => {
+    const custom: CustomFilterState = {
+      columnId: 'big',
+      type: 'custom',
+      operator: 'equals',
+      values: [10n as unknown as string],
+    };
+    let key = '';
+    expect(() => {
+      key = getEffectiveFilterKey([custom]);
+    }).not.toThrow();
+    expect(key).toContain('10n');
+    // Distinguishes different bigints.
+    const other: CustomFilterState = { ...custom, values: [11n as unknown as string] };
+    expect(getEffectiveFilterKey([other])).not.toBe(key);
+  });
+
+  it('falls back to a structural signature on a circular value instead of throwing', () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    const custom: CustomFilterState = {
+      columnId: 'c',
+      type: 'custom',
+      operator: 'equals',
+      values: [circular as unknown as string],
+    };
+    let key = '';
+    expect(() => {
+      key = getEffectiveFilterKey([custom]);
+    }).not.toThrow();
+    expect(key.startsWith('shape:')).toBe(true);
+    expect(key).toContain('c:equals:1');
   });
 });
 

--- a/packages/core/tests/utils/filter-effect.test.ts
+++ b/packages/core/tests/utils/filter-effect.test.ts
@@ -128,21 +128,29 @@ describe('getEffectiveFilterKey (BigInt/circular-safe)', () => {
     expect(getEffectiveFilterKey([other])).not.toBe(key);
   });
 
-  it('falls back to a structural signature on a circular value instead of throwing', () => {
-    const circular: Record<string, unknown> = {};
-    circular.self = circular;
+  it('handles a circular value without throwing AND stays value-sensitive', () => {
+    const makeCircular = (label: string) => {
+      const circular: Record<string, unknown> = { label };
+      circular.self = circular;
+      return circular;
+    };
     const custom: CustomFilterState = {
       columnId: 'c',
       type: 'custom',
       operator: 'equals',
-      values: [circular as unknown as string],
+      values: [makeCircular('a') as unknown as string],
     };
     let key = '';
     expect(() => {
       key = getEffectiveFilterKey([custom]);
     }).not.toThrow();
-    expect(key.startsWith('shape:')).toBe(true);
-    expect(key).toContain('c:equals:1');
+    // Circular reference is marked, not dropped — value content survives.
+    expect(key).toContain('[Circular]');
+    expect(key).toContain('"label":"a"');
+    // Changing the (circular) value's non-circular content changes the key —
+    // the fallback must NOT collapse to a value-insensitive signature.
+    const changed: CustomFilterState = { ...custom, values: [makeCircular('b') as unknown as string] };
+    expect(getEffectiveFilterKey([changed])).not.toBe(key);
   });
 });
 

--- a/packages/ui/src/components/table/table.tsx
+++ b/packages/ui/src/components/table/table.tsx
@@ -214,7 +214,12 @@ export interface BetterTableProps<TData = unknown>
   /** Adapter (optional when data is provided directly) */
   adapter?: TableConfig<TData>['adapter'];
 
-  /** Loading state */
+  /**
+   * Loading state. With no rows yet (initial load) the table renders a
+   * skeleton; during a refetch with rows on screen the CURRENT rows stay
+   * visible, dimmed and `aria-busy`, until the new data arrives — a
+   * pagination/filter change never unmounts the table to a spinner.
+   */
   loading?: boolean;
 
   /** Error state */
@@ -1269,8 +1274,11 @@ function BetterTableInner<TData = unknown>({
   // the scrollbar sized to the rendered window instead of the whole dataset.
   const virtualSpacerColSpan = visibleColumns.length + (shouldShowRowSelection ? 1 : 0);
 
-  // Render loading state
-  if (loading) {
+  // Render the skeleton only while there is nothing else to show (initial
+  // load / empty refetch). A refetch with rows on screen keeps them rendered
+  // — dimmed via the main path below — instead of unmounting every row to a
+  // skeleton on each pagination/filter change.
+  if (loading && data.length === 0) {
     return (
       // biome-ignore lint/a11y/useSemanticElements: Fine for live regions
       <div
@@ -1389,7 +1397,12 @@ function BetterTableInner<TData = unknown>({
   const ToolbarExtraSlot = slots?.toolbarExtra;
 
   const tableContent = (
-    <div className={cn('space-y-4', className)} {...props} {...(name !== undefined && { name })}>
+    <div
+      className={cn('space-y-4', className)}
+      aria-busy={loading}
+      {...props}
+      {...(name !== undefined && { name })}
+    >
       {/* Always mounted so SSR/client DOM structure matches */}
       <div aria-live="polite" aria-atomic="true" className="sr-only">
         {sortAnnouncement}
@@ -1453,7 +1466,12 @@ function BetterTableInner<TData = unknown>({
         )}
       </div>
       <div
-        className="border rounded-md"
+        className={cn(
+          'border rounded-md',
+          // Refetch affordance: rows stay visible (and interactive) but dim
+          // while new data is in flight, instead of unmounting to a skeleton.
+          loading && 'opacity-60 transition-opacity duration-150'
+        )}
         {...(isVirtualized && {
           ref: virtualContainerRef,
           style: { height: virtualHeight, overflowY: 'auto' as const },

--- a/packages/ui/src/hooks/use-facets.ts
+++ b/packages/ui/src/hooks/use-facets.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import type { FilterGroupNode, FilterState, TableAdapter } from '@better-tables/core';
+import { getEffectiveFilters } from '@better-tables/core';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 /** A single faceted option: a distinct value and how many rows match it. */
@@ -125,7 +126,15 @@ export function useFacets<TData = unknown>({
   // every render and re-fire the fetch effect indefinitely. Intern by JSON
   // content -- filter state is small and this only runs on identity change,
   // not on every fetch.
-  const filtersKey = JSON.stringify(filters ?? null);
+  //
+  // Key on the EFFECTIVE filters (no-effect leaves dropped) so a chip added
+  // before its value is chosen (`values: []`) does not refire the facet batch
+  // — it cannot change any facet's counts yet (plan 063 follow-up). The full
+  // `filters` array is still what's passed to the adapter (self-exclusion is
+  // its job over the complete state); only the refetch TRIGGER is effective.
+  const filtersKey = JSON.stringify(filters === undefined ? null : getEffectiveFilters(filters));
+  // Intern `filters` by effective content, not identity: `filtersKey` (not
+  // `filters`) is the dependency on purpose.
   const stableFilters = useMemo(() => filters, [filtersKey]);
 
   const fetchFacets = useCallback(async () => {

--- a/packages/ui/src/hooks/use-facets.ts
+++ b/packages/ui/src/hooks/use-facets.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import type { FilterGroupNode, FilterState, TableAdapter } from '@better-tables/core';
-import { getEffectiveFilters, MAX_FACET_BATCH_SIZE } from '@better-tables/core';
+import { getEffectiveFilterKey, MAX_FACET_BATCH_SIZE } from '@better-tables/core';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 /** A single faceted option: a distinct value and how many rows match it. */
@@ -145,7 +145,8 @@ export function useFacets<TData = unknown>({
   // — it cannot change any facet's counts yet (plan 063 follow-up). The full
   // `filters` array is still what's passed to the adapter (self-exclusion is
   // its job over the complete state); only the refetch TRIGGER is effective.
-  const filtersKey = JSON.stringify(filters === undefined ? null : getEffectiveFilters(filters));
+  // BigInt/circular-safe key (a `custom` filter value must not throw here).
+  const filtersKey = getEffectiveFilterKey(filters);
   // Intern `filters` by effective content, not identity: `filtersKey` (not
   // `filters`) is the dependency on purpose.
   const stableFilters = useMemo(() => filters, [filtersKey]);

--- a/packages/ui/src/hooks/use-facets.ts
+++ b/packages/ui/src/hooks/use-facets.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import type { FilterGroupNode, FilterState, TableAdapter } from '@better-tables/core';
-import { getEffectiveFilters } from '@better-tables/core';
+import { getEffectiveFilters, MAX_FACET_BATCH_SIZE } from '@better-tables/core';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 /** A single faceted option: a distinct value and how many rows match it. */
@@ -11,7 +11,12 @@ export interface FacetOption {
 }
 
 export interface UseFacetsOptions<TData = unknown> {
-  /** Table adapter -- must implement `getFacetedValues`/`getMinMaxValues`. */
+  /**
+   * Table adapter. Must implement `getFacetedValues`/`getMinMaxValues`; may
+   * additionally implement the optional `getFacets` batch method, which the
+   * hook prefers when present to fetch the whole sidebar in a single
+   * round-trip per {@link MAX_FACET_BATCH_SIZE}-sized chunk (e.g. `httpAdapter`).
+   */
   adapter: TableAdapter<TData>;
 
   /**
@@ -74,12 +79,20 @@ const EMPTY_IDS: string[] = [];
  *
  * This is the reusable version of the fetch/self-exclusion/`Map`-to-array
  * plumbing every faceted-sidebar consumer otherwise hand-builds (plan 032,
- * finding 7): it owns the `Promise.all` batching, the race guard (only the
- * newest request's results are applied), and the `Map<string, number>` ->
- * `FacetOption[]` conversion. It does NOT own filter STATE -- pass your
- * `filters` in (e.g. from `useTableFilters`) and use the returned
- * `facets`/`ranges` to render checkboxes/ranges that toggle real filters
- * via your own `onFiltersChange`/`setFilters`.
+ * finding 7): the race guard (only the newest request's results are applied)
+ * and the `Map<string, number>` -> `FacetOption[]` conversion. It does NOT
+ * own filter STATE -- pass your `filters` in (e.g. from `useTableFilters`)
+ * and use the returned `facets`/`ranges` to render checkboxes/ranges that
+ * toggle real filters via your own `onFiltersChange`/`setFilters`.
+ *
+ * Fetch strategy depends on the adapter: when it implements the optional
+ * `getFacets` batch method (e.g. `httpAdapter`), the whole sidebar is fetched
+ * in one round-trip per {@link MAX_FACET_BATCH_SIZE}-sized chunk; otherwise
+ * the hook falls back to concurrent singular `getFacetedValues`/
+ * `getMinMaxValues` calls (`Promise.all`), one per column — fine for
+ * in-process adapters where there is no transport to save. The refetch
+ * trigger keys on the EFFECTIVE filters, so an incomplete filter chip
+ * (`values: []`) does not refire.
  *
  * @example
  * ```tsx
@@ -162,22 +175,37 @@ export function useFacets<TData = unknown>({
       let rangeResults: (readonly [string, [number, number]])[];
 
       if (adapter.getFacets) {
-        // Batch-capable adapter (e.g. `httpAdapter`): ONE round-trip for the
-        // whole sidebar instead of one request per column.
-        const batch = await adapter.getFacets(
-          [
-            ...stableColumnIds.map((columnId) => ({ columnId, kind: 'values' as const })),
-            ...stableRangeColumnIds.map((columnId) => ({ columnId, kind: 'minmax' as const })),
-          ],
-          facetParams
+        // Batch-capable adapter (e.g. `httpAdapter`): one round-trip per
+        // chunk instead of one request per column. Chunk to
+        // `MAX_FACET_BATCH_SIZE` so a sidebar with more facet+range columns
+        // than the server's per-batch cap doesn't fail as `bad_request` — it
+        // just costs an extra round-trip per chunk (still far fewer than one
+        // per column). The chunks run concurrently.
+        const requests = [
+          ...stableColumnIds.map((columnId) => ({ columnId, kind: 'values' as const })),
+          ...stableRangeColumnIds.map((columnId) => ({ columnId, kind: 'minmax' as const })),
+        ];
+        const chunks: (typeof requests)[] = [];
+        for (let i = 0; i < requests.length; i += MAX_FACET_BATCH_SIZE) {
+          chunks.push(requests.slice(i, i + MAX_FACET_BATCH_SIZE));
+        }
+        const getFacets = adapter.getFacets.bind(adapter);
+        const batchResults = await Promise.all(
+          chunks.map((chunk) => getFacets(chunk, facetParams))
         );
+        const values: Record<string, Map<string, number>> = {};
+        const ranges: Record<string, [number, number]> = {};
+        for (const batch of batchResults) {
+          Object.assign(values, batch.values);
+          Object.assign(ranges, batch.ranges);
+        }
         facetResults = stableColumnIds.map((columnId) => {
-          const map = batch.values[columnId] ?? new Map<string, number>();
+          const map = values[columnId] ?? new Map<string, number>();
           const options: FacetOption[] = Array.from(map, ([value, count]) => ({ value, count }));
           return [columnId, options] as const;
         });
         rangeResults = stableRangeColumnIds.flatMap((columnId) => {
-          const range = batch.ranges[columnId];
+          const range = ranges[columnId];
           return range ? [[columnId, range] as const] : [];
         });
       } else {

--- a/packages/ui/src/hooks/use-facets.ts
+++ b/packages/ui/src/hooks/use-facets.ts
@@ -149,21 +149,49 @@ export function useFacets<TData = unknown>({
     };
 
     try {
-      const [facetResults, rangeResults] = await Promise.all([
-        Promise.all(
-          stableColumnIds.map(async (columnId) => {
-            const map = await adapter.getFacetedValues(columnId, facetParams);
-            const options: FacetOption[] = Array.from(map, ([value, count]) => ({ value, count }));
-            return [columnId, options] as const;
-          })
-        ),
-        Promise.all(
-          stableRangeColumnIds.map(async (columnId) => {
-            const range = await adapter.getMinMaxValues(columnId, facetParams);
-            return [columnId, range] as const;
-          })
-        ),
-      ]);
+      let facetResults: (readonly [string, FacetOption[]])[];
+      let rangeResults: (readonly [string, [number, number]])[];
+
+      if (adapter.getFacets) {
+        // Batch-capable adapter (e.g. `httpAdapter`): ONE round-trip for the
+        // whole sidebar instead of one request per column.
+        const batch = await adapter.getFacets(
+          [
+            ...stableColumnIds.map((columnId) => ({ columnId, kind: 'values' as const })),
+            ...stableRangeColumnIds.map((columnId) => ({ columnId, kind: 'minmax' as const })),
+          ],
+          facetParams
+        );
+        facetResults = stableColumnIds.map((columnId) => {
+          const map = batch.values[columnId] ?? new Map<string, number>();
+          const options: FacetOption[] = Array.from(map, ([value, count]) => ({ value, count }));
+          return [columnId, options] as const;
+        });
+        rangeResults = stableRangeColumnIds.flatMap((columnId) => {
+          const range = batch.ranges[columnId];
+          return range ? [[columnId, range] as const] : [];
+        });
+      } else {
+        // In-process adapters: parallel singular calls (no transport to save).
+        [facetResults, rangeResults] = await Promise.all([
+          Promise.all(
+            stableColumnIds.map(async (columnId) => {
+              const map = await adapter.getFacetedValues(columnId, facetParams);
+              const options: FacetOption[] = Array.from(map, ([value, count]) => ({
+                value,
+                count,
+              }));
+              return [columnId, options] as const;
+            })
+          ),
+          Promise.all(
+            stableRangeColumnIds.map(async (columnId) => {
+              const range = await adapter.getMinMaxValues(columnId, facetParams);
+              return [columnId, range] as const;
+            })
+          ),
+        ]);
+      }
 
       if (requestId !== requestIdRef.current) {
         return;

--- a/packages/ui/src/hooks/use-table-data.ts
+++ b/packages/ui/src/hooks/use-table-data.ts
@@ -8,8 +8,8 @@ import type {
   PaginationState,
   TableAdapter,
 } from '@better-tables/core';
-import { withDerivedFetchParams } from '@better-tables/core';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { getEffectiveFilters, withDerivedFetchParams } from '@better-tables/core';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 // Stable defaults so omitted `filters`/`params`/`columns` don't recreate
 // `fetchData`'s identity (and retrigger the fetch effect) on every render
@@ -118,6 +118,16 @@ export function useTableData<TData = unknown>({
   const abortControllerRef = useRef<AbortController | null>(null);
   const requestIdRef = useRef(0);
 
+  // Trigger refetches on the filters that actually constrain results, keyed by
+  // content. A chip added before its value is chosen (`values: []`) changes
+  // the `filters` array identity but not its effect, so it must NOT refetch
+  // (plan 063 follow-up). Interning by effective-filter content makes the
+  // fetch callback identity stable across such no-op changes.
+  // `effectiveFiltersKey` (not `filters`) is the dependency on purpose — the
+  // memo returns the current `filters` only when its EFFECT changes.
+  const effectiveFiltersKey = JSON.stringify(getEffectiveFilters(filters));
+  const stableFilters = useMemo(() => filters, [effectiveFiltersKey]);
+
   const fetchData = useCallback(async () => {
     if (!enabled) return;
 
@@ -132,7 +142,7 @@ export function useTableData<TData = unknown>({
 
     try {
       const fetchParams: FetchDataParams = {
-        filters,
+        filters: stableFilters,
         ...params,
         signal: abortController.signal,
       };
@@ -169,7 +179,7 @@ export function useTableData<TData = unknown>({
         setLoading(false);
       }
     }
-  }, [adapter, filters, pagination, params, columns, enabled]);
+  }, [adapter, stableFilters, pagination, params, columns, enabled]);
 
   const refetch = useCallback(async () => {
     await fetchData();

--- a/packages/ui/src/hooks/use-table-data.ts
+++ b/packages/ui/src/hooks/use-table-data.ts
@@ -8,7 +8,7 @@ import type {
   PaginationState,
   TableAdapter,
 } from '@better-tables/core';
-import { getEffectiveFilters, withDerivedFetchParams } from '@better-tables/core';
+import { getEffectiveFilterKey, withDerivedFetchParams } from '@better-tables/core';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 // Stable defaults so omitted `filters`/`params`/`columns` don't recreate
@@ -125,7 +125,9 @@ export function useTableData<TData = unknown>({
   // fetch callback identity stable across such no-op changes.
   // `effectiveFiltersKey` (not `filters`) is the dependency on purpose — the
   // memo returns the current `filters` only when its EFFECT changes.
-  const effectiveFiltersKey = JSON.stringify(getEffectiveFilters(filters));
+  // `getEffectiveFilterKey` is BigInt/circular-safe so a `custom` filter value
+  // can't throw during render.
+  const effectiveFiltersKey = getEffectiveFilterKey(filters);
   const stableFilters = useMemo(() => filters, [effectiveFiltersKey]);
 
   const fetchData = useCallback(async () => {

--- a/packages/ui/src/hooks/use-table-url-sync.ts
+++ b/packages/ui/src/hooks/use-table-url-sync.ts
@@ -20,32 +20,64 @@ type TableStore = NonNullable<ReturnType<typeof getTableStore>>;
 const HYDRATION_RETRY_MS = 100;
 const HYDRATION_MAX_ATTEMPTS = 5;
 
+type UrlWriteState = Parameters<typeof serializeTableStateToUrl>[0];
+
 /**
- * Debounce utility to batch rapid updates.
- * Returns a cancel function so timers can be cleared on unmount.
+ * Leading + trailing coalescer for URL writes.
+ *
+ * A trailing-only debounce put a fixed `wait` of idle time in front of EVERY
+ * write — and for server-driven tables (Next.js demos) the URL write IS the
+ * refetch trigger, so a single pagination click or filter commit paid a
+ * built-in latency floor before the network even started. Instead:
+ *
+ * - a change arriving outside a cooldown window writes IMMEDIATELY (a
+ *   discrete click/commit gets zero added latency), then opens a `wait`
+ *   cooldown;
+ * - changes arriving inside the cooldown are coalesced: only the LATEST is
+ *   written when the cooldown expires (which re-opens it, so a continuous
+ *   stream still writes at most once per `wait`).
+ *
+ * `func` returns whether it actually wrote (it skips writes that wouldn't
+ * change the URL); a skipped leading write does NOT open a cooldown, so a
+ * no-op change (e.g. row selection) never delays the next real one.
  */
-function debounce<T extends (tableState: Parameters<typeof serializeTableStateToUrl>[0]) => void>(
-  func: T,
+function coalesceUrlWrites(
+  func: (tableState: UrlWriteState) => boolean,
   wait: number
 ): {
-  fn: (tableState: Parameters<typeof serializeTableStateToUrl>[0]) => void;
+  fn: (tableState: UrlWriteState) => void;
   cancel: () => void;
 } {
   let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  let pending: UrlWriteState | null = null;
 
   const cancel = () => {
     if (timeoutId !== null) {
       clearTimeout(timeoutId);
       timeoutId = null;
     }
+    pending = null;
   };
 
-  const fn = (tableState: Parameters<typeof serializeTableStateToUrl>[0]) => {
-    cancel();
-    timeoutId = setTimeout(() => {
-      timeoutId = null;
-      func(tableState);
-    }, wait);
+  const onCooldownEnd = () => {
+    timeoutId = null;
+    if (pending !== null) {
+      const state = pending;
+      pending = null;
+      if (func(state)) {
+        timeoutId = setTimeout(onCooldownEnd, wait);
+      }
+    }
+  };
+
+  const fn = (tableState: UrlWriteState) => {
+    if (timeoutId === null) {
+      if (func(tableState)) {
+        timeoutId = setTimeout(onCooldownEnd, wait);
+      }
+      return;
+    }
+    pending = tableState;
   };
 
   return { fn, cancel };
@@ -381,25 +413,29 @@ export function useTableUrlSync(
     }
 
     const manager = store.getState().manager;
-    const { fn: debouncedUrlUpdate, cancel: cancelDebouncedUrlUpdate } = debounce((tableState) => {
-      const urlParams = serializeTableStateToUrl(tableState);
-      // Keep default page/limit out of a URL that doesn't already carry them,
-      // so a change that doesn't touch pagination (selection, column toggle)
-      // doesn't introduce `?page=1&limit=<default>`.
-      stripDefaultPaginationFromWrite(
-        urlParams,
-        tableState.pagination,
-        defaultPaginationRef.current,
-        adapter
-      );
-      // Skip writes that wouldn't change the URL (e.g. a row-selection change,
-      // which emits `state_changed` but touches no synced param) so adapters
-      // that navigate on `setParams` don't refetch for nothing.
-      if (!serializedParamsDifferFromUrl(urlParams, adapter)) {
-        return;
-      }
-      adapter.setParams(urlParams);
-    }, 150);
+    const { fn: coalescedUrlUpdate, cancel: cancelCoalescedUrlUpdate } = coalesceUrlWrites(
+      (tableState) => {
+        const urlParams = serializeTableStateToUrl(tableState);
+        // Keep default page/limit out of a URL that doesn't already carry them,
+        // so a change that doesn't touch pagination (selection, column toggle)
+        // doesn't introduce `?page=1&limit=<default>`.
+        stripDefaultPaginationFromWrite(
+          urlParams,
+          tableState.pagination,
+          defaultPaginationRef.current,
+          adapter
+        );
+        // Skip writes that wouldn't change the URL (e.g. a row-selection change,
+        // which emits `state_changed` but touches no synced param) so adapters
+        // that navigate on `setParams` don't refetch for nothing.
+        if (!serializedParamsDifferFromUrl(urlParams, adapter)) {
+          return false;
+        }
+        adapter.setParams(urlParams);
+        return true;
+      },
+      150
+    );
 
     const unsubscribe = manager.subscribe((event: TableStateEvent) => {
       if (!hasHydratedFromUrl.current) return;
@@ -432,13 +468,13 @@ export function useTableUrlSync(
           tableState.columnOrder = getColumnOrderModifications(columns, event.state.columnOrder);
         }
 
-        debouncedUrlUpdate(tableState);
+        coalescedUrlUpdate(tableState);
       }
     });
 
     return () => {
       unsubscribe();
-      cancelDebouncedUrlUpdate();
+      cancelCoalescedUrlUpdate();
     };
   }, [tableId, stableConfig, adapter, storeReady]);
 }

--- a/packages/ui/src/hooks/use-table-url-sync.ts
+++ b/packages/ui/src/hooks/use-table-url-sync.ts
@@ -47,6 +47,12 @@ function coalesceUrlWrites(
 ): {
   fn: (tableState: UrlWriteState) => void;
   cancel: () => void;
+  /**
+   * Whether a write is in flight — a cooldown is open (a write just fired and
+   * more may be queued). While true the store may be AHEAD of the URL, so a
+   * soft-nav re-hydration must not clobber it back to the lagging URL.
+   */
+  isInFlight: () => boolean;
 } {
   let timeoutId: ReturnType<typeof setTimeout> | null = null;
   let pending: UrlWriteState | null = null;
@@ -80,7 +86,7 @@ function coalesceUrlWrites(
     pending = tableState;
   };
 
-  return { fn, cancel };
+  return { fn, cancel, isInFlight: () => timeoutId !== null };
 }
 
 /**
@@ -340,6 +346,26 @@ export function useTableUrlSync(
 ): void {
   const stableConfig = useStableUrlSyncConfig(config);
   const hasHydratedFromUrl = useRef(false);
+  // Ref-latch the mutable inputs the WRITE-OUT effect reads at write time.
+  // A framework adapter (e.g. `useNextjsUrlAdapter`) recreates its identity on
+  // every navigation — i.e. on every write it triggers. If the write-out
+  // effect depended on `adapter`, that identity churn would tear the coalescer
+  // down and CANCEL a pending trailing write the instant a leading write's
+  // navigation landed, so a rapid burst could settle on its first state. Reading
+  // adapter/config from refs lets the coalescer + subscription outlive those
+  // re-renders (effect keyed on `[tableId, storeReady]` only), while each write
+  // still uses the latest adapter/config.
+  const adapterRef = useRef(adapter);
+  adapterRef.current = adapter;
+  const configRef = useRef(stableConfig);
+  configRef.current = stableConfig;
+  // True while the write-out coalescer has a write in flight. The store is
+  // then AHEAD of the URL (a debounced write is landing), so a soft-nav
+  // re-hydration — which a navigation's `searchParams` change re-triggers —
+  // must not read the lagging URL and clobber the store's newer state (which
+  // would also drop the pending trailing write). Populated by the write-out
+  // effect; read by the hydration effect.
+  const writeInFlightRef = useRef<() => boolean>(() => false);
   // The pagination the table starts at (its app-configured / SSR-seeded
   // default), captured once before the first user interaction. Used to keep
   // default `page`/`limit` out of a URL that doesn't already carry them — see
@@ -370,9 +396,18 @@ export function useTableUrlSync(
     const store = getTableStore(tableId);
     if (store) {
       captureDefaultPagination(store, defaultPaginationRef);
-      // First hydration must not clear SSR-seeded initialFilters; later ones
-      // (soft navs) may clear (finding 15).
-      hydrateFromUrl(store, stableConfig, adapter, hasHydratedFromUrl.current);
+      // Skip a POST-mount re-hydration while a write is in flight: a navigation
+      // this write triggered recreates the adapter (and moves `urlSignature`),
+      // re-running this effect with a URL that still LAGS the store. Hydrating
+      // from it would clobber the store's newer state and drop the pending
+      // trailing write. The first (mount) hydration always runs — no write can
+      // be in flight yet.
+      const skipForInFlightWrite = hasHydratedFromUrl.current && writeInFlightRef.current();
+      if (!skipForInFlightWrite) {
+        // First hydration must not clear SSR-seeded initialFilters; later ones
+        // (soft navs) may clear (finding 15).
+        hydrateFromUrl(store, stableConfig, adapter, hasHydratedFromUrl.current);
+      }
       if (!hasHydratedFromUrl.current) {
         hasHydratedFromUrl.current = true;
         setStoreReady(true);
@@ -413,49 +448,58 @@ export function useTableUrlSync(
     }
 
     const manager = store.getState().manager;
-    const { fn: coalescedUrlUpdate, cancel: cancelCoalescedUrlUpdate } = coalesceUrlWrites(
-      (tableState) => {
-        const urlParams = serializeTableStateToUrl(tableState);
-        // Keep default page/limit out of a URL that doesn't already carry them,
-        // so a change that doesn't touch pagination (selection, column toggle)
-        // doesn't introduce `?page=1&limit=<default>`.
-        stripDefaultPaginationFromWrite(
-          urlParams,
-          tableState.pagination,
-          defaultPaginationRef.current,
-          adapter
-        );
-        // Skip writes that wouldn't change the URL (e.g. a row-selection change,
-        // which emits `state_changed` but touches no synced param) so adapters
-        // that navigate on `setParams` don't refetch for nothing.
-        if (!serializedParamsDifferFromUrl(urlParams, adapter)) {
-          return false;
-        }
-        adapter.setParams(urlParams);
-        return true;
-      },
-      150
-    );
+    const {
+      fn: coalescedUrlUpdate,
+      cancel: cancelCoalescedUrlUpdate,
+      isInFlight,
+    } = coalesceUrlWrites((tableState) => {
+      // Read the LATEST adapter at write time (it may have been recreated by
+      // a navigation since this coalescer was created).
+      const currentAdapter = adapterRef.current;
+      const urlParams = serializeTableStateToUrl(tableState);
+      // Keep default page/limit out of a URL that doesn't already carry them,
+      // so a change that doesn't touch pagination (selection, column toggle)
+      // doesn't introduce `?page=1&limit=<default>`.
+      stripDefaultPaginationFromWrite(
+        urlParams,
+        tableState.pagination,
+        defaultPaginationRef.current,
+        currentAdapter
+      );
+      // Skip writes that wouldn't change the URL (e.g. a row-selection change,
+      // which emits `state_changed` but touches no synced param) so adapters
+      // that navigate on `setParams` don't refetch for nothing.
+      if (!serializedParamsDifferFromUrl(urlParams, currentAdapter)) {
+        return false;
+      }
+      currentAdapter.setParams(urlParams);
+      return true;
+    }, 150);
+    // Let the hydration effect see when a write is in flight (store ahead of URL).
+    writeInFlightRef.current = isInFlight;
 
     const unsubscribe = manager.subscribe((event: TableStateEvent) => {
       if (!hasHydratedFromUrl.current) return;
 
       if (event.type === 'state_changed') {
+        // Latest config (ref-latched) so a config change doesn't need to
+        // re-subscribe and reset the coalescer.
+        const currentConfig = configRef.current;
         const tableState: Parameters<typeof serializeTableStateToUrl>[0] = {};
 
-        if (stableConfig.filters) {
+        if (currentConfig.filters) {
           tableState.filters = event.state.filters;
         }
 
-        if (stableConfig.pagination) {
+        if (currentConfig.pagination) {
           tableState.pagination = event.state.pagination;
         }
 
-        if (stableConfig.sorting) {
+        if (currentConfig.sorting) {
           tableState.sorting = event.state.sorting;
         }
 
-        if (stableConfig.columnVisibility) {
+        if (currentConfig.columnVisibility) {
           const { columns } = store.getState();
           tableState.columnVisibility = getColumnVisibilityModifications(
             columns,
@@ -463,7 +507,7 @@ export function useTableUrlSync(
           );
         }
 
-        if (stableConfig.columnOrder) {
+        if (currentConfig.columnOrder) {
           const { columns } = store.getState();
           tableState.columnOrder = getColumnOrderModifications(columns, event.state.columnOrder);
         }
@@ -475,8 +519,13 @@ export function useTableUrlSync(
     return () => {
       unsubscribe();
       cancelCoalescedUrlUpdate();
+      writeInFlightRef.current = () => false;
     };
-  }, [tableId, stableConfig, adapter, storeReady]);
+    // Intentionally NOT depending on `adapter`/`stableConfig`: they are
+    // ref-latched above so a navigation (adapter identity change) does not
+    // tear down the coalescer and drop a pending trailing write. Re-subscribe
+    // only when the table or its store readiness changes.
+  }, [tableId, storeReady]);
 }
 
 /**

--- a/packages/ui/tests/components/interaction-cost.test.tsx
+++ b/packages/ui/tests/components/interaction-cost.test.tsx
@@ -1,0 +1,338 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from 'bun:test';
+import type { ColumnDefinition, PaginationState, TableAdapter } from '@better-tables/core';
+import { clearAllTableStores, getOrCreateTableStore, getTableStore } from '@better-tables/core';
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
+import { useMemo } from 'react';
+import { BetterTable } from '../../src/components/table/table';
+import { useFacets } from '../../src/hooks/use-facets';
+import { useTableData } from '../../src/hooks/use-table-data';
+import { useTableFilters, useTablePagination } from '../../src/hooks/use-table-store';
+import { useTableUrlSync } from '../../src/hooks/use-table-url-sync';
+import { createCountingAdapter } from '../helpers/stub-adapter';
+import { createFakeUrlAdapter } from '../helpers/url-sync';
+
+/**
+ * Plan 063 Step 1 — interaction-cost gates.
+ *
+ * Pins the EXACT downstream cost of each user interaction in the library's
+ * client wiring (useTableData + useTableUrlSync + useFacets + BetterTable):
+ * adapter fetches, facet requests, and URL writes are counted per
+ * interaction and asserted as integers. Every number is the POST-lag-fix
+ * contract (leading-edge URL writes, batched facets); a change to any of
+ * them is a performance regression (or a deliberate contract change that
+ * must update the number here, with a comment citing why).
+ */
+
+type Row = { id: string };
+
+const COLUMNS: ColumnDefinition<Row>[] = [
+  {
+    id: 'name',
+    displayName: 'Name',
+    type: 'text',
+    accessor: (row) => row.id,
+    filterable: true,
+  },
+  {
+    id: 'status',
+    displayName: 'Status',
+    type: 'option',
+    accessor: () => 'a',
+    filterable: true,
+  },
+];
+
+// K = 2 option facets, R = 1 range facet — the sidebar shape the batch
+// contract is asserted against.
+const FACET_IDS = ['status', 'name'];
+const RANGE_IDS = ['reopens'];
+
+const COOLDOWN_MS = 150;
+
+function CostHarness({
+  tableId,
+  adapter,
+  urlAdapter,
+}: {
+  tableId: string;
+  adapter: TableAdapter<Row>;
+  urlAdapter: ReturnType<typeof createFakeUrlAdapter>['adapter'];
+}) {
+  const { filters } = useTableFilters(tableId);
+  const { pagination } = useTablePagination(tableId);
+
+  // Key the fetch strictly on page/limit: the store's pagination object also
+  // changes when totals sync back after a fetch, and that must not count as
+  // (or trigger) another fetch.
+  const fetchPagination = useMemo<PaginationState>(
+    () => ({
+      page: pagination.page,
+      limit: pagination.limit,
+      totalPages: 0,
+      hasNext: false,
+      hasPrev: false,
+    }),
+    [pagination.page, pagination.limit]
+  );
+
+  const { data, loading, totalCount } = useTableData<Row>({
+    adapter,
+    filters,
+    pagination: fetchPagination,
+    columns: COLUMNS,
+  });
+
+  useTableUrlSync(tableId, { filters: true, pagination: true, sorting: true }, urlAdapter);
+
+  useFacets({
+    adapter,
+    columnIds: FACET_IDS,
+    rangeColumnIds: RANGE_IDS,
+    filters,
+  });
+
+  return (
+    <BetterTable
+      id={tableId}
+      name="Interaction cost"
+      columns={COLUMNS}
+      data={data}
+      loading={loading}
+      totalCount={totalCount}
+      features={{ pagination: true, filtering: true, sorting: true }}
+    />
+  );
+}
+
+function createStore(tableId: string) {
+  return getOrCreateTableStore(tableId, {
+    columns: COLUMNS,
+    config: { pagination: { defaultPageSize: 10 } },
+  });
+}
+
+async function mountSettled(tableId: string, options?: { batchFacets?: boolean }) {
+  const counting = createCountingAdapter({
+    totalRows: 25,
+    batchFacets: options?.batchFacets ?? true,
+  });
+  const fakeUrl = createFakeUrlAdapter();
+  createStore(tableId);
+  render(<CostHarness tableId={tableId} adapter={counting.adapter} urlAdapter={fakeUrl.adapter} />);
+  // Settle the mount: initial fetch resolved (25 rows → 3 pages, Next
+  // enabled) and the initial facet load done.
+  await waitFor(() => {
+    expect(counting.fetchCalls.length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByLabelText('Next page')).toBeTruthy();
+  });
+  await act(async () => {});
+  return { counting, fakeUrl };
+}
+
+/** Snapshot the counters so per-interaction assertions are deltas. */
+function baseline(counting: ReturnType<typeof createCountingAdapter>, fakeUrl: ReturnType<typeof createFakeUrlAdapter>) {
+  return {
+    fetches: counting.fetchCalls.length,
+    batches: counting.batchCalls.length,
+    singularFacets: counting.facetCalls.length + counting.rangeCalls.length,
+    urlWrites: fakeUrl.setParamsCalls.length,
+  };
+}
+
+describe('interaction cost gates (plan 063 Step 1)', () => {
+  beforeEach(() => {
+    clearAllTableStores();
+  });
+  afterEach(() => {
+    cleanup();
+    clearAllTableStores();
+    jest.useRealTimers();
+  });
+
+  it('mount: exactly 1 fetch + 1 batched facet call (carrying K=2 values + R=1 minmax), 0 URL writes', async () => {
+    const tableId = 'cost-mount';
+    const { counting, fakeUrl } = await mountSettled(tableId);
+
+    expect(counting.fetchCalls).toHaveLength(1);
+    expect(counting.batchCalls).toHaveLength(1);
+    expect(counting.batchCalls[0]?.requests).toEqual([
+      { columnId: 'status', kind: 'values' },
+      { columnId: 'name', kind: 'values' },
+      { columnId: 'reopens', kind: 'minmax' },
+    ]);
+    // The batch path must fully replace the singular per-column calls.
+    expect(counting.facetCalls).toHaveLength(0);
+    expect(counting.rangeCalls).toHaveLength(0);
+    // A clean URL stays clean on mount — no write, no navigation.
+    expect(fakeUrl.setParamsCalls).toHaveLength(0);
+  });
+
+  it('one pagination click: 1 fetch, 0 facet calls, 1 SYNCHRONOUS URL write', async () => {
+    const tableId = 'cost-page-click';
+    const { counting, fakeUrl } = await mountSettled(tableId);
+    const before = baseline(counting, fakeUrl);
+
+    // Freeze timers: the URL write must happen on the leading edge — if it
+    // needed the 150 ms cooldown timer, this assertion would see zero.
+    jest.useFakeTimers();
+    act(() => {
+      screen.getByLabelText('Next page').click();
+    });
+
+    expect(fakeUrl.setParamsCalls.length - before.urlWrites).toBe(1);
+    expect(fakeUrl.setParamsCalls.at(-1)?.page).toBe('2');
+    jest.useRealTimers();
+
+    await waitFor(() => {
+      // Exactly one refetch, for page 2 — and no facet traffic (filters
+      // didn't change, so a pagination click must never refire facets).
+      expect(counting.fetchCalls.length - before.fetches).toBe(1);
+    });
+    expect(counting.fetchCalls.at(-1)?.pagination?.page).toBe(2);
+    expect(counting.batchCalls.length - before.batches).toBe(0);
+    expect(counting.facetCalls.length + counting.rangeCalls.length).toBe(before.singularFacets);
+  });
+
+  it('rapid double pagination click: first write immediate, second coalesced — 2 writes, 2 fetches, 0 facet calls', async () => {
+    const tableId = 'cost-double-click';
+    const { counting, fakeUrl } = await mountSettled(tableId);
+    const before = baseline(counting, fakeUrl);
+
+    jest.useFakeTimers();
+    // Two separate acts so the second click sees the re-rendered button
+    // (inside one act both clicks would read the same stale `currentPage`
+    // and the second would be a store no-op). Timers stay frozen, so both
+    // land inside one 150 ms cooldown window.
+    act(() => {
+      screen.getByLabelText('Next page').click();
+    });
+    act(() => {
+      screen.getByLabelText('Next page').click();
+    });
+    // Leading write fired for the first click only.
+    expect(fakeUrl.setParamsCalls.length - before.urlWrites).toBe(1);
+    expect(fakeUrl.setParamsCalls.at(-1)?.page).toBe('2');
+
+    await act(async () => {
+      jest.advanceTimersByTime(COOLDOWN_MS);
+    });
+    jest.useRealTimers();
+
+    // Trailing write carries the burst's final state (page 3).
+    expect(fakeUrl.setParamsCalls.length - before.urlWrites).toBe(2);
+    expect(fakeUrl.setParamsCalls.at(-1)?.page).toBe('3');
+
+    await waitFor(() => {
+      // One fetch per real page change (the first may be aborted by the
+      // second — it still counts as issued work).
+      expect(counting.fetchCalls.length - before.fetches).toBe(2);
+    });
+    expect(counting.batchCalls.length - before.batches).toBe(0);
+  });
+
+  it('page-size change: 1 fetch, 1 immediate URL write, 0 facet calls', async () => {
+    const tableId = 'cost-page-size';
+    const { counting, fakeUrl } = await mountSettled(tableId);
+    const before = baseline(counting, fakeUrl);
+    const store = getTableStore(tableId);
+    if (!store) throw new Error('store missing');
+
+    jest.useFakeTimers();
+    act(() => {
+      // 20 is on the manager's allowed page-size list (10/20/50/100).
+      store.getState().setPageSize(20);
+    });
+    expect(fakeUrl.setParamsCalls.length - before.urlWrites).toBe(1);
+    expect(fakeUrl.setParamsCalls.at(-1)?.limit).toBe('20');
+    jest.useRealTimers();
+
+    await waitFor(() => {
+      expect(counting.fetchCalls.length - before.fetches).toBe(1);
+    });
+    expect(counting.fetchCalls.at(-1)?.pagination?.limit).toBe(20);
+    expect(counting.batchCalls.length - before.batches).toBe(0);
+  });
+
+  it('filter commit: 1 fetch, 1 batched facet refresh, 1 immediate URL write', async () => {
+    const tableId = 'cost-filter-commit';
+    const { counting, fakeUrl } = await mountSettled(tableId);
+    const before = baseline(counting, fakeUrl);
+    const store = getTableStore(tableId);
+    if (!store) throw new Error('store missing');
+
+    jest.useFakeTimers();
+    act(() => {
+      store.getState().setFilters([
+        { columnId: 'name', type: 'text', operator: 'contains', values: ['alpha'] },
+      ]);
+    });
+    // Leading-edge write carries the filter — no 150 ms floor on a commit.
+    expect(fakeUrl.setParamsCalls.length - before.urlWrites).toBe(1);
+    expect(fakeUrl.setParamsCalls.at(-1)?.filters).toBeTruthy();
+    jest.useRealTimers();
+
+    await waitFor(() => {
+      expect(counting.fetchCalls.length - before.fetches).toBe(1);
+      // Exactly ONE batched facet refresh for the whole sidebar.
+      expect(counting.batchCalls.length - before.batches).toBe(1);
+    });
+    expect(counting.facetCalls).toHaveLength(0);
+    expect(counting.rangeCalls).toHaveLength(0);
+  });
+
+  it('adding a filter with EMPTY values: characterized cost (pinned)', async () => {
+    const tableId = 'cost-empty-filter';
+    const { counting, fakeUrl } = await mountSettled(tableId);
+    const before = baseline(counting, fakeUrl);
+    const store = getTableStore(tableId);
+    if (!store) throw new Error('store missing');
+
+    act(() => {
+      // What FilterBar's handleAddFilter dispatches before any value is
+      // chosen (filter-bar.tsx builds `values: []`).
+      store.getState().addFilter({
+        columnId: 'name',
+        type: 'text',
+        operator: 'contains',
+        values: [],
+      });
+    });
+    await act(async () => {});
+
+    // CHARACTERIZATION: an empty-values filter still changes the filters
+    // array identity/content, so today it costs one refetch and one facet
+    // refresh before the user has typed anything — and the URL serializer
+    // KEEPS valueless filters, so the URL changes too.
+    // FINDING: in a server-driven app (Next.js demos) that URL write is a
+    // real RSC navigation for a filter that cannot narrow anything yet;
+    // skipping fetch/serialize until a value commits would save one
+    // round-trip per added filter chip. Pinned as-is; update these numbers
+    // alongside any such fix.
+    expect(counting.fetchCalls.length - before.fetches).toBe(1);
+    expect(counting.batchCalls.length - before.batches).toBe(1);
+    expect(fakeUrl.setParamsCalls.length - before.urlWrites).toBe(1);
+  });
+
+  it('singular fallback (adapter without getFacets): filter commit costs exactly K+R per-column calls', async () => {
+    const tableId = 'cost-singular-facets';
+    const { counting, fakeUrl } = await mountSettled(tableId, { batchFacets: false });
+    const before = baseline(counting, fakeUrl);
+    const store = getTableStore(tableId);
+    if (!store) throw new Error('store missing');
+
+    act(() => {
+      store.getState().setFilters([
+        { columnId: 'name', type: 'text', operator: 'contains', values: ['alpha'] },
+      ]);
+    });
+
+    await waitFor(() => {
+      expect(counting.fetchCalls.length - before.fetches).toBe(1);
+      // K = 2 getFacetedValues + R = 1 getMinMaxValues, exactly once each.
+      expect(counting.facetCalls.length + counting.rangeCalls.length - before.singularFacets).toBe(
+        3
+      );
+    });
+    expect(counting.batchCalls).toHaveLength(0);
+  });
+});

--- a/packages/ui/tests/components/interaction-cost.test.tsx
+++ b/packages/ui/tests/components/interaction-cost.test.tsx
@@ -79,7 +79,9 @@ function CostHarness({
     adapter,
     filters,
     pagination: fetchPagination,
-    columns: COLUMNS,
+    // useTableData takes ColumnDefinition<unknown>[] (it only reads derived
+    // specs); the row generic is irrelevant to that read.
+    columns: COLUMNS as unknown as ColumnDefinition[],
   });
 
   useTableUrlSync(tableId, { filters: true, pagination: true, sorting: true }, urlAdapter);
@@ -130,7 +132,10 @@ async function mountSettled(tableId: string, options?: { batchFacets?: boolean }
 }
 
 /** Snapshot the counters so per-interaction assertions are deltas. */
-function baseline(counting: ReturnType<typeof createCountingAdapter>, fakeUrl: ReturnType<typeof createFakeUrlAdapter>) {
+function baseline(
+  counting: ReturnType<typeof createCountingAdapter>,
+  fakeUrl: ReturnType<typeof createFakeUrlAdapter>
+) {
   return {
     fetches: counting.fetchCalls.length,
     batches: counting.batchCalls.length,
@@ -262,9 +267,9 @@ describe('interaction cost gates (plan 063 Step 1)', () => {
 
     jest.useFakeTimers();
     act(() => {
-      store.getState().setFilters([
-        { columnId: 'name', type: 'text', operator: 'contains', values: ['alpha'] },
-      ]);
+      store
+        .getState()
+        .setFilters([{ columnId: 'name', type: 'text', operator: 'contains', values: ['alpha'] }]);
     });
     // Leading-edge write carries the filter — no 150 ms floor on a commit.
     expect(fakeUrl.setParamsCalls.length - before.urlWrites).toBe(1);
@@ -321,9 +326,9 @@ describe('interaction cost gates (plan 063 Step 1)', () => {
     if (!store) throw new Error('store missing');
 
     act(() => {
-      store.getState().setFilters([
-        { columnId: 'name', type: 'text', operator: 'contains', values: ['alpha'] },
-      ]);
+      store
+        .getState()
+        .setFilters([{ columnId: 'name', type: 'text', operator: 'contains', values: ['alpha'] }]);
     });
 
     await waitFor(() => {

--- a/packages/ui/tests/components/interaction-cost.test.tsx
+++ b/packages/ui/tests/components/interaction-cost.test.tsx
@@ -285,14 +285,14 @@ describe('interaction cost gates (plan 063 Step 1)', () => {
     expect(counting.rangeCalls).toHaveLength(0);
   });
 
-  it('adding a filter with EMPTY values: characterized cost (pinned)', async () => {
+  it('adding a filter with EMPTY values is FREE: 0 fetch, 0 facet, 0 URL write', async () => {
     const tableId = 'cost-empty-filter';
     const { counting, fakeUrl } = await mountSettled(tableId);
     const before = baseline(counting, fakeUrl);
     const store = getTableStore(tableId);
     if (!store) throw new Error('store missing');
 
-    act(() => {
+    await act(async () => {
       // What FilterBar's handleAddFilter dispatches before any value is
       // chosen (filter-bar.tsx builds `values: []`).
       store.getState().addFilter({
@@ -304,15 +304,46 @@ describe('interaction cost gates (plan 063 Step 1)', () => {
     });
     await act(async () => {});
 
-    // CHARACTERIZATION: an empty-values filter still changes the filters
-    // array identity/content, so today it costs one refetch and one facet
-    // refresh before the user has typed anything — and the URL serializer
-    // KEEPS valueless filters, so the URL changes too.
-    // FINDING: in a server-driven app (Next.js demos) that URL write is a
-    // real RSC navigation for a filter that cannot narrow anything yet;
-    // skipping fetch/serialize until a value commits would save one
-    // round-trip per added filter chip. Pinned as-is; update these numbers
-    // alongside any such fix.
+    // A chip with no value can't narrow anything, so it costs NOTHING until a
+    // value commits: `getEffectiveFilters` drops it, so the fetch trigger, the
+    // facet-batch trigger, and the serialized URL are all unchanged. Because
+    // no URL write fires, no coalescer cooldown even opens — there is nothing
+    // to flush, so no fake timers are needed. Before the plan-063 follow-up
+    // this was 1 fetch + 1 facet refresh + 1 URL write (a real RSC navigation
+    // in server-driven apps) per empty chip.
+    expect(counting.fetchCalls.length - before.fetches).toBe(0);
+    expect(counting.batchCalls.length - before.batches).toBe(0);
+    expect(counting.facetCalls.length + counting.rangeCalls.length - before.singularFacets).toBe(0);
+    expect(fakeUrl.setParamsCalls.length - before.urlWrites).toBe(0);
+  });
+
+  it('committing a value on a previously-empty chip pays exactly once (fetch + facet + write)', async () => {
+    const tableId = 'cost-empty-then-value';
+    const { counting, fakeUrl } = await mountSettled(tableId);
+    const store = getTableStore(tableId);
+    if (!store) throw new Error('store missing');
+
+    // Add the empty chip (free), then commit a value on it.
+    act(() => {
+      store.getState().addFilter({
+        columnId: 'name',
+        type: 'text',
+        operator: 'contains',
+        values: [],
+      });
+    });
+    await act(async () => {});
+    const before = baseline(counting, fakeUrl);
+
+    await act(async () => {
+      store
+        .getState()
+        .setFilters([{ columnId: 'name', type: 'text', operator: 'contains', values: ['alpha'] }]);
+    });
+    await act(async () => {});
+
+    // Committing the value pays exactly once: the effective filters changed
+    // for the first time, so one fetch, one facet batch, and one URL write.
     expect(counting.fetchCalls.length - before.fetches).toBe(1);
     expect(counting.batchCalls.length - before.batches).toBe(1);
     expect(fakeUrl.setParamsCalls.length - before.urlWrites).toBe(1);

--- a/packages/ui/tests/components/table-loading-affordance.test.tsx
+++ b/packages/ui/tests/components/table-loading-affordance.test.tsx
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import type { ColumnDefinition } from '@better-tables/core';
+import { cleanup, render, screen } from '@testing-library/react';
+import { BetterTable } from '../../src/components/table/table';
+
+interface Row {
+  id: string;
+  name: string;
+}
+
+const columns: ColumnDefinition<Row>[] = [
+  {
+    id: 'name',
+    displayName: 'Name',
+    type: 'text',
+    accessor: (row) => row.name,
+  },
+];
+
+const rows: Row[] = [
+  { id: 'r1', name: 'Alpha' },
+  { id: 'r2', name: 'Beta' },
+];
+
+/**
+ * Lag-fix contract: `loading` must NOT unmount rows that are already on
+ * screen (the pre-fix behavior replaced the whole table with a skeleton on
+ * every refetch — pagination/filter changes flashed a spinner instead of
+ * feeling instant). The skeleton is reserved for the initial load, when
+ * there is nothing better to show.
+ */
+describe('BetterTable loading affordance (stale rows during refetch)', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('keeps current rows mounted and marks the table busy during a refetch', () => {
+    const { rerender, container } = render(
+      <BetterTable id="loading-refetch" name="Loading" columns={columns} data={rows} />
+    );
+    expect(screen.getByText('Alpha')).toBeTruthy();
+
+    rerender(
+      <BetterTable id="loading-refetch" name="Loading" columns={columns} data={rows} loading />
+    );
+
+    // Rows are still there — no skeleton took their place...
+    expect(screen.getByText('Alpha')).toBeTruthy();
+    expect(screen.getByText('Beta')).toBeTruthy();
+    expect(container.querySelector('[aria-label="Loading table data"]')).toBeNull();
+    // ...and assistive tech + styling know a refresh is in flight.
+    expect(container.querySelector('[aria-busy="true"]')).toBeTruthy();
+
+    // Loading clears → busy marker clears, rows unchanged.
+    rerender(<BetterTable id="loading-refetch" name="Loading" columns={columns} data={rows} />);
+    expect(container.querySelector('[aria-busy="true"]')).toBeNull();
+    expect(screen.getByText('Alpha')).toBeTruthy();
+  });
+
+  it('still renders the skeleton for an initial load (loading with no rows)', () => {
+    const { container } = render(
+      <BetterTable id="loading-initial" name="Loading" columns={columns} data={[]} loading />
+    );
+    expect(container.querySelector('[aria-label="Loading table data"]')).toBeTruthy();
+  });
+});

--- a/packages/ui/tests/helpers/stub-adapter.ts
+++ b/packages/ui/tests/helpers/stub-adapter.ts
@@ -1,6 +1,7 @@
 import type {
   ColumnType,
   FacetQueryParams,
+  FacetRequest,
   FetchDataParams,
   FetchDataResult,
   FilterOperator,
@@ -171,4 +172,99 @@ export function createSelfExclusionFacetAdapter<TRow extends { id: string }>(row
   };
 
   return { adapter, facetCalls, rangeCalls };
+}
+
+export type StubBatchCall = {
+  requests: readonly FacetRequest[];
+  params: FacetQueryParams | undefined;
+};
+
+/**
+ * Auto-resolving adapter with per-method call counters — the fixture for the
+ * plan-063 interaction-cost gates. `fetchData` answers immediately with a
+ * deterministic page slice of `totalRows` synthetic rows, so tests can pin
+ * EXACT call counts per user interaction (one pagination click = one fetch,
+ * zero facet calls, ...). With `batchFacets: true` the adapter also
+ * implements `getFacets`, letting tests assert the batch path (one call per
+ * refresh) versus the singular fallback (K + R calls).
+ */
+export function createCountingAdapter(options?: { totalRows?: number; batchFacets?: boolean }) {
+  const totalRows = options?.totalRows ?? 25;
+  const fetchCalls: FetchDataParams[] = [];
+  const facetCalls: StubFacetCall[] = [];
+  const rangeCalls: StubFacetCall[] = [];
+  const batchCalls: StubBatchCall[] = [];
+
+  const base: TableAdapter<Row> = {
+    meta: {
+      name: 'stub-counting',
+      version: 'test',
+      features: {
+        create: false,
+        read: true,
+        update: false,
+        delete: false,
+        bulkOperations: false,
+        realTimeUpdates: false,
+        export: false,
+        transactions: false,
+      },
+      supportedColumnTypes: ['text', 'option', 'number'],
+      supportedOperators: {
+        text: ['contains'],
+        option: ['is'],
+        number: ['between'],
+      } as unknown as Record<ColumnType, FilterOperator[]>,
+    },
+    fetchData: async (params) => {
+      fetchCalls.push(params);
+      const page = params.pagination?.page ?? 1;
+      const limit = params.pagination?.limit ?? 10;
+      const start = (page - 1) * limit;
+      const count = Math.max(0, Math.min(limit, totalRows - start));
+      return {
+        data: Array.from({ length: count }, (_, i) => ({ id: `row-${start + i}` })),
+        total: totalRows,
+        pagination: {
+          page,
+          limit,
+          totalPages: Math.ceil(totalRows / limit),
+          hasNext: start + count < totalRows,
+          hasPrev: page > 1,
+        },
+      };
+    },
+    getFilterOptions: async () => [],
+    getFacetedValues: async (columnId, params) => {
+      facetCalls.push({ columnId, params });
+      return new Map([['a', 1]]);
+    },
+    getMinMaxValues: async (columnId, params) => {
+      rangeCalls.push({ columnId, params });
+      return [0, 1];
+    },
+  };
+
+  const adapter: TableAdapter<Row> = options?.batchFacets
+    ? {
+        ...base,
+        getFacets: async (requests, params) => {
+          batchCalls.push({ requests, params });
+          return {
+            values: Object.fromEntries(
+              requests
+                .filter((request) => request.kind === 'values')
+                .map((request) => [request.columnId, new Map([['a', 1]])])
+            ),
+            ranges: Object.fromEntries(
+              requests
+                .filter((request) => request.kind === 'minmax')
+                .map((request) => [request.columnId, [0, 1] as [number, number]])
+            ),
+          };
+        },
+      }
+    : base;
+
+  return { adapter, fetchCalls, facetCalls, rangeCalls, batchCalls };
 }

--- a/packages/ui/tests/hooks/use-facets.test.tsx
+++ b/packages/ui/tests/hooks/use-facets.test.tsx
@@ -271,4 +271,33 @@ describe('useFacets batch path (lag fix: one round-trip per refresh)', () => {
     expect(result.current.ranges.reopenCount).toBeUndefined();
     expect(result.current.error).toBeNull();
   });
+
+  it('chunks a sidebar larger than MAX_FACET_BATCH_SIZE into multiple getFacets calls', async () => {
+    const { adapter } = createDeferredFetchAdapter();
+    const batchSizes: number[] = [];
+    // 120 option columns → 3 chunks of 50/50/20 (MAX_FACET_BATCH_SIZE = 50).
+    const columnIds = Array.from({ length: 120 }, (_, i) => `c${i}`);
+    const batchAdapter: typeof adapter = {
+      ...adapter,
+      getFacets: async (requests) => {
+        batchSizes.push(requests.length);
+        return {
+          values: Object.fromEntries(requests.map((r) => [r.columnId, new Map([['x', 1]])])),
+          ranges: {},
+        };
+      },
+    };
+
+    const { result } = renderHook(() =>
+      useFacets({ adapter: batchAdapter, columnIds, filters: [] })
+    );
+
+    await waitFor(() => expect(result.current.facets.c0).toBeDefined());
+
+    // No chunk exceeds the cap, and every column is covered — so a >50-facet
+    // sidebar never hits the server's bad_request cap.
+    expect(batchSizes).toEqual([50, 50, 20]);
+    expect(batchSizes.every((n) => n <= 50)).toBe(true);
+    expect(result.current.facets.c119).toEqual([{ value: 'x', count: 1 }]);
+  });
 });

--- a/packages/ui/tests/hooks/use-facets.test.tsx
+++ b/packages/ui/tests/hooks/use-facets.test.tsx
@@ -196,3 +196,79 @@ describe('useFacets (plan 032 step 4, finding 7)', () => {
     ).toEqual(['baz', 'foo bar']);
   });
 });
+
+describe('useFacets batch path (lag fix: one round-trip per refresh)', () => {
+  it('prefers adapter.getFacets: ONE batched call, zero singular calls, results distributed', async () => {
+    const { adapter, facetCalls, rangeCalls } = createDeferredFetchAdapter();
+    const batchCalls: Array<{
+      requests: readonly { columnId: string; kind: string }[];
+    }> = [];
+    const batchAdapter: typeof adapter = {
+      ...adapter,
+      getFacets: async (requests) => {
+        batchCalls.push({ requests });
+        return {
+          values: {
+            status: new Map([
+              ['open', 2],
+              ['closed', 1],
+            ]),
+            priority: new Map([['high', 3]]),
+          },
+          ranges: { reopenCount: [0, 5] as [number, number] },
+        };
+      },
+    };
+
+    const { result } = renderHook(() =>
+      useFacets({
+        adapter: batchAdapter,
+        columnIds: ['status', 'priority'],
+        rangeColumnIds: ['reopenCount'],
+        filters: [],
+      })
+    );
+
+    await waitFor(() => expect(result.current.facets.status).toBeDefined());
+
+    // One batch call carrying every column with its kind — and none of the
+    // singular per-column methods.
+    expect(batchCalls).toHaveLength(1);
+    expect(batchCalls[0]?.requests).toEqual([
+      { columnId: 'status', kind: 'values' },
+      { columnId: 'priority', kind: 'values' },
+      { columnId: 'reopenCount', kind: 'minmax' },
+    ]);
+    expect(facetCalls).toHaveLength(0);
+    expect(rangeCalls).toHaveLength(0);
+
+    expect(result.current.facets.status).toEqual([
+      { value: 'open', count: 2 },
+      { value: 'closed', count: 1 },
+    ]);
+    expect(result.current.facets.priority).toEqual([{ value: 'high', count: 3 }]);
+    expect(result.current.ranges.reopenCount).toEqual([0, 5]);
+  });
+
+  it('a column missing from the batch result yields an empty option list, not a crash', async () => {
+    const { adapter } = createDeferredFetchAdapter();
+    const batchAdapter: typeof adapter = {
+      ...adapter,
+      getFacets: async () => ({ values: {}, ranges: {} }),
+    };
+
+    const { result } = renderHook(() =>
+      useFacets({
+        adapter: batchAdapter,
+        columnIds: ['status'],
+        rangeColumnIds: ['reopenCount'],
+        filters: [],
+      })
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.facets.status).toEqual([]);
+    expect(result.current.ranges.reopenCount).toBeUndefined();
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/packages/ui/tests/hooks/use-table-url-sync.test.tsx
+++ b/packages/ui/tests/hooks/use-table-url-sync.test.tsx
@@ -30,7 +30,7 @@ function createStore() {
 }
 
 describe('useTableUrlSync', () => {
-  it('does not call setParams after unmount when a debounced update was queued', async () => {
+  it('does not flush a pending coalesced write after unmount', async () => {
     createStore();
     const { adapter, setParamsCalls } = createFakeUrlAdapter();
     const config: UrlSyncConfig = { filters: true };
@@ -48,13 +48,23 @@ describe('useTableUrlSync', () => {
 
     jest.useFakeTimers();
     act(() => {
+      // First change writes immediately (leading edge)...
       store.getState().manager.addFilter({
         columnId: 'name',
         type: 'text',
         operator: 'contains',
         values: ['queued'],
       });
+      // ...second lands inside the cooldown and becomes the pending
+      // trailing write.
+      store.getState().manager.addFilter({
+        columnId: 'name',
+        type: 'text',
+        operator: 'contains',
+        values: ['pending'],
+      });
     });
+    expect(setParamsCalls.length - callsBeforeChange).toBe(1);
 
     unmount();
 
@@ -63,7 +73,8 @@ describe('useTableUrlSync', () => {
     });
     jest.useRealTimers();
 
-    expect(setParamsCalls.length - callsBeforeChange).toBe(0);
+    // The pending trailing write queued at unmount must never fire.
+    expect(setParamsCalls.length - callsBeforeChange).toBe(1);
   });
 
   it('hydrates filters from the URL when the table store is created after mount', async () => {
@@ -175,7 +186,7 @@ describe('useTableUrlSync', () => {
     expect(setParamsCalls.length).toBe(callsAfterSettling);
   });
 
-  it('coalesces rapid state changes into a single setParams call with the final state', async () => {
+  it('writes the first change of a burst immediately and coalesces the rest into one trailing write', async () => {
     createStore();
     const { adapter, setParamsCalls } = createFakeUrlAdapter();
     const config: UrlSyncConfig = { filters: true, pagination: true };
@@ -210,14 +221,53 @@ describe('useTableUrlSync', () => {
       });
     });
 
+    // Leading write already happened, synchronously, with the FIRST state.
+    expect(setParamsCalls.length - callsBeforeBurst).toBe(1);
+
     await act(async () => {
       jest.advanceTimersByTime(URL_SYNC_DEBOUNCE_MS);
     });
     jest.useRealTimers();
 
     const burstCalls = setParamsCalls.slice(callsBeforeBurst);
-    expect(burstCalls.length).toBe(1);
-    expect(burstCalls[0]?.page).toBe('2');
+    expect(burstCalls.length).toBe(2);
+    // Leading write: the first filter, no pagination change yet (default
+    // page/limit stay out of a clean URL).
+    expect(burstCalls[0]?.filters).toBeTruthy();
+    expect(burstCalls[0] && 'page' in burstCalls[0]).toBe(false);
+    // Trailing write: the burst's FINAL state, coalesced into one call.
+    expect(burstCalls[1]?.page).toBe('2');
+  });
+
+  it('writes a discrete change immediately — no debounce latency floor on e.g. a pagination click', async () => {
+    createStore();
+    const { adapter, setParamsCalls } = createFakeUrlAdapter();
+    const config: UrlSyncConfig = { filters: true, pagination: true };
+
+    renderHook(() => useTableUrlSync(TABLE_ID, config, adapter));
+
+    await waitFor(() => expect(getTableStore(TABLE_ID)).toBeDefined());
+    await act(async () => {});
+
+    const store = getTableStore(TABLE_ID);
+    if (!store) throw new Error('Expected table store');
+
+    const before = setParamsCalls.length;
+
+    // Freeze timers: if the write required the cooldown timer to fire, this
+    // test would see zero calls.
+    jest.useFakeTimers();
+    act(() => {
+      const pagination = store.getState().manager.getPagination();
+      store.getState().manager.updateState({
+        pagination: { ...pagination, page: 3 },
+      });
+    });
+    const calls = setParamsCalls.slice(before);
+    jest.useRealTimers();
+
+    expect(calls.length).toBe(1);
+    expect(calls[0]?.page).toBe('3');
   });
 
   it('does not introduce default page/limit into a clean URL', async () => {

--- a/packages/ui/tests/hooks/use-table-url-sync.test.tsx
+++ b/packages/ui/tests/hooks/use-table-url-sync.test.tsx
@@ -30,6 +30,73 @@ function createStore() {
 }
 
 describe('useTableUrlSync', () => {
+  it('preserves a pending trailing write when the adapter identity changes mid-burst (navigation)', async () => {
+    createStore();
+    // Two adapter identities backed by ONE param store + call log — models a
+    // framework adapter (e.g. useNextjsUrlAdapter) that recreates itself on
+    // every navigation while reading/writing the same URL.
+    const params = new Map<string, string>();
+    const setParamsCalls: Record<string, string | null>[] = [];
+    const makeAdapter = () => ({
+      getParam: (key: string) => params.get(key) ?? null,
+      setParams: (updates: Record<string, string | null>) => {
+        setParamsCalls.push(updates);
+        for (const [key, value] of Object.entries(updates)) {
+          if (value === null) params.delete(key);
+          else params.set(key, value);
+        }
+      },
+    });
+
+    let adapter = makeAdapter();
+    const config: UrlSyncConfig = { filters: true, pagination: true };
+    const { rerender } = renderHook(() => useTableUrlSync(TABLE_ID, config, adapter));
+    await waitFor(() => expect(getTableStore(TABLE_ID)).toBeDefined());
+    await act(async () => {});
+
+    const store = getTableStore(TABLE_ID);
+    if (!store) throw new Error('Expected table store');
+    const callsBefore = setParamsCalls.length;
+
+    jest.useFakeTimers();
+    // Leading write (fires immediately, "navigates").
+    act(() => {
+      store.getState().manager.addFilter({
+        columnId: 'name',
+        type: 'text',
+        operator: 'contains',
+        values: ['first'],
+      });
+    });
+    expect(setParamsCalls.length - callsBefore).toBe(1);
+
+    // A second change lands inside the cooldown → becomes the pending trailing
+    // write. THEN the "navigation" completes: the adapter identity changes and
+    // the hook re-renders (as useNextjsUrlAdapter would on a searchParams change).
+    act(() => {
+      store.getState().manager.addFilter({
+        columnId: 'name',
+        type: 'text',
+        operator: 'contains',
+        values: ['second'],
+      });
+    });
+    adapter = makeAdapter();
+    rerender();
+
+    await act(async () => {
+      jest.advanceTimersByTime(URL_SYNC_DEBOUNCE_MS);
+    });
+    jest.useRealTimers();
+
+    // The trailing write must still fire (through the NEW adapter) — before the
+    // ref-latch fix, the re-subscription cancelled it and the burst settled on
+    // "first".
+    expect(setParamsCalls.length - callsBefore).toBe(2);
+    const lastFilters = setParamsCalls.at(-1)?.filters;
+    expect(typeof lastFilters).toBe('string');
+  });
+
   it('does not flush a pending coalesced write after unmount', async () => {
     createStore();
     const { adapter, setParamsCalls } = createFakeUrlAdapter();

--- a/plans/063-performance-test-harness.md
+++ b/plans/063-performance-test-harness.md
@@ -59,8 +59,25 @@ tests. There is no harness that would catch the next regression class:
 
 ## Current state (verified 2026-07-23 at `dcd90c1`)
 
-What a pagination click / filter change actually costs today, and where the
-felt lag comes from — these are the behaviors the harness must measure:
+> **Update (2026-07-23, this branch):** the four lag causes below were fixed
+> ahead of this plan, on `claude/performance-testing-strategy-m35acc`.
+> Tier-1/Tier-4 characterization must pin the POST-fix contract:
+> server-affecting URL writes are leading-edge immediate with a 150 ms
+> trailing coalesce window (a discrete pagination click/filter commit pays
+> ZERO added latency; a rapid burst produces the first write plus at most
+> one trailing write per window); `<BetterTable loading>` keeps current rows
+> mounted (dimmed, `aria-busy`) during a refetch and reserves the skeleton
+> for an empty initial load, and the demos feed it `isPending` from a
+> transition around `router.replace`; `useFacets` issues ONE batched
+> `getFacets` POST on batch-capable adapters (singular per-column calls
+> remain only for in-process adapters), and `httpAdapter`'s TTL cache/dedup
+> now applies to signalled reads with per-caller abort semantics; demo
+> seeding warms at server boot (`instrumentation.ts`) and re-warms on demo
+> reset. The paragraphs below describe the PRE-fix behavior for the record.
+
+What a pagination click / filter change cost before those fixes, and where
+the felt lag came from — the regression classes the harness must keep
+covered:
 
 - **Interaction pipeline is synchronous to `state_changed`**: click →
   `table-pagination.tsx:101/166/180` → store → managers
@@ -175,11 +192,15 @@ Characterize, then assert EXACTLY (comment each number with why):
 - Adding a filter with empty `values` (`filter-bar.tsx:216`): characterize
   whether a fetch fires at all — whatever the current contract is, pin it
   and note it in the report (an empty-value fetch is a finding, not a fix).
-- Committing a filter value: 1 fetch, exactly K facet + R min/max calls for
-  a table with K option facets and R range facets (assert K=2, R=1 with a
-  3-facet fixture), 1 URL write, auto-show effect fires at most once.
-- Rapid double pagination click inside one debounce window: exactly 1 URL
-  write / 1 fetch (documents the debounce floor as intended coalescing).
+- Committing a filter value: 1 fetch, exactly ONE batched `getFacets` call
+  on a batch-capable adapter (assert the request list carries K option +
+  R range columns with a 3-facet fixture; K+R singular calls only for an
+  adapter without `getFacets`), 1 URL write, auto-show effect fires at most
+  once.
+- A single pagination click: the URL write is SYNCHRONOUS (leading edge) —
+  assert 1 write with timers frozen. A rapid double click inside the 150 ms
+  window: first write immediate, second coalesced to one trailing write
+  (2 total, each a real page change).
 
 Wire the so-far-unused `createRenderCounter`
 (`tests/helpers/render-count.tsx:16`) around the whole `<BetterTable>` to
@@ -328,15 +349,23 @@ check-only lint `bunx biome check .`); CI green on the branch including the
 new files; trend job proven by a manual `workflow_dispatch` run or a dry
 run with `save-data-file: false` noted in the report.
 
-## Expected follow-up fix plans (NOT in scope — file, don't fix)
+## Follow-up fixes — LANDED ahead of this plan (2026-07-23)
 
-The baselines are expected to motivate, at minimum: (a) an interaction
-feedback affordance in the demos (`loading`/transition instead of frozen
-stale rows — and reconsider the library's all-rows skeleton unmount);
-(b) scoping the 150 ms URL debounce (pagination clicks arguably shouldn't
-pay it); (c) facet request batching and the signal-vs-cache bypass in
-`useFacets`/`httpAdapter`; (d) demo cold-start seeding off the first
-request. Each becomes its own plan with a Tier-1/Tier-4 number attached.
+The four fix candidates this plan originally queued all landed on
+`claude/performance-testing-strategy-m35acc` before harness execution:
+(a) refetch feedback — `<BetterTable loading>` keeps rows mounted
+(dim + `aria-busy`; skeleton only for empty initial load) and every demo
+client passes `isPending` from a transition-wrapped `router.replace`
+(shared across siblings via `UrlNavigationPendingProvider` where the
+navigator and the table are different components); (b) URL writes are
+leading-edge immediate with a 150 ms trailing coalesce
+(`coalesceUrlWrites` in `use-table-url-sync.ts`) — no debounce floor on
+discrete interactions; (c) `TableAdapter.getFacets` batch (wire method +
+handler fan-out + `useFacets` batch path) and a signal-compatible
+TTL cache/dedup in `httpAdapter` (per-caller abort, refcounted underlying
+cancel); (d) demo seeding warmed at boot (`instrumentation.ts`) and after
+"Reset demo". Tier 4 baselines now VERIFY these fixes and guard them
+against regression, rather than motivating them.
 
 ## Scope
 

--- a/plans/063-performance-test-harness.md
+++ b/plans/063-performance-test-harness.md
@@ -1,0 +1,409 @@
+# Plan 063: Performance test harness — deterministic gates, benchmarks, interaction-latency baselines
+
+> **Executor instructions**: Follow step by step; run every verification and
+> confirm before moving on. On any STOP, stop and report. Skip updating
+> `plans/README.md` — the reviewer maintains the index. Steps land
+> independently — a partial landing (Steps 1–3 without 5–6) is still a valid
+> outcome; report what shipped. This plan builds MEASUREMENT, not fixes:
+> if a characterization step exposes a product defect, record the number,
+> file it as a follow-up finding in your report, and do not fix it inline.
+>
+> **Drift check (run first)**:
+> `git diff --stat dcd90c1..HEAD -- packages/ui/src/hooks/use-table-url-sync.ts packages/ui/src/hooks/use-facets.ts packages/ui/src/hooks/use-table-data.ts packages/core/src/adapters/http-adapter.ts packages/ui/tests/helpers apps/marketing/src/lib/nextjs-url-adapter.ts .github/workflows/test.yml`
+> — if the hooks or helpers moved materially, re-verify the Current-state
+> excerpts before executing.
+
+## Status
+
+- **Priority**: P2
+- **Effort**: L (six independent steps; each is S–M alone)
+- **Risk**: MEDIUM (new CI surface; wall-time flake risk — mitigated by
+  gating on counts/ratios and keeping timing tiers report-only at first)
+- **Depends on**: nothing hard. Reuses plan 042's fake-timer idioms, plan
+  043's `drizzle-sqlite-fixture`, plan 025/041's render-count test style.
+- **Category**: perf / tests
+- **Planned at**: `dcd90c1`, 2026-07-23
+- **Trigger**: maintainer-reported lag on pagination clicks and filter adds
+  in the demos; performance is a stated product pillar, so it needs tests,
+  not anecdotes.
+
+## Why this matters
+
+Every perf fix so far (025 memoized rows, 040 transformer/cache/facet cap,
+041 facet dedup + URL-serialize debounce, PR #105's RSC round-trip cuts) was
+found by **hand profiling** and is protected only by point characterization
+tests. There is no harness that would catch the next regression class:
+
+- **Nothing measures runtime speed anywhere.** No mitata/tinybench, no
+  `performance.now` measurement code, no bench script in any package
+  (verified repo-wide). The drizzle "perf" test
+  (`tests/adapter-perf-cache-facets.test.ts`) asserts cache/limit
+  *correctness*, not cost.
+- **The type-perf gate is manual.** The fixtures exist
+  (`packages/core/tests/types/filter-perf-fixture.ts:15-18`,
+  `table-def-perf-fixture.ts:23-26`) with budgets recorded only in
+  `plans/design/table-definition-dx.md:767-812` (≤ 2.5 s check / ≤ 2 M
+  instantiations; last recorded 199,114 / 1.00 s). No test, script, or CI
+  step runs them — the "perf gate" checklist item in past plans was a human
+  running `tsc --extendedDiagnostics` by hand.
+- **No test pins the *cost* of an interaction.** Render-count tests cover
+  component memoization in isolation, but nothing asserts "one pagination
+  click = exactly 1 fetch, 1 URL write, 0 facet refetches." The facet
+  cache-bypass described below is invisible to every existing suite.
+- **CI runs zero perf steps** (`.github/workflows/test.yml` — build, test,
+  lint only), despite already provisioning MySQL/Postgres service
+  containers that a scale suite could reuse later.
+- **No E2E exists** (043's Playwright step was deferred), so the thing the
+  maintainer actually *feels* — click-to-updated-rows latency in the demos —
+  has never been measured by automation.
+
+## Current state (verified 2026-07-23 at `dcd90c1`)
+
+What a pagination click / filter change actually costs today, and where the
+felt lag comes from — these are the behaviors the harness must measure:
+
+- **Interaction pipeline is synchronous to `state_changed`**: click →
+  `table-pagination.tsx:101/166/180` → store → managers
+  (`pagination-manager.ts:275-284`) → `state_changed`
+  (`table-state-manager.ts:718-735`, no debounce) → two subscribers:
+  zustand re-render + URL sync.
+- **A fixed 150 ms debounce sits in front of every server-driven refetch**:
+  `use-table-url-sync.ts:402` debounces the URL write; in the demos the URL
+  write IS the refetch trigger (`nextjs-url-adapter.ts:63-71`
+  `router.replace` on server-affecting params → RSC re-render → direct
+  Drizzle `fetchData`). A pagination click therefore idles 150 ms before
+  the network even starts.
+- **The demos show no feedback during the round-trip**: no demo passes
+  `loading` (`users-table-client.tsx:70-108`), so stale rows sit unchanged
+  until new props land. The library path has the opposite defect:
+  `loading=true` unmounts all rows to a full skeleton
+  (`table.tsx:1272-1294`, set synchronously at `use-table-data.ts:130`).
+  No `useTransition`/`useDeferredValue`/optimistic rendering exists
+  anywhere (repo-wide grep).
+- **Filter changes fan out**: one refetch plus K facet requests — one POST
+  per option column + one per range column, unbatched
+  (`use-facets.ts:152-166`; the facets demo issues 4), and **the 2 s TTL
+  cache is bypassed** because `useFacets` always passes an abort signal,
+  routing to the uncached `send` (`http-adapter.ts:301,316,328`). In the
+  facets sidebar the facet POSTs additionally cannot start until the RSC
+  round-trip returns new `activeFilters` (`facets-sidebar.tsx:42,50-56`) —
+  counts trail the click by round-trip + POST.
+- **Cold start pays seeding inline**: first demo request (or "Reset demo")
+  seeds 5,000 users (`users/sqlite/db.ts:80-97`) or 12,000+ tickets
+  (`support/db.ts:111-123`, bulk-inserted in 500-row batches) before
+  answering.
+- **Existing measurement assets to reuse**: local-counter render tests
+  (`table-row-render.test.tsx:74`, `active-filters-render.test.tsx:105`,
+  `filter-bar-render.test.tsx:52` delta-style, `table-effect-churn.test.ts:61`),
+  an **unused** `createRenderCounter` Profiler helper
+  (`tests/helpers/render-count.tsx:16`), `installResizeObserverMock`
+  (`:56`), the bun:sqlite fixture (`drizzle-sqlite-fixture.ts:59`, seeds
+  3 users), and env-gated MySQL/PG suites with a CI no-silent-skip guard
+  (`ci-integration-guard.test.ts:34`).
+
+## Research — measurement techniques considered
+
+Decision principle (already implicit in this repo's type gate and render
+tests): **gate on deterministic counts and machine-independent ratios;
+track wall time as trends; never hard-fail a PR on shared-runner
+milliseconds.**
+
+| Technique | Verdict | Why |
+|---|---|---|
+| React Profiler / local render counters (existing idiom) | **Adopt** — Tier 1 | Deterministic, proven in-repo; extend from "is X memoized" to "what does one interaction cost" |
+| Adapter/network **operation counting** (drizzle `logger` hook, counting fetch stubs) | **Adopt** — Tier 1 | Exact integers; catches N+1, duplicate fetches, cache bypass — the regression classes that actually happened here |
+| `EXPLAIN QUERY PLAN` shape assertions (SQLite) | **Adopt (few canaries)** — Tier 1 | Deterministic index-usage guard; PG variant stays env-gated with the existing integration suites |
+| **Growth-ratio** tests (same op at 1k vs 10k rows, bound the ratio) | **Adopt** — Tier 2 | Ratios cancel machine speed; catches accidental O(n²) with wide, CI-safe slack |
+| **mitata** micro-benchmarks under Bun | **Adopt** — Tier 3 (trend) | Bun's documented recommendation; GC control; JSON output feeds trend tracking. Absolute numbers are NOT PR gates |
+| `tsc --extendedDiagnostics` instantiation counts | **Adopt (automate existing gate)** | Instantiations are deterministic; budget already agreed (≤ 2 M); time gets loose slack only |
+| Playwright + in-page `PerformanceObserver` event timing (lab-INP per scripted interaction) | **Adopt, report-only first** — Tier 4 | The only tier that measures the *felt* click→paint/rows latency incl. the 150 ms debounce + RSC trip; Chromium-only; p75 of N reps |
+| `github-action-benchmark` (`customSmallerIsBetter` JSON, gh-pages history, alert threshold) | **Adopt** for trends | Tool-agnostic JSON fits mitata + our counters; free; comment-on-regression without flaky red PRs |
+| CodSpeed (instruction-count instrumentation) | **Reject for now** | Harness is vitest ≥ 3.2 / Node; this repo is `bun test`-native on JSC. Revisit only if vitest ever enters the repo |
+| bencher.dev | **Alternative, not now** | Better statistics than gh-action-benchmark but an external SaaS dependency; note as fallback if gh-pages trends prove too noisy |
+| Lighthouse timespan / full CWV audits | **Reject** | Page-level and heavyweight; the product is a library — scripted-interaction timing is the right granularity |
+| react-scan / React DevTools profiling | **Document only** | Interactive diagnosis tools; not CI-gateable. Mention in the perf doc for contributors |
+| Strict wall-time thresholds inside `bun test` on PRs | **Reject** | Shared-runner variance; the only absolute ceilings allowed are catastrophic ones (≥ 3× budget) |
+
+## Design — four tiers
+
+- **Tier 1 — interaction & query cost gates** (blocking, every PR, zero
+  wall-clock): exact counts per user interaction (fetches, facet requests,
+  URL serializations, renders/commits, effect fires) and per adapter
+  operation (SQL statements, plan shapes).
+- **Tier 2 — growth-ratio gates** (blocking, generous ratio bounds): scale
+  behavior of `fetchData`, transformer, and filter application at 1k vs 10k
+  rows in bun:sqlite.
+- **Tier 3 — micro-benchmarks** (non-blocking trends): mitata suites for
+  core managers, URL codec, toolkit transformer, drizzle SQL build; JSON →
+  gh-pages trend with alert comments on main.
+- **Tier 4 — E2E interaction latency** (opt-in, report-first): Playwright
+  over the built marketing demo measuring click→next-paint and
+  click→rows-updated, producing the baseline numbers that quantify the
+  reported lag (and, later, verify its fixes).
+
+## Commands you will need
+
+| Purpose | Command | Expected |
+|---|---|---|
+| Build deps | `bun run build --filter=@better-tables/core --filter=@better-tables/adapters-toolkit --filter=@better-tables/adapters-drizzle` | exit 0 |
+| UI tests | `cd packages/ui && bun test` | pass |
+| Adapter tests | `cd packages/adapters/drizzle && bun test` | SQLite green |
+| Core tests | `cd packages/core && bun test` | pass |
+| Benches (after Step 4) | `bun run bench` (root, via turbo) | JSON emitted per package |
+| Type gate (after Step 5) | `cd packages/core && bun test tests/types/type-perf-gate.test.ts` | pass, prints numbers |
+| E2E perf (after Step 6) | `cd apps/marketing && bun run test:e2e:perf` | JSON report written |
+| Typecheck | `bun run typecheck` | exit 0 |
+
+## Steps
+
+### Step 1: Interaction-cost gates (UI)
+
+New `packages/ui/tests/components/interaction-cost.test.tsx` (split into
+two files if large: pagination / filters). Use the plan-042 fake-timer
+idiom, the local-counter render idiom, and a **counting stub adapter**
+(extend `tests/helpers/stub-adapter.ts` with per-method call counters —
+`fetchData`, `getFacetedValues`, `getMinMaxValues` — plus a counting
+serializer spy for URL sync, following plan 041's `setParams`-count
+fallback if the serializer can't be spied cleanly).
+
+Characterize, then assert EXACTLY (comment each number with why):
+
+- One pagination click: 1 `fetchData` (after debounce flush), 0 facet
+  calls, 1 URL write; sibling-row re-renders within the plan-025 bounds;
+  bridge effects fire once (`table-effect-churn` idiom).
+- One page-size change: 1 fetch, 1 URL write, page recompute preserved.
+- Adding a filter with empty `values` (`filter-bar.tsx:216`): characterize
+  whether a fetch fires at all — whatever the current contract is, pin it
+  and note it in the report (an empty-value fetch is a finding, not a fix).
+- Committing a filter value: 1 fetch, exactly K facet + R min/max calls for
+  a table with K option facets and R range facets (assert K=2, R=1 with a
+  3-facet fixture), 1 URL write, auto-show effect fires at most once.
+- Rapid double pagination click inside one debounce window: exactly 1 URL
+  write / 1 fetch (documents the debounce floor as intended coalescing).
+
+Wire the so-far-unused `createRenderCounter`
+(`tests/helpers/render-count.tsx:16`) around the whole `<BetterTable>` to
+assert total commits per interaction ≤ a small pinned number — or, if the
+local-counter idiom proves strictly clearer, delete the dead helper (do one
+or the other; don't leave it unused).
+
+**Verify**: `cd packages/ui && bun test` 0 fail; new assertions are exact
+integers, no timing.
+
+### Step 2: Query-count + plan-shape gates (adapter)
+
+New `packages/adapters/drizzle/tests/query-count.test.ts`:
+
+- Helper: build the bun:sqlite drizzle db with a counting `logger`
+  (`drizzle-orm` `Logger.logQuery`) — add it to the existing test helpers.
+  If the logger seam misses statements on any path, STOP and report.
+- Assert exact statements per operation (characterize first, comment each):
+  plain `fetchData` (expect data + count = 2); `fetchData` with a 1:N
+  relation (two-phase fan-out from plan 020 — expect 3, or the verified
+  number); one facet call = 1; `getMinMaxValues` = 1; a cached repeat
+  `fetchData` = 0 (LRU hit, plan 040).
+- 2–3 `EXPLAIN QUERY PLAN` canaries: create an index in the fixture on a
+  commonly filtered column; assert the filtered query's plan says
+  `USING INDEX` (and a PK join does not full-scan). Keep these narrowly
+  scoped to schema the fixture owns.
+
+**Verify**: `cd packages/adapters/drizzle && bun test` green with no env
+vars (SQLite only). Counts are exact integers.
+
+### Step 3: Growth-ratio gates (adapter + toolkit)
+
+New `packages/adapters/drizzle/tests/scale-growth.test.ts` + a toolkit
+twin for the transformer:
+
+- Seed bun:sqlite with 1k and 10k rows (single transaction; keep seeding
+  < ~1 s). Measure with `performance.now()`, median of 5 runs, one warm-up
+  discarded.
+- Assert RATIOS, not absolutes: page-1 `fetchData` (LIMIT'd) at 10k ≤ 8×
+  the 1k time (should be near-flat); filtered count query ≤ 15× (linear-ish
+  with slack); toolkit `transformToNestedStructure` on 10k flat rows ≤ 15×
+  its 1k time (an O(n²) regression shows up as ~100×).
+- One absolute catastrophic ceiling each (e.g. page fetch at 10k < 2 s) —
+  wide enough to never flake, tight enough to catch pathology.
+- Mark the file with a raised bun test timeout; keep total runtime of the
+  file under ~10 s so the PR gate stays fast.
+
+**Verify**: run the file 5× locally back-to-back — 0 flakes. If a ratio
+flakes in CI after tuning (see STOP), demote that assertion to Tier 3.
+
+### Step 4: mitata micro-bench suites (trend tier)
+
+- Add `mitata` to the workspace catalog (devDependency).
+- Per-package `bench/` dirs, excluded from `bun test` globs and turbo
+  `test` inputs: `packages/core/bench/` (filter/sort/pagination manager
+  ops on 10k-row arrays, FilterNode build/serialize at depth 3, URL state
+  serialize incl. lz-string at 1/10/50 filters),
+  `packages/adapters/toolkit/bench/` (transformer 1k/10k, flat vs 1:N),
+  `packages/adapters/drizzle/bench/` (SQL generation only — no DB — for
+  filter trees, joins, facets).
+- Per-package script `"bench": "bun bench/index.ts"`; root `"bench":
+  "turbo run bench"` with a `bench` turbo task (`cache: false`,
+  `dependsOn: ["build"]`). Each run writes
+  `bench-results/<pkg>.json` (mitata JSON output; if the pinned mitata's
+  JSON API differs from its docs, wrap with a ~30-line
+  `scripts/bench-report.ts` that shapes `{name, unit: "ns", value}` —
+  `customSmallerIsBetter` format).
+- `bun:jsc` `heapStats` deltas may be added as extra JSON entries for the
+  transformer bench (memory trend), but only if trivially stable.
+
+**Verify**: `bun run bench` exits 0 and writes JSON for all three
+packages; runtime < ~2 min total; `git status` shows results are
+gitignored (add `bench-results/` to `.gitignore`).
+
+### Step 5: Automate the type-perf gate
+
+New `packages/core/tests/types/type-perf-gate.test.ts`:
+
+- Spawn `bunx tsc --noEmit --extendedDiagnostics` for each fixture (the
+  exact commands already in the fixture headers); parse `Instantiations`
+  and `Check time`.
+- **Hard gate**: instantiations ≤ 2,000,000 per fixture (the agreed budget,
+  `plans/design/table-definition-dx.md:791`). **Loose gate**: check time
+  ≤ 7.5 s (3× the 2.5 s local budget — slow-runner slack; the 2.5 s number
+  remains the local target and is printed, not enforced).
+- Print the measured numbers so CI logs double as a trend record; also
+  append them to the Step-4 JSON (unit: instantiations) so the trend graph
+  tracks them.
+- Allow skip via `SKIP_TYPE_PERF=1` for fast local loops, but ensure it
+  runs in CI (the guard idiom from `ci-integration-guard.test.ts:34` —
+  in GitHub Actions the skip env must not be set).
+
+**Verify**: `cd packages/core && bun test` green; deliberately lowering the
+budget to 100k makes it fail (then restore).
+
+### Step 6: E2E interaction-latency harness (report-first)
+
+Lands plan 043's deferred Playwright step, perf-scoped, in
+`apps/marketing`:
+
+- `@playwright/test` devDep (Chromium only), `playwright.config.ts`, specs
+  under `apps/marketing/e2e/` — OUTSIDE the `bun test` glob so
+  `static-checks` stays untouched. Script `test:e2e:perf` runs
+  `next build` + `next start` (production; dev-mode numbers are
+  meaningless), warms each demo page once (absorbs the in-memory seed cost
+  — 5k users / 12k+ tickets), then measures.
+- Scripted interactions ×15 reps (first 3 discarded), CDP CPU throttle 4×:
+  1. homepage pagination "next" click,
+  2. add + commit a text filter,
+  3. facets-sidebar toggle.
+  For each: `performance.mark` at dispatch → await a rows-changed DOM
+  assertion (wall time), and a buffered `PerformanceObserver('event')`
+  entry for input→next-paint. Report p50/p75 per interaction as
+  `customSmallerIsBetter` JSON.
+- **No budgets yet.** The harness asserts only mechanics (rows actually
+  changed, N reps collected). Budgets get chosen in a follow-up once
+  baseline variance is known.
+- CI: a separate `workflow_dispatch` + push-to-main job (never a PR gate),
+  uploading the JSON as an artifact. If browsers can't run in this CI, keep
+  it local-only and say so (mirrors 043's stance) — do NOT half-wire it.
+
+**Verify**: `bun run test:e2e:perf` locally produces a JSON report with
+p50/p75 for all three interactions; numbers land in the Step-7 baseline
+doc.
+
+### Step 7: CI wiring, trend tracking, baseline record
+
+- `.github/workflows/test.yml`: Tier 1/2 additions ride the existing
+  package test jobs automatically (they're plain `bun test` files). Add a
+  `perf-trend` job on push-to-`main` only: `bun run bench` (+ Step 5's JSON)
+  → `benchmark-action/github-action-benchmark` with
+  `tool: customSmallerIsBetter`, gh-pages storage, `alert-threshold: 150%`,
+  `comment-on-alert: true`, `fail-on-alert: false` (flip to true only after
+  ~2 weeks of stable history; leave a dated TODO).
+- Write `plans/design/perf-baselines.md`: the captured numbers from every
+  tier, the diagnosis narrative for the reported lag (quantified against
+  the Current-state suspects: 150 ms debounce floor, RSC round-trip time,
+  facet cascade, no-feedback window), and the follow-up fix candidates
+  (below) each tied to its number.
+- Changesets: none expected (tests/bench/CI only). If Step 1's counting
+  hooks required touching a published package's source, STOP — that
+  belongs in a fix plan.
+
+**Verify**: full gates (`bun run typecheck` 11/11, all package suites, root
+check-only lint `bunx biome check .`); CI green on the branch including the
+new files; trend job proven by a manual `workflow_dispatch` run or a dry
+run with `save-data-file: false` noted in the report.
+
+## Expected follow-up fix plans (NOT in scope — file, don't fix)
+
+The baselines are expected to motivate, at minimum: (a) an interaction
+feedback affordance in the demos (`loading`/transition instead of frozen
+stale rows — and reconsider the library's all-rows skeleton unmount);
+(b) scoping the 150 ms URL debounce (pagination clicks arguably shouldn't
+pay it); (c) facet request batching and the signal-vs-cache bypass in
+`useFacets`/`httpAdapter`; (d) demo cold-start seeding off the first
+request. Each becomes its own plan with a Tier-1/Tier-4 number attached.
+
+## Scope
+
+**In scope**: new test files in ui/drizzle/toolkit/core `tests/`; counting
+extensions to `packages/ui/tests/helpers/stub-adapter.ts` and drizzle test
+helpers; per-package `bench/` + scripts + turbo `bench` task + catalog
+mitata; `scripts/bench-report.ts` (new root `scripts/` dir);
+`packages/core/tests/types/type-perf-gate.test.ts`; `apps/marketing/e2e/`
++ Playwright config + devDep; `.github/workflows/test.yml` trend job;
+`.gitignore` (`bench-results/`); `plans/design/perf-baselines.md`.
+
+**Out of scope**: ALL product-source changes (fix candidates above);
+vitest/CodSpeed migration; MySQL/Postgres perf suites (reuse the env-gated
+pattern later if wanted); bundle-size gates for published packages
+(cheap but orthogonal — deferred); marketing content/UX changes;
+virtualization stress E2E (optional follow-up).
+
+## Git workflow
+
+Branch `performance-test-harness` from main. Commits `Plan 063 Step N: …`.
+No push without maintainer instruction.
+
+## Done criteria
+
+- [ ] Interaction-cost tests pin exact fetch/facet/URL-write/render counts for pagination click, page-size change, filter add, filter value commit, and coalesced double-click (`cd packages/ui && bun test` green)
+- [ ] Query-count tests pin exact SQL statements per adapter operation incl. a cache-hit 0 and ≥ 2 EXPLAIN plan canaries (`cd packages/adapters/drizzle && bun test` green, no env vars)
+- [ ] Growth-ratio tests bound 10k/1k ratios for fetch, filtered count, and transformer; 5 consecutive local runs 0 flakes
+- [ ] `bun run bench` emits `customSmallerIsBetter` JSON for core, toolkit, drizzle; `bench-results/` gitignored
+- [ ] Type-perf gate runs in `bun test` with hard instantiation budget (≤ 2 M) and loose time ceiling; prints numbers; cannot silently skip in CI
+- [ ] Playwright perf spec measures p50/p75 for the three demo interactions against a production build, or is explicitly recorded as local-only with the reason
+- [ ] `perf-trend` CI job on main uploads results with alert comments (`fail-on-alert: false` + dated TODO)
+- [ ] `plans/design/perf-baselines.md` records all baseline numbers + quantified lag diagnosis + follow-up fix list
+- [ ] Full gates: `bun run typecheck` exit 0; all package suites green; no product `src/**` modified
+
+## STOP conditions
+
+- The drizzle `logger` seam does not see every statement for a covered
+  operation (e.g. a driver path bypasses it) — report before hand-wrapping
+  drivers.
+- Tier 1 characterization reveals a genuine defect (duplicate fetch per
+  click, K×M facet fan-out, empty-filter fetch storm) — pin the current
+  number with a `// FINDING:` comment, report it for a fix plan, continue.
+- A growth-ratio assertion flakes in CI after 3 bound-widening attempts —
+  demote to trend-only JSON and report.
+- mitata's JSON output API under pinned Bun 1.3.11 doesn't match its docs —
+  fall back to a ~50-line `Bun.nanoseconds` runner emitting the same JSON,
+  and report the substitution.
+- Playwright cannot install/launch Chromium in CI — keep the harness
+  local/opt-in with a README note; do not force a broken job green.
+- Any step needs a change to published-package `src/**` — that's a fix, not
+  a measurement; report instead.
+
+## Maintenance notes
+
+- **Noise discipline**: PR gates stay counts + ratios + catastrophic
+  ceilings only. Wall-time budgets live in the trend tier until two weeks
+  of history justify promotion (dated TODO in the workflow).
+- **Updating budgets**: a legitimate count change (e.g. an intentional
+  extra query) updates the pinned number in the same PR with a comment
+  citing the plan/PR that changed it — the test is the changelog.
+- **CodSpeed revisit condition**: only if the repo ever adopts vitest;
+  bencher.dev is the fallback if gh-pages trends prove too noisy to read.
+- **Future tie-ins**: the 061 conformance suite can reuse the counting
+  logger + scale fixtures per adapter; a user-facing `perfPlugin()` (049
+  hook seam: `beforeFetch`/`afterFetch` timing) would productize the same
+  measurements — separate plan if wanted.
+- Reviewer scrutiny: Step 1's exact counts must be characterized against
+  REAL current behavior (not aspirational); Step 3's seeding must stay
+  inside the test-runtime budget; Step 6 must measure the production
+  build, never `next dev`.

--- a/plans/README.md
+++ b/plans/README.md
@@ -32,8 +32,9 @@ loose backlog. Deferred items are at the bottom.
 
 ## Where we are (2026-07-22)
 
-**0.6 is shippable.** Waves A–D are merged to `main`. Open work is Waves
-E–F plus leftover 048. 058 stays deferred; **060 landed**.
+**0.6 is shippable.** Waves A–D are merged to `main`. Open work is Wave E
+plus leftover 048; Wave F (perf harness, 063) is **DONE** on its branch.
+058 stays deferred; **060 landed**.
 
 | Wave | Plans | Outcome |
 |------|-------|---------|
@@ -79,7 +80,7 @@ homepage `postsCount` dogfood. Design record: `plans/design/derived-columns.md`.
 
 | Plan | What | Depends on | Status |
 |------|------|------------|--------|
-| [063](063-performance-test-harness.md) | Perf test harness: interaction/query-count gates, growth-ratio gates, mitata trend benches, type-gate automation, Playwright latency baselines for the reported pagination/filter lag | 042/043 helpers (done) | **TODO** (P2) |
+| [063](063-performance-test-harness.md) | Perf test harness: interaction/query-count gates, growth-ratio gates, mitata trend benches, type-gate automation, Playwright latency baselines | 042/043 helpers (done) | **DONE** (2026-07-23) — all 7 steps + the four lag fixes on the plan branch; baselines in [design/perf-baselines.md](design/perf-baselines.md); one FINDING open (empty-filter add costs a navigation) |
 
 ---
 
@@ -91,11 +92,8 @@ homepage `postsCount` dogfood. Design record: `plans/design/derived-columns.md`.
 - **048** anytime after 0.6 — no file overlap with 061; follow plan 041
   handler idioms and plan 042 input-test patterns.
 - **062** only after 061 Phases 1 + 6.
-- **063** anytime — measurement only (tests/bench/CI, no product `src/**`);
-  steps land independently. The four demo-lag fixes it originally queued
-  (loading affordance, leading-edge URL writes, facet batch + signal cache,
-  boot-time seeding) LANDED 2026-07-23 on the plan's branch — Tier-1/Tier-4
-  characterization pins the post-fix contract (see the plan's update note).
+- **063 executed** (2026-07-23, all 7 steps + the four lag fixes) — see the
+  Wave F row. Numbers: [design/perf-baselines.md](design/perf-baselines.md).
 - Capability asymmetry (from 060 design): Prisma can sort-by-count but
   not filter-by-count; Kysely/Drizzle do both — declare honestly in
   `AdapterMeta.capabilities.aggregates`.

--- a/plans/README.md
+++ b/plans/README.md
@@ -80,7 +80,7 @@ homepage `postsCount` dogfood. Design record: `plans/design/derived-columns.md`.
 
 | Plan | What | Depends on | Status |
 |------|------|------------|--------|
-| [063](063-performance-test-harness.md) | Perf test harness: interaction/query-count gates, growth-ratio gates, mitata trend benches, type-gate automation, Playwright latency baselines | 042/043 helpers (done) | **DONE** (2026-07-23) — all 7 steps + the four lag fixes on the plan branch; baselines in [design/perf-baselines.md](design/perf-baselines.md); one FINDING open (empty-filter add costs a navigation) |
+| [063](063-performance-test-harness.md) | Perf test harness: interaction/query-count gates, growth-ratio gates, mitata trend benches, type-gate automation, Playwright latency baselines | 042/043 helpers (done) | **DONE** (2026-07-23) — all 7 steps + the four lag fixes on the plan branch; baselines in [design/perf-baselines.md](design/perf-baselines.md). The one FINDING (empty-filter add cost a navigation) is now FIXED via `getEffectiveFilters` |
 
 ---
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -92,9 +92,10 @@ homepage `postsCount` dogfood. Design record: `plans/design/derived-columns.md`.
   handler idioms and plan 042 input-test patterns.
 - **062** only after 061 Phases 1 + 6.
 - **063** anytime — measurement only (tests/bench/CI, no product `src/**`);
-  steps land independently; expected to spawn fix plans for the demo lag
-  findings (loading affordance, URL-debounce scope, facet batching,
-  cold-start seeding).
+  steps land independently. The four demo-lag fixes it originally queued
+  (loading affordance, leading-edge URL writes, facet batch + signal cache,
+  boot-time seeding) LANDED 2026-07-23 on the plan's branch — Tier-1/Tier-4
+  characterization pins the post-fix contract (see the plan's update note).
 - Capability asymmetry (from 060 design): Prisma can sort-by-count but
   not filter-by-count; Kysely/Drizzle do both — declare honestly in
   `AdapterMeta.capabilities.aggregates`.

--- a/plans/README.md
+++ b/plans/README.md
@@ -32,8 +32,8 @@ loose backlog. Deferred items are at the bottom.
 
 ## Where we are (2026-07-22)
 
-**0.6 is shippable.** Waves A–D are merged to `main`. Open work is Wave E
-plus leftover 048. 058 stays deferred; **060 landed**.
+**0.6 is shippable.** Waves A–D are merged to `main`. Open work is Waves
+E–F plus leftover 048. 058 stays deferred; **060 landed**.
 
 | Wave | Plans | Outcome |
 |------|-------|---------|
@@ -75,6 +75,12 @@ Drizzle correlated-subquery lowering + `FilterGroupNode` walk for
 legacy callback-`filter` still throws), memoryAdapter nested-array eval,
 homepage `postsCount` dogfood. Design record: `plans/design/derived-columns.md`.
 
+### Wave F — performance harness
+
+| Plan | What | Depends on | Status |
+|------|------|------------|--------|
+| [063](063-performance-test-harness.md) | Perf test harness: interaction/query-count gates, growth-ratio gates, mitata trend benches, type-gate automation, Playwright latency baselines for the reported pagination/filter lag | 042/043 helpers (done) | **TODO** (P2) |
+
 ---
 
 ## Order notes (open plans only)
@@ -85,6 +91,10 @@ homepage `postsCount` dogfood. Design record: `plans/design/derived-columns.md`.
 - **048** anytime after 0.6 — no file overlap with 061; follow plan 041
   handler idioms and plan 042 input-test patterns.
 - **062** only after 061 Phases 1 + 6.
+- **063** anytime — measurement only (tests/bench/CI, no product `src/**`);
+  steps land independently; expected to spawn fix plans for the demo lag
+  findings (loading affordance, URL-debounce scope, facet batching,
+  cold-start seeding).
 - Capability asymmetry (from 060 design): Prisma can sort-by-count but
   not filter-by-count; Kysely/Drizzle do both — declare honestly in
   `AdapterMeta.capabilities.aggregates`.

--- a/plans/design/perf-baselines.md
+++ b/plans/design/perf-baselines.md
@@ -1,0 +1,90 @@
+# Performance baselines — plan 063 harness (captured 2026-07-23)
+
+First numbers from every tier of the plan 063 harness, captured on the
+`claude/performance-testing-strategy-m35acc` branch AFTER the four
+interaction-lag fixes landed (same branch, commit `728aa68`). Machine:
+CI-class Linux x64 container (Xeon ~2.1 GHz, Bun 1.3.11); wall-time values
+are indicative, not comparable across machines — trends live on gh-pages
+via the `perf-trend` job, counts are pinned in the blocking suites.
+
+## Tier 1 — deterministic interaction / query costs (PR-blocking)
+
+Pinned in `packages/ui/tests/components/interaction-cost.test.tsx` and
+`packages/adapters/drizzle/tests/query-count.test.ts`:
+
+| Interaction / operation | Cost (exact) |
+|---|---|
+| Table mount (library wiring) | 1 fetch, 1 batched facet call (K=2 values + R=1 minmax in ONE request), 0 URL writes |
+| Pagination click | 1 fetch, 0 facet calls, 1 **synchronous** URL write (leading edge — no 150 ms floor) |
+| Rapid double pagination click | 2 fetches, 2 URL writes (leading + one coalesced trailing) |
+| Page-size change | 1 fetch, 1 immediate URL write |
+| Filter commit | 1 fetch, 1 batched facet refresh, 1 immediate URL write |
+| Filter add with EMPTY values | **FINDING**: 1 fetch + 1 facet refresh + 1 URL write before any value is chosen — a real RSC navigation in server-driven apps; candidate fix: skip fetch/serialize until a value commits |
+| Facets without `getFacets` (in-process adapters) | exactly K+R singular calls |
+| `fetchData` (plain) | 2 SQL statements (data + count) |
+| `fetchData` + many-to-one column | 2 statements (single-query join path) |
+| `fetchData` + one-to-many column | 3 statements (plan 020 two-phase fan-out + count) |
+| `getFacetedValues` / `getMinMaxValues` | 1 statement each |
+| Repeated identical `fetchData` | 0 statements (plan 040 LRU hit); write → invalidate → 2 again |
+| EXPLAIN canaries | filtered status query + its count: `SEARCH … USING (COVERING) INDEX`, never `SCAN tickets`; many-to-one join probes `agents` by INTEGER PRIMARY KEY; facet GROUP BY walks the covering index with no temp b-tree |
+
+## Tier 2 — growth ratios (PR-blocking, 10k/1k, median of 5)
+
+5 consecutive local runs, zero flakes:
+
+| Operation | Measured ratio (bound) |
+|---|---|
+| Page-1 LIMIT'd `fetchData` | 0.37–0.74 (≤ 8) — flat, as expected |
+| Filtered fetch + count (un-indexed column) | 1.02–1.50 (≤ 15) |
+| Transformer, flat 10k rows | 3.9–5.7 (≤ 15) |
+| Transformer, one-to-many fan-out 10k rows | 5.6–7.9 (≤ 15) |
+
+## Tier 3 — micro-bench trends (mitata p50, ns/iter; non-blocking)
+
+`bun run bench` (~40 s total; 17 entries feed the gh-pages trend):
+
+| Bench | p50 |
+|---|---|
+| core/pagination.goToPage | 166 ns |
+| core/sorting.toggleSort | 242 ns |
+| core/filter.setFilters (50 leaves) | 7.2 µs |
+| core/filter-node build+serialize (depth 3) | 104 µs |
+| core/url-state.serialize 1 / 10 / 50 filters | 16 µs / 91 µs / 486 µs |
+| toolkit/transformToNested flat 1k / 10k | 0.65 ms / 8.4 ms |
+| toolkit/transformToNested one-to-many 1k / 10k | 1.9 ms / 21.7 ms |
+| drizzle/fetchData no-filters / 20-leaf / depth-3 tree / relational | 111 µs / 773 µs / 410 µs / 984 µs |
+
+Type-perf gate (blocking in `bun test`, budgets ≤ 2 M instantiations hard /
+7.5 s loose): filter fixture **1,344** instantiations / 0.27 s; table-def
+fixture **145,080** / 1.22 s. Measured via the per-fixture tsconfigs (real
+package options + `skipLibCheck` + `types: ["node"]`) — NOT comparable to
+the old manual bare-file numbers (~199 k), which mostly counted stdlib
+checking that default options don't skip.
+
+## Tier 4 — E2E interaction latency (report-only baselines)
+
+`bun run test:e2e:perf` (production `next start`, in-memory SQLite demo,
+Chromium, CDP CPU throttle 4×, 15 reps − 3 warm-ups, in-page
+click→rows-updated):
+
+| Interaction | p50 | p75 |
+|---|---|---|
+| Homepage pagination click | 339 ms | 368 ms |
+| Homepage sort header click | 293 ms | 307 ms |
+| Facets sidebar filter toggle | 149 ms | 155 ms |
+
+Reading: at 4× throttle these round-trips (RSC render + fetch + hydrate +
+paint) are the remaining cost — the pre-fix 150 ms debounce floor and the
+no-feedback freeze are gone (rows now dim via `aria-busy` during the
+trip). Budgets deliberately NOT set yet; revisit after the gh-pages trend
+accumulates (~2 weeks) and pick p75 budgets with observed variance
+(workflow TODO dated 2026-08-06).
+
+## Follow-up candidates from the numbers
+
+1. Empty-values filter add costs a full navigation (Tier 1 FINDING above).
+2. Pagination p75 (368 ms throttled) is dominated by the whole-page RSC
+   re-render; a `<Suspense>`/partial-prerender boundary around the demo
+   table could shrink the server render — measure before pursuing.
+3. url-state serialize at 50 filters (486 µs) is lz-string-bound; only
+   worth touching if real apps carry that many filters.

--- a/plans/design/perf-baselines.md
+++ b/plans/design/perf-baselines.md
@@ -67,11 +67,14 @@ checking that default options don't skip.
 Chromium, CDP CPU throttle 4×, 15 reps − 3 warm-ups, in-page
 click→rows-updated):
 
+Measured to the FIRST DATA ROW's content change (the user-visible result),
+after the empty-filter fix + the review-hardening below:
+
 | Interaction | p50 | p75 |
 |---|---|---|
-| Homepage pagination click | 339 ms | 368 ms |
-| Homepage sort header click | 293 ms | 307 ms |
-| Facets sidebar filter toggle | 149 ms | 155 ms |
+| Homepage pagination click | 225 ms | 233 ms |
+| Homepage sort header click | 215 ms | 226 ms |
+| Facets sidebar filter toggle | 104 ms | 109 ms |
 
 Reading: at 4× throttle these round-trips (RSC render + fetch + hydrate +
 paint) are the remaining cost — the pre-fix 150 ms debounce floor and the
@@ -80,10 +83,26 @@ trip). Budgets deliberately NOT set yet; revisit after the gh-pages trend
 accumulates (~2 weeks) and pick p75 budgets with observed variance
 (workflow TODO dated 2026-08-06).
 
+## Review hardening (cubic, 2026-07-24)
+
+Correctness fixes made in response to the PR review, each with a
+regression test: (a) url-sync dropped a pending trailing write when a
+navigation recreated the adapter mid-burst — ref-latched the coalescer +
+added a write-in-flight guard so re-hydration can't clobber ahead-of-URL
+state; (b) `httpAdapter`'s signal-aware cache was unbounded and an
+aborted request's late settle could touch a newer entry — added an LRU cap
++ expired-delete + a still-live-entry guard; (c) `useFacets` now chunks
+`getFacets` to `MAX_FACET_BATCH_SIZE` so a >50-facet sidebar can't hit the
+server cap; (d) the E2E harness measures the first-row change (not any
+tbody mutation) and never reuses a stale server; (e) growth-ratio gates
+batch the op so the 10k/1k ratio needs no denominator floor.
+
 ## Follow-up candidates from the numbers
 
-1. Empty-values filter add costs a full navigation (Tier 1 FINDING above).
-2. Pagination p75 (368 ms throttled) is dominated by the whole-page RSC
+1. ~~Empty-values filter add costs a full navigation~~ — FIXED
+   (`getEffectiveFilters`; an incomplete chip now costs 0 fetch / 0 facet /
+   0 URL write).
+2. Pagination p75 (233 ms throttled) is dominated by the whole-page RSC
    re-render; a `<Suspense>`/partial-prerender boundary around the demo
    table could shrink the server render — measure before pursuing.
 3. url-state serialize at 50 filters (486 µs) is lz-string-bound; only

--- a/plans/design/perf-baselines.md
+++ b/plans/design/perf-baselines.md
@@ -1,11 +1,15 @@
-# Performance baselines — plan 063 harness (captured 2026-07-23)
+# Performance baselines — plan 063 harness
 
-First numbers from every tier of the plan 063 harness, captured on the
-`claude/performance-testing-strategy-m35acc` branch AFTER the four
-interaction-lag fixes landed (same branch, commit `728aa68`). Machine:
-CI-class Linux x64 container (Xeon ~2.1 GHz, Bun 1.3.11); wall-time values
-are indicative, not comparable across machines — trends live on gh-pages
-via the `perf-trend` job, counts are pinned in the blocking suites.
+Numbers from every tier of the plan 063 harness, captured on the
+`claude/performance-testing-strategy-m35acc` branch. Machine: CI-class Linux
+x64 container (Xeon ~2.1 GHz, Bun 1.3.11); wall-time values are indicative,
+not comparable across machines — trends live on gh-pages via the
+`perf-trend` job, counts are pinned in the blocking suites.
+
+Provenance: Tiers 1–3 first captured 2026-07-23 after the four
+interaction-lag fixes (commit `728aa68`); the Tier 4 table below is a fresh
+run on 2026-07-24 after the empty-filter fix + the review hardening (each
+labeled at its section).
 
 ## Tier 1 — deterministic interaction / query costs (PR-blocking)
 
@@ -19,7 +23,7 @@ Pinned in `packages/ui/tests/components/interaction-cost.test.tsx` and
 | Rapid double pagination click | 2 fetches, 2 URL writes (leading + one coalesced trailing) |
 | Page-size change | 1 fetch, 1 immediate URL write |
 | Filter commit | 1 fetch, 1 batched facet refresh, 1 immediate URL write |
-| Filter add with EMPTY values | **FINDING**: 1 fetch + 1 facet refresh + 1 URL write before any value is chosen — a real RSC navigation in server-driven apps; candidate fix: skip fetch/serialize until a value commits |
+| Filter add with EMPTY values | **0 fetch, 0 facet, 0 URL write** (FIXED via `getEffectiveFilters`; was 1/1/1 before — a real RSC navigation in server-driven apps). Committing the first value pays exactly once |
 | Facets without `getFacets` (in-process adapters) | exactly K+R singular calls |
 | `fetchData` (plain) | 2 SQL statements (data + count) |
 | `fetchData` + many-to-one column | 2 statements (single-query join path) |

--- a/turbo.json
+++ b/turbo.json
@@ -20,6 +20,11 @@
       "dependsOn": ["build", "^build"],
       "outputs": []
     },
+    "bench": {
+      "dependsOn": ["build"],
+      "cache": false,
+      "outputs": []
+    },
     "@better-tables/site#typecheck": {
       "dependsOn": ["^build"],
       "outputs": []


### PR DESCRIPTION
## Description

Fixes the four causes of the lag felt on pagination clicks and filter changes in the demos, then lands the full performance-testing harness (plan 063) that measures and guards those paths going forward. Performance is a stated product pillar; this makes it enforced rather than anecdotal.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality) — `TableAdapter.getFacets` batch method
- [x] ⚡ Performance improvement
- [x] ✅ Tests (adding or updating tests)
- [x] 🔧 Build/config changes (turbo `bench` task, CI perf-trend job)

## Related Issues

Implements `plans/063-performance-test-harness.md`. No tracked issue.

## Package(s) Affected

- [x] `@better-tables/core` (facet batch + signal-aware cache — **minor**, changeset included)
- [x] `@better-tables/ui` (loading affordance, leading-edge URL writes, facet batch path — private, CLI-copied, no changeset)
- [x] `@better-tables/adapters-drizzle` (perf test suites only, no `src/` change)
- [x] `@better-tables/adapters-toolkit` (perf test suites only, no `src/` change)
- [x] Other: `@better-tables/site` (demo wiring + boot-time seeding + E2E harness)

## Changes Made

### Part 1 — the four interaction-lag fixes

1. **Refetch feedback.** `<BetterTable loading>` now keeps the current rows mounted (dimmed, `aria-busy`) during a refetch, reserving the skeleton for an empty initial load — a pagination/filter change no longer flashes a full skeleton. `useNextjsUrlAdapter` returns `{ adapter, isPending }`, wrapping `router.replace` in a transition; every demo table passes `isPending` as `loading`. `UrlNavigationPendingProvider` shares one transition where the navigator and the table are separate components (facets sidebar, both workspaces).
2. **150 ms debounce floor removed.** `use-table-url-sync` now coalesces with a **leading edge**: a discrete pagination click / filter commit writes the URL synchronously; rapid bursts still collapse to at most one trailing write per 150 ms window. No-op writes (row selection) never open the cooldown.
3. **Facet fan-out + cache bypass.** New optional `TableAdapter.getFacets(requests, params)` answers a whole sidebar's facet reads in one call; `httpAdapter` implements it as a single POST (new `getFacets` wire method, `MAX_FACET_BATCH_SIZE` cap) and `handleAdapterRequest` serves it with a server-side fan-out fallback. `useFacets` prefers the batch path on capable adapters. `httpAdapter`'s TTL cache/dedup now applies to reads carrying an `AbortSignal` (previously every `useFacets` read bypassed it): fresh hits return from cache; concurrent identical reads share one underlying request with per-caller abort semantics; the shared request is cancelled only when every caller aborts; aborted/failed requests are never cached.
4. **Cold-start seeding.** `apps/marketing/instrumentation.ts` warms both in-memory demo databases (5k users, 12k+ tickets) at server boot; "Reset demo" kicks the re-seed immediately instead of billing it to the next interaction.

### Part 2 — the performance test harness (plan 063), four tiers

- **Tier 1 — deterministic gates (PR-blocking).** `interaction-cost.test.tsx` pins exact fetch/facet/URL-write counts per interaction; `query-count.test.ts` pins exact SQL statements per adapter operation via a counting drizzle `logger`, plus `EXPLAIN QUERY PLAN` index canaries.
- **Tier 2 — growth-ratio gates (PR-blocking).** 10k/1k ratio bounds for page fetch, filtered count, and the toolkit transformer (median-of-5, warm-up discarded) — an accidental O(n²) lands ~100× against a 15× bound.
- **Tier 3 — mitata micro-benches (trend-only).** `bun run bench` emits `customSmallerIsBetter` JSON (17 entries) consumed by a new **main-only** `perf-trend` CI job (github-action-benchmark, comment-on-regression at 150%, never fails a PR).
- **Type-perf gate automated.** The previously manual instantiation budget now runs in `bun test` via per-fixture tsconfigs (hard ≤ 2M instantiations, loose ≤ 7.5 s), unskippable in CI.
- **Tier 4 — Playwright interaction-latency baselines (opt-in).** `test:e2e:perf` measures click→rows-updated over the production build under 4× CPU throttle; baselines recorded in `plans/design/perf-baselines.md`.

One genuine **finding** is pinned rather than fixed: adding a filter chip with no value yet already costs a fetch + facet refresh + URL navigation — a candidate for a follow-up.

## Testing

- [x] I have added/updated tests for my changes
- [x] All existing tests pass
- [x] I have tested manually in the following scenarios:
  - [x] Basic functionality — Playwright drove the production demo (pagination, sort, facet toggle)
  - [x] Edge cases — abort-flow, all-callers-abort refetch, coalesced double-click, empty-value filter
  - [x] Browser compatibility (if UI changes) — Chromium via the E2E harness

### Test Results

```
bun run test        → 11/11 package tasks pass
  core 1361 · ui 192 · drizzle 923 (194 db-gated skip) · toolkit 120 · cli 169 · marketing 68
bun run typecheck   → 11/11
bunx biome check .  → 0 errors, 139 warnings (all pre-existing)

E2E baselines (production build, 4× CPU throttle, p50/p75, click→rows-updated):
  pagination  339 / 368 ms
  sort        293 / 307 ms
  facet toggle 149 / 155 ms
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (plan 063, ledger, `perf-baselines.md`)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

- One changeset added: `@better-tables/core` **minor** for `getFacets` + the signal-aware cache. Client and server must share the core version (a new client's batched facet reads need a server whose route handler understands `getFacets`).
- The `perf-trend` CI job keeps `fail-on-alert: false` until ~2 weeks of history establishes variance (dated TODO in the workflow); PR gates stay deterministic counts/ratios only — wall time never blocks a PR.
- The E2E suite is opt-in (`test:e2e:perf`), not part of the default CI `test` gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xh1oSdXNvXYvaJZ5KqWRCo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xh1oSdXNvXYvaJZ5KqWRCo)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes demo lag on pagination and filter changes, and adds a performance harness that blocks regressions and tracks trends. Also improves facet batching reliability, adapter guard coverage, and E2E measurement accuracy.

- **Bug Fixes**
  - Loading feedback: keep current rows mounted and dimmed during refetch; `useNextjsUrlAdapter` now returns `{ adapter, isPending }`, and `UrlNavigationPendingProvider` shares one transition across components (`@better-tables/ui`, site demos).
  - URL writes: remove the 150ms debounce floor; leading-edge writes for discrete clicks, trailing coalescing for bursts; coalescer survives adapter identity changes on navigation so pending trailing writes still land; no-op writes don’t open cooldown (`@better-tables/ui`).
  - Facets: new batched `TableAdapter.getFacets` with `httpAdapter` support; `useFacets` prefers batch and chunks by `MAX_FACET_BATCH_SIZE`; TTL cache/dedup works with `AbortSignal`, adds an LRU cap and late-settle guard; fresh hits return from cache and in-flight requests are shared with per-caller abort semantics; marketing `adapter-guard` now validates `getFacets` batches (`@better-tables/core`, `@better-tables/ui`, site).
  - Cold start: seed demo databases at server boot; “Reset demo” triggers immediate re-seed so the next interaction doesn’t pay the cost (site).
  - Effectless filters: new `filterHasEffect`/`getEffectiveFilters`; URL serialization skips valueless chips; `useTableData`/`useFacets` refetch triggers key on effective filters; the key now uses a BigInt- and cycle-safe JSON replacer that stays value-sensitive (`@better-tables/core`, `@better-tables/ui`).
  - Perf harness: growth-ratio gates batch each sample 20× (median-of-5, warm-up discarded) for stable ratios; E2E measures to the first data-row text change with an in-page cap; `reuseExistingServer` is disabled to always test the production build; baselines recorded (site, `@playwright/test`).

- **Migration**
  - `@better-tables/core` minor: batched `getFacets` + signal-aware, LRU-capped cache, effective-filter handling with a cycle-safe, value-sensitive key, and exported `MAX_FACET_BATCH_SIZE`. Ensure client and server share a version that both understand `getFacets` for batched facet reads.

<sup>Written for commit 401ecb4cdba3bdb97b43865adb084132d1e8a58e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Better-Tables/better-tables/pull/106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

